### PR TITLE
Add design first OpenApi yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ You must also set the following [secrets](https://docs.github.com/en/actions/sec
 | --------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | CONTAINER_REGISTRY_USERNAME | The username to use when authenticating to the container registry defined in the `CONTAINER_REGISTRY` variable. |
 | CONTAINER_REGISTRY_PASSWORD | The password to use when authenticating to the container registry defined in the `CONTAINER_REGISTRY` variable. |
+
+## API Design First & OpenAPI Development
+
+The approach we are taking with the API is 'design first'. The API is designed before it is coded using the [OpenAPI 3.0](https://swagger.io/docs/specification/v3_0/about/) standard and then that design is implemented in the .NET web API. The API design can also be used to help develop the website. A [swagger.yaml](api/definition/swagger.yaml) file is the API design artifact and defines how the API should look. To make changes to the yaml file you can either edit the file directly (fine for smaller changes) or use a visual editor (handy for major changes).
+A useful visual editor is [SwaggerHub](https://swagger.io/), which has a free tier.
+There is a handy VS Code extension [OpenAPI Editor](https://docs.42crunch.com/latest/content/tasks/integrate_vs_code.htm) which makes editing the yaml file easier and highlights any issues. 
+

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -21,5 +21,7 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+definition/*
+**/
 LICENSE
 README.md

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -21,7 +21,6 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
-definition/*
-**/
+definition
 LICENSE
 README.md

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -1,26 +1,26 @@
 openapi: 3.0.0
 servers:
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/ANDREWJEVANS/fingertips-next-api/1.0.0
+  # Added by API Auto Mocking Plugin
+  - description: API server
+    url: https://fingertips-next-api/1.0.0
 info:
   description: An API to query public health indicator data.
   version: "1.0.0"
   title: Fingertips API
   contact:
-    email: you@your-company.com
+    email:  ProfileFeedback@dhsc.gov.uk
 tags:
   - name: indicators
     description: Endpoints dealing with public health indicators
 paths:
-  /indicators:
+  /indicators/summary:
     get:
       tags:
         - indicators
-      summary: searches indicators
-      operationId: searchIndicators
+      summary: Get indicator summaries & filter results
+      operationId: filterIndicators
       description: |
-        By passing in the appropriate options, you can search for
-        public health indicators
+        Get summaries of public health indicators, by passing in the appropriate options you can filter the results
       parameters:
         - $ref: "#/components/parameters/indicator_ids"
       responses:
@@ -63,7 +63,10 @@ paths:
     get:
       tags:
         - indicators
-      summary: Get health data for an indicator
+      summary: Get health data for indicators
+      description: Get data for public health indicators. Supply one or more unique indicator
+        ids in the query string. This will return all data for all areas and all years for those indicators. Optionally filter the results by supplying one
+        or more area codes and one or more years in the query string.
       responses:
         "200":
           content:
@@ -74,7 +77,7 @@ paths:
                   $ref: "#/components/schemas/HealthDataForIndicatorAndArea"
                 title: GetHealthDataForAnIndicatorOk
           description: Data containing the health data points for the indicators, years
-            and geaographical areas requested
+            and geographical areas requested
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -82,9 +85,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/indicator_ids"
         - $ref: "#/components/parameters/area_codes"
-      description: Get health data for indicators. Supply one or more unique indicator
-        ids in the query string. Optionally filter the results by supplying one
-        or more area codes and one or more years in the query string.
+        - $ref: "#/components/parameters/years"
       operationId: getHealthDataForAnIndicator
 components:
   schemas:
@@ -146,22 +147,19 @@ components:
           description: The year that the data point is for
         count:
           type: number
-          format: int32
           example: 222
           description: The count
         value:
           type: number
-          format: int32
           example: 506.60912
           description: The value
         lowerCi:
           type: number
-          format: int32
           example: 441.69151
           description: The lower confidence interval
         upperCi:
           type: number
-          format: int32
+          format: float
           example: 578.32766
           description: The upper confidence interval
     HealthDataForIndicatorAndArea:
@@ -177,7 +175,7 @@ components:
         areaCode:
           type: string
           example: A1426
-          description: The unique area code that the health data is are for
+          description: The unique area code that the health data for
         indicatorId:
           type: integer
           format: int32

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -1,0 +1,273 @@
+openapi: 3.0.0
+servers:
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/ANDREWJEVANS/fingertips-next-api/1.0.0
+info:
+  description: An API to query public health indicator data.
+  version: "1.0.0"
+  title: Fingertips API
+  contact:
+    email: you@your-company.com
+tags:
+  - name: indicators
+    description: Endpoints dealing with public health indicators
+paths:
+  /indicators:
+    get:
+      tags:
+        - indicators
+      summary: searches indicators
+      operationId: searchIndicators
+      description: |
+        By passing in the appropriate options, you can search for
+        public health indicators
+      parameters:
+        - $ref: "#/components/parameters/indicator_ids"
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IndicatorSummary'
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '500':
+          $ref: "#/components/responses/InternalServerErrror"
+  /indicators/{indicator_id}:
+    get:
+      tags:
+        - indicators
+      summary: Get indicator
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Indicator"
+          description: The request was successful, and the server has returned the
+            requested resource in the response body.
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+           $ref: "#/components/responses/InternalServerErrror"
+      parameters:
+        - $ref: "#/components/parameters/indicator_id"
+      description: >
+        Fetches details of a specific indicator by its unique identifier. The
+        response includes the indicator's metadata
+      operationId: getIndicator
+  /indicators/data:
+    get:
+      tags:
+        - indicators
+      summary: Get health data for an indicator
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HealthDataForIndicatorAndArea"
+                title: GetHealthDataForAnIndicatorOk
+          description: Data containing the health data points for the indicators, years
+            and geaographical areas requested
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerErrror"
+      parameters:
+        - $ref: "#/components/parameters/indicator_ids"
+        - $ref: "#/components/parameters/area_codes"
+      description: Get health data for indicators. Supply one or more unique indicator
+        ids in the query string. Optionally filter the results by supplying one
+        or more area codes and one or more years in the query string.
+      operationId: getHealthDataForAnIndicator
+components:
+  schemas:
+    IndicatorSummary:
+      type: object
+      description: A summary of a public health indicator
+      required:
+        - id
+        - title
+      properties:
+        id:
+          type: integer
+          format: int32
+          example: 3456
+          description: The unique identifier of the indicator
+        title:
+          type: string
+          example: "Hypertension: QOF prevalence (all ages)"
+          description: The title of the indicator
+    Indicator:
+      type: object
+      description: A public health indicator
+      required:
+        - id
+        - title
+        - definition
+      properties:
+        id:
+          type: integer
+          format: int32
+          example: 3456
+          description: The unique identifier of the indicator
+        title:
+          type: string
+          example: "Hypertension: QOF prevalence (all ages)"
+          description: The title of the indicator
+        definition:
+          type: string
+          example: "The percentage of patients with established hypertension, as
+              recorded on practice disease registers (proportion of total list
+              size)"
+          description: The definition of the indicator
+    HealthDataPoint:
+      type: object
+      description: Represents a health data point for a public health indicator with a
+        count, value, upper confidence interval, lower confidence interval and a
+        year.
+      required:
+        - year
+        - count
+        - value
+        - lowerCi
+        - upperCi
+      properties:
+        year:
+          type: integer
+          format: int32
+          example: 2023
+          description: The year that the data point is for
+        count:
+          type: number
+          format: int32
+          example: 222
+          description: The count
+        value:
+          type: number
+          format: int32
+          example: 506.60912
+          description: The value
+        lowerCi:
+          type: number
+          format: int32
+          example: 441.69151
+          description: The lower confidence interval
+        upperCi:
+          type: number
+          format: int32
+          example: 578.32766
+          description: The upper confidence interval
+    HealthDataForIndicatorAndArea:
+      type: object
+      description: Associates a list of health data points with the relevant
+        geographical area (represented by it's unique code) and indicator
+        (represented by it's unique identifier).
+      required:
+        - areaCode
+        - healthData
+        - indicatorId
+      properties:
+        areaCode:
+          type: string
+          example: A1426
+          description: The unique area code that the health data is are for
+        indicatorId:
+          type: integer
+          format: int32
+          example: 1234
+          description: The unique identifier of the indicator that the health data points are for
+        healthData:
+          type: array
+          items:
+            $ref: "#/components/schemas/HealthDataPoint"
+          description: The health data points for the area and indicator
+  parameters:
+    years:
+      in: query
+      name: years
+      description: A list of years, up to 10 years can be requested
+      style: form
+      schema:
+        type: array
+        items:
+          type: integer
+          example: 2023
+        maxItems: 10
+    area_codes:
+      in: query
+      name: area_codes
+      description: A list of area codes, up to 10 area codes can be requested
+      style: form
+      schema:
+        type: array
+        items:
+          type: string
+          example: G82109
+        maxItems: 10
+    indicator_id:
+      in: path
+      name: indicator_id
+      style: simple
+      schema:
+        type: integer
+        example: 1234
+        minimum: 1
+      explode: false
+      required: true
+      description: The unique identifier of the indicator
+    indicator_ids:
+      in: query
+      name: indicator_ids
+      description: A list of indicator_ids, up to 10 can be requested
+      style: form
+      schema:
+        type: array
+        items:
+          type: integer
+          example: 1234
+        maxItems: 10
+  responses:
+    NotFound:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+      description: The server cannot find the requested resource. The endpoint may be
+        invalid or the resource may no longer exist.
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+      description: The server could not understand the request due to invalid syntax.
+        The client should modify the request and try again.
+    InternalServerErrror:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+      description: The server encountered an unexpected condition that prevented it
+        from fulfilling the request. Report the issue to the support team if it
+        persists.

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 servers:
   # Added by API Auto Mocking Plugin
-  - description: API server
+  - description: SwaggerHub API Auto Mocking
     url: https://fingertips-next-api/1.0.0
 info:
   description: An API to query public health indicator data.
@@ -13,7 +13,7 @@ tags:
   - name: indicators
     description: Endpoints dealing with public health indicators
 paths:
-  /indicators/summary:
+  /indicators:
     get:
       tags:
         - indicators
@@ -59,13 +59,12 @@ paths:
         Fetches details of a specific indicator by its unique identifier. The
         response includes the indicator's metadata
       operationId: getIndicator
-  /indicators/data:
+  /indicators/{indicator_id}/data:
     get:
       tags:
         - indicators
-      summary: Get health data for indicators
-      description: Get data for public health indicators. Supply one or more unique indicator
-        ids in the query string. This will return all data for all areas and all years for those indicators. Optionally filter the results by supplying one
+      summary: Get health data for an indicator
+      description: Get data for a public health indicator. This will return all data for all areas and all years for the indicators. Optionally filter the results by supplying one
         or more area codes and one or more years in the query string.
       responses:
         "200":
@@ -74,16 +73,16 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/HealthDataForIndicatorAndArea"
+                  $ref: "#/components/schemas/HealthDataForArea"
                 title: GetHealthDataForAnIndicatorOk
-          description: Data containing the health data points for the indicators, years
+          description: Data containing the health data points for the indicator, years
             and geographical areas requested
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalServerErrror"
       parameters:
-        - $ref: "#/components/parameters/indicator_ids"
+        - $ref: "#/components/parameters/indicator_id"
         - $ref: "#/components/parameters/area_codes"
         - $ref: "#/components/parameters/years"
       operationId: getHealthDataForAnIndicator
@@ -93,10 +92,10 @@ components:
       type: object
       description: A summary of a public health indicator
       required:
-        - id
+        - indicator_id
         - title
       properties:
-        id:
+        indicator_id:
           type: integer
           format: int32
           example: 3456
@@ -109,11 +108,11 @@ components:
       type: object
       description: A public health indicator
       required:
-        - id
+        - indicator_id
         - title
         - definition
       properties:
-        id:
+        indicator_id:
           type: integer
           format: int32
           example: 3456
@@ -162,25 +161,18 @@ components:
           format: float
           example: 578.32766
           description: The upper confidence interval
-    HealthDataForIndicatorAndArea:
+    HealthDataForArea:
       type: object
       description: Associates a list of health data points with the relevant
-        geographical area (represented by it's unique code) and indicator
-        (represented by it's unique identifier).
+        geographical area (represented by it's unique code).
       required:
         - areaCode
         - healthData
-        - indicatorId
       properties:
         areaCode:
           type: string
           example: A1426
           description: The unique area code that the health data for
-        indicatorId:
-          type: integer
-          format: int32
-          example: 1234
-          description: The unique identifier of the indicator that the health data points are for
         healthData:
           type: array
           items:


### PR DESCRIPTION
As discussed I added the initial OpenApi 3.0.0 yaml definition file. This file should be used as a guide to implement the API. It can be edited directly or you can use a visual tool such as SwaggerHub or the 42crunch OpenApi Editor extension for VS Code. Can you review the file and see if it makes sense, for the time being