### PR TITLE
DHSCFT-201: use the first indicator selected to get healthData

### DIFF
--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -23,7 +23,7 @@ export default async function ChartPage(
   const config = getApiConfiguration();
   const indicatorApi = new IndicatorsApi(config);
   const data = await indicatorApi.getHealthDataForAnIndicator({
-    indicatorId: Number(searchedIndicator),
+    indicatorId: Number(indicatorsSelected[0]),
     areaCodes: areaCodes,
   });
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-201](https://bjss-enterprise.atlassian.net/browse/DHSCFT-201)

The chart page was incorrectly using the searched indicator as the indicatorID to call the api and get healthData.

This should be the indicator selected and as part of the thin slice. This will just be the first indicator if there are multiples. 

## Validation

All tests pass and ran manually.

Not tested against the real api but we would need to make sure that in the searchResults page the indicators returned have indicatorIds that return health data when we make the call to get health data.
