### PR TITLE
Fix docker compose down command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker compose --profile api up --build -d
 Finally, you can stop all of the running containers with the following command, where `<profile_name>` is the profile name you provided to the `up` command:
 
 ```bash
-docker compose down --profile <profile_name>
+docker compose --profile <profile_name> down
 ```
 
 ## Making Changes to the Application


### PR DESCRIPTION
<h1>Description</h1>
This PR updates the docker compose down command in the README file, as the `profile` argument was placed in the wrong position, causing the command to fail. 

<h1>Changes</h1>

- Updated the `docker compose down` command and placed the `profile` argument in the right position. 