### PR TITLE
add .gitattribute to configure EOF for .sh files to use LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# set EOF to be windows compatible for docker
+*.sh text eol=lf


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-163](https://bjss-enterprise.atlassian.net/browse/DHSCFT-163?atlOrigin=eyJpIjoiMDRkZWI2Y2RiZDQ0NGEzYmJmODY3MDE0Yzk1ZDQyZDgiLCJwIjoiaiJ9)

## Changes
Add .gitattributes file to set EOF for *.sh files to be LF.

## Validation

Local functional check with:
```docker compose --profile all up --build --remove-orphans -d```
