### PR TITLE
make some minor changes to the area API endpoints in the swagger

### DIFF
--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -58,14 +58,13 @@ paths:
       tags:
         - areas
       summary: Get area
-      description: Get the full details of a given area, including it's parent, optionally including it's children, siblings, cousins and ancestors
+      description: Get the full details of a given area, including it's parent, optionally including it's children and ancestors
       operationId: getArea
       parameters:
         - $ref: "#/components/parameters/area_code"
         - $ref: "#/components/parameters/includeChildren"
-        - $ref: "#/components/parameters/includeSiblings"
-        - $ref: "#/components/parameters/includeCousins"
         - $ref: "#/components/parameters/includeAncestors"
+        - $ref: "#/components/parameters/child_area_type"
       responses:
         '200':
           description: The area node
@@ -223,14 +222,6 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/Area"
-            siblings:
-              type: array
-              items:
-                $ref: "#/components/schemas/Area"
-            cousins:
-              type: array
-              items:
-                $ref: "#/components/schemas/Area"
             ancestors:
               type: array
               items:
@@ -347,28 +338,25 @@ components:
       explode: false
       required: true
       description: The area code of the area/ geography
+    child_area_type:
+      in: query
+      name: child_area_type
+      style: form
+      required: false
+      schema:
+        type: string
+        example: PCN
+      description: The type of area to request children for
     includeChildren:
       in: query
       name: includeChildren
-      description: include the child areas
-      schema:
-        type: boolean
-    includeSiblings:
-      in: query
-      name: includeSiblings
-      description: include the sibling areas
-      schema:
-        type: boolean
-    includeCousins:
-      in: query
-      name: includeCousins
-      description: include the cousin areas
-      schema:
+      description: Optionally, include the child areas. By default this is the direct children, to get children at a lower level supply the optional query paramter for child area type.
+      schema:        
         type: boolean
     includeAncestors:
       in: query
       name: includeAncestors
-      description: include the ancestor areas
+      description: Optionally, include the ancestor areas
       schema:
         type: boolean
     area_codes:

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -62,8 +62,8 @@ paths:
       operationId: getArea
       parameters:
         - $ref: "#/components/parameters/area_code"
-        - $ref: "#/components/parameters/includeChildren"
-        - $ref: "#/components/parameters/includeAncestors"
+        - $ref: "#/components/parameters/include_children"
+        - $ref: "#/components/parameters/include_ancestors"
         - $ref: "#/components/parameters/child_area_type"
       responses:
         '200':
@@ -347,15 +347,15 @@ components:
         type: string
         example: PCN
       description: The type of area to request children for
-    includeChildren:
+    include_children:
       in: query
-      name: includeChildren
+      name: include_children
       description: Optionally, include the child areas. By default this is the direct children, to get children at a lower level supply the optional query paramter for child area type.
       schema:        
         type: boolean
-    includeAncestors:
+    include_ancestors:
       in: query
-      name: includeAncestors
+      name: include_ancestors
       description: Optionally, include the ancestor areas
       schema:
         type: boolean


### PR DESCRIPTION
# Description

Simplify the areas API endpoints, adding suport for getting children at different levels

## Changes

- Remove the ability to get cousins and siblings
- Add the ability to get child areas at lower levels (e.g. grandchildren)
