### PR TITLE
[DHSCFT-TECH]: Clear the Areas.Areas table before populating it

### DIFF
--- a/database/fingertips-db/PostDeployment/PopulateFingertips.sql
+++ b/database/fingertips-db/PostDeployment/PopulateFingertips.sql
@@ -3005,10 +3005,13 @@ INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [Se
 SET IDENTITY_INSERT [dbo].[HealthMeasure] OFF
 GO
 
-INSERT [Areas].[Areas]   
+--delete all existing data so we always start from a known position
+DELETE FROM [Areas].[Areas]
+
+INSERT [Areas].[Areas]
 VALUES
 -- root level data
-('/', 0,'E92000001','England', 'Country','All') 
+('/', 0,'E92000001','England', 'Country','All')
 
 -- first level data
 ,('/1/',1,'E12000001','North East region (statistical)','Regions Statistical','Admin')
@@ -3022,7 +3025,7 @@ VALUES
 ,('/9/',1,'E40000011','Midlands NHS Region','NHS region','NHS')
 ,('/10/',1,'E40000012','North East and Yorkshire NHS Region','NHS region','NHS')
 
--- second level data 
+-- second level data
 ,('/1/1/',2,'E06000047','County Durham','Counties & UAs','Admin')
 ,('/1/2/',2,'E06000005','Darlington','Counties & UAs','Admin')
 ,('/1/3/',2,'E08000037','Gateshead','Counties & UAs','Admin')
@@ -3030,7 +3033,7 @@ VALUES
 ,('/4/2/',2,'E38000026','NHS Cambridgeshire and Peterborough ICB','ICB','NHS')
 ,('/5/1/',2,'E38000240','NHS North Central London ICB','ICB','NHS')
 ,('/5/2/',2,'E38000244','NHS South East London ICB','ICB','NHS')
- 
+
 -- third level data
 ,('/4/1/1/',3,'U15488','East Basildon PCN','PCN','NHS')
 ,('/4/1/2/',3,'U55146','Central Basildon PCN','PCN','NHS')


### PR DESCRIPTION
# Description

Jira ticket: None.

There is an issue with the database population script that means it fails when run a second time against an already-populated DB. This is due to the fact that we are not clearing the `Areas.Areas` table before population and are using fixed values for the `Node` primary key field in our population script.

## Changes

- Add a `DELETE FROM` statement to `PopulateFingertips.sql` to clear the `Areas.Areas` table before populating it

## Validation

Ran the `docker compose --profile all up --build --remove-orphans -d` command twice on `main`:
![Screenshot 2025-01-17 at 10 27 57](https://github.com/user-attachments/assets/ee9c833c-036b-4704-9f56-5559bc9fb1a3)
![Screenshot 2025-01-17 at 10 29 37](https://github.com/user-attachments/assets/3bcf707b-5ddf-4679-bcde-36fdd3b9f42c)

The db-setup container logs contained the following:
```
An error occurred while the batch was being executed.
Updating database (Failed)
*** Could not deploy package.
Error SQL72014: Core Microsoft SqlClient Data Provider: Msg 2627, Level 14, State 1, Line 2 Violation of PRIMARY KEY constraint 'PK__Areas__7D8CACC0DB70DBE7'. Cannot insert duplicate key in object 'Areas.Areas'. The duplicate key value is (0x).
```

Then ran `docker compose --profile all down` to tear down all containers, checked out this branch and ran `docker compose --profile all up --build --remove-orphans -d` twice:
![Screenshot 2025-01-17 at 10 56 37](https://github.com/user-attachments/assets/23aafaa0-a2fd-4578-a4cf-ebd71dfce2ee)
![Screenshot 2025-01-17 at 10 57 02](https://github.com/user-attachments/assets/1e9681c3-93da-49b1-af02-f8aa32a43f85)

Finally, checked the `Areas.Areas` table still contains the expected data:
![Screenshot 2025-01-17 at 10 58 26](https://github.com/user-attachments/assets/032ccd52-3eb5-4f7d-a182-a045bca5caab)