### PR TITLE
FTN-71: Make the frontend app query the API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,30 @@ on:
       - main
 
 jobs:
+  git-version:
+    name: Determine semantic version number
+    runs-on: ubuntu-latest
+
+    outputs:
+      sem-ver: ${{ steps.version_step.outputs.semVer }}
+      full-sem-ver: ${{ steps.version_step.outputs.fullSemVer }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          # GitVersion requires the entire history
+          fetch-depth: 0
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3.0.0
+        with:
+          versionSpec: "6.x"
+
+      - name: Generate semantic version
+        id: version_step
+        uses: gittools/actions/gitversion/execute@v3.0.0
+
   frontend-build:
     name: Build frontend
     runs-on: ubuntu-latest
@@ -52,6 +76,7 @@ jobs:
   container-build:
     name: Build container
     runs-on: ubuntu-latest
+    needs: git-version
 
     strategy:
       matrix:
@@ -93,8 +118,8 @@ jobs:
             type=ref,event=pr
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ github.run_id  }}
-            type=raw,value=${{ github.run_id  }}-${{ github.run_attempt }}
+            type=raw,value=${{ needs.git-version.outputs.sem-ver }}
+            type=raw,value=${{ needs.git-version.outputs.full-sem-ver }}
 
       - name: Build and push container
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Temporary home for FingerTipsNext.
 
 A [Docker compose](https://docs.docker.com/compose/) definition is provided (see [compose.yaml](compose.yaml)) to allow the individual application containers to be run locally.
 
-To build the application containers you will need Docker installed: <https://docs.docker.com/engine/install/>. Once Docker is installed, you can start the application with the following command:
+To build the application containers you will need Docker installed: <https://docs.docker.com/engine/install/>. Once Docker is installed, you can start the whole application with the following command:
 
 ```bash
 docker compose up --build -d
@@ -14,10 +14,29 @@ docker compose up --build -d
 
 This will build and then start the containers in the background. You can view the frontend application at [http://localhost:3000/](http://localhost:3000/) and the API at [http://localhost:5144/](http://localhost:5144/).
 
-You can stop all of the containers with the following command:
+It is also possible to start a subset of the application's containers using Docker's support for profiles. The following profiles have been defined:
+
+| Profile Name | Services Included        |
+| ------------ | ------------------------ |
+| frontend     | The frontend application |
+| api          | The API application      |
+
+You can start a specific profile by providing the `--profile <profile_name>` argument to the `docker compose` command. For example:
+
+```bash
+docker compose --profile api up --build -d
+```
+
+Finally, you can stop all of the running containers with the following command:
 
 ```bash
 docker compose down
+```
+
+If you have started a specific profile, you'll need to provide it with the `--profile <profile_name>` argument:
+
+```bash
+docker compose --profile api down
 ```
 
 ## Deploying the Application

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Docker compose](https://docs.docker.com/compose/) definition is provided (see
 To build the application containers you will need Docker installed: <https://docs.docker.com/engine/install/>. Once Docker is installed, you can start the whole application with the following command:
 
 ```bash
-docker compose up --build -d
+docker compose --profile all up --build -d
 ```
 
 This will build and then start the containers in the background. You can view the frontend application at [http://localhost:3000/](http://localhost:3000/) and the API at [http://localhost:5144/](http://localhost:5144/).
@@ -18,25 +18,20 @@ It is also possible to start a subset of the application's containers using Dock
 
 | Profile Name | Services Included        |
 | ------------ | ------------------------ |
+| all          | All application services |
 | frontend     | The frontend application |
 | api          | The API application      |
 
-You can start a specific profile by providing the `--profile <profile_name>` argument to the `docker compose` command. For example:
+You can start a specific profile by providing the `--profile <profile_name>` argument to the `docker compose` command. For example the following command will start only the API:
 
 ```bash
 docker compose --profile api up --build -d
 ```
 
-Finally, you can stop all of the running containers with the following command:
+Finally, you can stop all of the running containers with the following command, where `<profile_name>` is the profile name you provided to the `up` command:
 
 ```bash
-docker compose down
-```
-
-If you have started a specific profile, you'll need to provide it with the `--profile <profile_name>` argument:
-
-```bash
-docker compose --profile api down
+docker compose down --profile <profile_name>
 ```
 
 ## Deploying the Application

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,14 @@
 services:
   frontend:
+    profiles:
+      - frontend
     build: frontend/fingertips-frontend
     ports:
       - 3000:3000
 
   api:
+    profiles:
+      - api
     build: api/DHSC.FingertipsNext.Api/DHSC.FingertipsNext.Api
     ports:
       - 5144:8080

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,18 @@
 services:
   frontend:
     profiles:
+      - all
       - frontend
+
     build: frontend/fingertips-frontend
+    environment:
+      - FINGERTIPS_API_URL=http://api:8080
     ports:
       - 3000:3000
 
   api:
     profiles:
+      - all
       - api
     build: api/DHSC.FingertipsNext.Api/DHSC.FingertipsNext.Api
     ports:

--- a/frontend/fingertips-frontend/.env.development
+++ b/frontend/fingertips-frontend/.env.development
@@ -1,0 +1,1 @@
+FINGERTIPS_API_URL="http://localhost:5144"

--- a/frontend/fingertips-frontend/README.md
+++ b/frontend/fingertips-frontend/README.md
@@ -28,7 +28,7 @@ npm run typecheck
 
 ### Running the Development Server
 
-To run the Next development server:
+To run the Next development server, as well as the containers required for the API backend, you will need to have Docker running and then run the following NPM script:
 
 ```bash
 npm run dev
@@ -37,6 +37,12 @@ npm run dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can then start editing the application and your browser will auto-update as you edit the files.
+
+You can also run the Next development server without running the API containers by using the following command:
+
+```bash
+npm run dev:standalone
+```
 
 ## Building
 

--- a/frontend/fingertips-frontend/app/page.tsx
+++ b/frontend/fingertips-frontend/app/page.tsx
@@ -1,6 +1,31 @@
 import Image from "next/image";
+import { connection } from "next/server";
 
-export default function Home() {
+type Forecast = {
+  date: string;
+  temperatureC: number;
+  temperatureF: number;
+  summary: string;
+};
+
+export default async function Home() {
+  // We don't want to render this page statically
+  await connection();
+
+  const apiUrl = process.env.FINGERTIPS_API_URL;
+
+  if (!apiUrl) {
+    throw new Error(
+      "No API URL set. Have you set the FINGERTIPS_API_URL environment variable?"
+    );
+  }
+
+  const weatherData = await fetch(apiUrl, {
+    // Cache the data for 60s
+    next: { revalidate: 60 },
+  });
+  const forecasts: Forecast[] = await weatherData.json();
+
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
@@ -20,6 +45,14 @@ export default function Home() {
             Fingertips is a large public health data collection. Data is
             organised into themed profiles.
           </p>
+
+          <ul>
+            {forecasts.map((f) => (
+              <li key={f.date}>
+                {f.date}, {f.temperatureC}, {f.temperatureF}, {f.summary}
+              </li>
+            ))}
+          </ul>
         </div>
       </main>
     </div>

--- a/frontend/fingertips-frontend/package-lock.json
+++ b/frontend/fingertips-frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "concurrently": "^9.1.0",
         "eslint": "^9.13.0",
         "eslint-config-next": "15.0.1",
         "postcss": "^8",
@@ -1707,6 +1708,61 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -1768,6 +1824,48 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.0.tgz",
+      "integrity": "sha512-VxkzwMAn4LP7WyMnJNbHN5mKV9L2IbyDjpzemKr99sXNR3GqRNMMHdm7prV1ws9wg7ETj6WUkNOigZVsptwbgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2142,6 +2240,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2871,6 +2979,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3730,6 +3848,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4550,6 +4675,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -4621,6 +4756,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -4774,6 +4919,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -5270,6 +5425,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -5663,6 +5828,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
@@ -5674,6 +5849,57 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "concurrently \"npm run api:start\" \"npm run dev:standalone\" && npm run api:stop",
+    "dev:standalone": "next dev",
     "build": "next build",
     "start": "next start",
+    "api:start": "docker compose --profile api up --build",
+    "api:stop": "docker compose --profile api down",
     "lint": "next lint",
     "typecheck": "tsc"
   },
@@ -20,6 +23,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "concurrently": "^9.1.0",
     "eslint": "^9.13.0",
     "eslint-config-next": "15.0.1",
     "postcss": "^8",

--- a/terraform/environment/container_app.tf
+++ b/terraform/environment/container_app.tf
@@ -73,6 +73,10 @@ resource "azurerm_container_app" "frontend_container_app" {
       image  = "${var.registry_server_url}/${var.frontend_repository_name}:${var.frontend_container_tag}"
       cpu    = 0.25
       memory = "0.5Gi"
+      env {
+        name  = "FINGERTIPS_API_URL"
+        value = "http://${azurerm_container_app.api_container_app.ingress[0].fqdn}"
+      }
     }
   }
 


### PR DESCRIPTION
Make the frontend application query the API and show the details returned.

![Screenshot 2024-11-07 at 11 30 40](https://github.com/user-attachments/assets/b1557a66-a44b-44da-9ae8-411cf8fa3667)

This is a very simple first version of the code to do this and will need refactoring into a more logical structure and to present the data better.

Changes:
- Re-enable the use of [GitVersion](https://gitversion.net/) in the CI workflow to generate a semantic version for each change (that is used to tag the container images produced)
- Add profiles to the Docker `compose.yaml` file, to allow a subset of services to be run. For example, to allow the API to be run while you work on the frontend
- Made the frontend call the API and display the weather forecasts returned
  - Added the `FINGERTIPS_API_URL` environment variable to the Docker `compose.yaml` file, to allow the FE to communicate with the API when run locally
  - Added the `FINGERTIPS_API_URL` environment variable to the `frontend/fingertips-frontend/.env.development` file. This sets the API url when running the Next dev server, so allows it to connect to the API running in a container (see [Next's docs on environment variables](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#default-environment-variables))
  - Added the `FINGERTIPS_API_URL` environment variable to the frontend container app's Terraform configuration, so that it is provided with the URL of the API container app
  - Made the frontend app's `dev` NPM script also start the API container (a `dev:standalone` command has been added to run the FE on its own)