### PR TITLE
Fix compose.yaml following API refactor

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
 
     build: frontend/fingertips-frontend
     environment:
-      FINGERTIPS_API_URL: "http://api:8080"
+      FINGERTIPS_API_URL: "http://api:8080/WeatherForecast"
     ports:
       - 3000:3000
 
@@ -19,7 +19,7 @@ services:
       db-setup:
         condition: service_completed_successfully
 
-    build: api/DHSC.FingertipsNext.Api/DHSC.FingertipsNext.Api
+    build: api
     environment:
       DB_SERVER: db
       DB_NAME: ${DB_NAME}


### PR DESCRIPTION
# Description

This PR makes some tweaks to the `compose.yaml` file so that the application works again following the API refactoring done in #9.

# Changes
- Updated the `FINGERTIPS_API_URL` environment variable passed to the frontend container to add the path to the WeatherForecast controller that is the one which returns data from the DB
- Updated the path to the API container's Dockerfile, now that it has been moved

# Validation
I've verified that I am able to run `docker compose --profile all up --build --remove-orphans -d` locally and all containers start successfully:
![Screenshot 2024-12-03 at 12 24 41](https://github.com/user-attachments/assets/2458d114-fbb7-4e12-b006-56136eed7ea4)

Once they have started I am able to navigate to the frontend application and see that it has successfully retrieve data from the API:
![Screenshot 2024-12-03 at 12 25 39](https://github.com/user-attachments/assets/9a574929-2834-41d0-8a26-0db31e9cbfdd)