### PR TITLE
2 changes to get the dev environment running in Windows.

### DIFF
--- a/database/fingertips-db/fingertips-db.sqlproj
+++ b/database/fingertips-db/fingertips-db.sqlproj
@@ -3,9 +3,10 @@
   <Sdk Name="Microsoft.Build.Sql" Version="0.2.0-preview" />
   <PropertyGroup>
     <Name>fingertips-db</Name>
-    <ProjectGuid>{AE804CEA-8B4D-4297-86FB-DC39E46CC918}</ProjectGuid>
+    <ProjectGuid>{ae804cea-8b4d-4297-86fb-dc39e46cc918}</ProjectGuid>
     <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
     <ModelCollation>1033, CI</ModelCollation>
+    <TargetDatabaseSet>True</TargetDatabaseSet>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="PostDeployment" />
@@ -13,6 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="PostDeployment\PopulateWeatherForecast.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <Build Include="Tables\WeatherForecast.sql" />
   </ItemGroup>
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />

--- a/frontend/fingertips-frontend/README.md
+++ b/frontend/fingertips-frontend/README.md
@@ -8,8 +8,8 @@ The Fingertips frontend. A [Next.js](https://nextjs.org) project.
 
 Before starting development on this application you need to do the following:
 
-1. Ensure you are using the correct Node.js version. The currently-supported version is specified in the [.nvmrc](.nvmrc) file. It is recommended you install nvm and use it to manage your Node.js version. With nvm installed you can install and use the correct Node.js version by running `nvm install` in this directory.
-1. Install the necessary dependencies: `npm install`
+1. Ensure that you are using the correct Node.js version. The currently-supported version is specified in the [.nvmrc](.nvmrc) file. It is recommended you install nvm and use it to manage your Node.js version. With nvm installed you can install and use the correct Node.js version by running `nvm install` in this directory. This applies to a Mac but doesn't work on Windows. If you use Windows use [nvm-windows](https://github.com/coreybutler/nvm-windows) and follow [this](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/). Unfortunately this tool doesn't recognise the .nvmrc file, so use the `nvm install` and `nvm use` commands and specify the node version explicitly e.g. `nvm use 20.18.0`.
+2. Install the necessary dependencies: `npm install`
 
 ### Linting
 


### PR DESCRIPTION
Following the existing readme.md to get up and running on a Windows laptop. 

1. NVM is a bit different on Windows, so I have changed readme.md to help people with a Windows laptop. 
2. Table script not added to Table folder in the sqlproject. 
3. CRLF changed to LF for the entrypoint.sh as that stops the docker container for sql running in Windows