### PR TITLE
Update deploy trigger for main branch only

### DIFF
--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -5,6 +5,8 @@ on:
     workflows: [Fingertips Frontend Build]
     types:
       - completed
+    branches:
+      - main
 
 jobs:
   determine-version:


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-189](https://bjss-enterprise.atlassian.net/browse/DHSCFT-189)

Fix to the deployment pipeline to only deploy from completed builds on the main branch.

## Changes

- Update deployment pipeline to only deploy from completed builds on the main branch

## Validation

n/a