### PR TITLE
DHSCT-213 - Shouldly migration

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.Core.UnitTests/CoreControllerTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.Core.UnitTests/CoreControllerTests.cs
@@ -1,12 +1,12 @@
 namespace DHSC.FingertipsNext.Modules.Core.UnitTests;
 
-using FluentAssertions;
+using Shouldly;
 public class CoreControllerTests
 {
     [Fact]
     public void Test1()
     {
         bool results = true;
-        results.Should().BeTrue();
+        results.ShouldBeTrue();
     }
 }

--- a/api/DHSC.FingertipsNext.Modules.Core.UnitTests/DHSC.FingertipsNext.Modules.Core.UnitTests.csproj
+++ b/api/DHSC.FingertipsNext.Modules.Core.UnitTests/DHSC.FingertipsNext.Modules.Core.UnitTests.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
@@ -1,7 +1,7 @@
 ﻿using DHSC.FingertipsNext.Modules.HealthData.Controllers.V1;
 using DHSC.FingertipsNext.Modules.HealthData.Schemas;
 using DHSC.FingertipsNext.Modules.HealthData.Service;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using NSubstitute.Equivalency;
@@ -54,7 +54,7 @@ public class IndicatorControllerTests
 
         // expect
         response?.StatusCode.Equals(200);
-        response?.Value.Should().BeEquivalentTo(SampleHealthData);
+        response?.Value.ShouldBeEquivalentTo(SampleHealthData);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class IndicatorControllerTests
         var response = await _controller.GetIndicatorDataAsync(3) as ObjectResult;
 
         // expect
-        response?.StatusCode.Equals(404);
+        response?.StatusCode.ShouldBe(404);
     }
 
     private static readonly List<HealthDataForArea> SampleHealthData =

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/DHSC.FingertipsNext.Modules.HealthData.UnitTests.csproj
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/DHSC.FingertipsNext.Modules.HealthData.UnitTests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     </ItemGroup>

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/ModuleTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/ModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 
 namespace DHSC.FingertipsNext.Modules.HealthData.Tests;
 
@@ -9,6 +9,6 @@ public class ModuleTests
     [Fact]
     public void ModuleName_IsNamed_Indicators()
     {
-        _module.ModuleName.Should().Be("healthdata");
+        _module.ModuleName.ShouldBe("healthdata");
     }
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
@@ -1,7 +1,10 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using DHSC.FingertipsNext.Modules.HealthData.Repository;
+using DHSC.FingertipsNext.Modules.HealthData.Repository.Models;
+using DHSC.FingertipsNext.Modules.HealthData.Schemas;
 using Microsoft.EntityFrameworkCore;
 using DHSC.FingertipsNext.Modules.HealthData.Tests.Helpers;
+using Microsoft.AspNetCore.Http;
 
 namespace DHSC.FingertipsNext.Modules.HealthData.Tests.Repository;
 
@@ -26,9 +29,7 @@ public class HealthDataRepositoryTests
     {
         var act = () => _repository = new HealthDataRepository(null!);
 
-        act.Should()
-            .Throw<ArgumentNullException>()
-            .WithMessage("Value cannot be null. (Parameter 'healthDataDbContext')");
+        act.ShouldThrow<ArgumentNullException>().Message.ShouldBe("Value cannot be null. (Parameter 'healthDataDbContext')");
     }
 
     [Fact]
@@ -41,7 +42,7 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(3, [], []);
 
         // assert
-        result.Should().BeEmpty();
+        result.ShouldBeEmpty();
     }
 
     [Fact]
@@ -54,10 +55,12 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(1, [], []);
 
         // assert
-        result.Should().NotBeEmpty();
-        result.Should().HaveCount(1);
-        result.Should()
-              .BeEquivalentTo([TestHelper.BuildHealthMeasureModel("Code", 2020, DateTime.Parse("2024-03-21 13:26"))]);
+        result.ShouldNotBeEmpty();
+        result.Count().ShouldBe(1);
+        result.ShouldBeEquivalentTo(new List<HealthMeasureModel>()
+        {
+            TestHelper.BuildHealthMeasureModel("Code", 2020, DateTime.Parse("2024-03-21 13:26"))
+        });
     }
 
     [Fact]
@@ -72,13 +75,13 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(500, ["Code2"], []);
 
         // assert
-        result.Should().NotBeEmpty();
-        result.Should().HaveCount(2);
-        result.Should()
-            .BeEquivalentTo([
-                TestHelper.BuildHealthMeasureModel("Code2", 2023, DateTime.Parse("2024-03-21 13:26"), 2, 500),
-                TestHelper.BuildHealthMeasureModel("Code2", 2022, DateTime.Parse("2024-03-21 13:26"), 3, 500),
-                ]);
+        result.ShouldNotBeEmpty();
+        result.Count().ShouldBe(2);
+        result.ShouldBeEquivalentTo(new List<HealthMeasureModel>()
+        {
+            TestHelper.BuildHealthMeasureModel("Code2", 2022, DateTime.Parse("2024-03-21 13:26"), 3, 500),
+            TestHelper.BuildHealthMeasureModel("Code2", 2023, DateTime.Parse("2024-03-21 13:26"), 2, 500),
+        });
     }
 
     [Fact]
@@ -91,7 +94,7 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(1, ["Code2"], []);
 
         // assert
-        result.Should().BeEmpty();
+        result.ShouldBeEmpty();
     }
 
     [Fact]
@@ -107,13 +110,13 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(500, [], [2022, 2023]);
 
         // assert
-        result.Should().NotBeEmpty();
-        result.Should().HaveCount(3);
-        result.Should().BeEquivalentTo([
+        result.ShouldNotBeEmpty();
+        result.Count().ShouldBe(3);
+        result.ShouldBeEquivalentTo(new List<HealthMeasureModel>() {
                 TestHelper.BuildHealthMeasureModel("Code3", 2022, DateTime.Parse("2024-03-21 13:26"), 4, 500),
                 TestHelper.BuildHealthMeasureModel("Code1", 2023, DateTime.Parse("2024-03-21 13:26"), 2, 500),
                 TestHelper.BuildHealthMeasureModel("Code2", 2023, DateTime.Parse("2024-03-21 13:26"), 3, 500),
-            ]);
+            });
     }
 
     [Fact]
@@ -127,7 +130,7 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(500, [], [2019]);
 
         // assert
-        result.Should().BeEmpty();
+        result.ShouldBeEmpty();
     }
 
     [Fact]
@@ -143,11 +146,11 @@ public class HealthDataRepositoryTests
         var result = await _repository.GetIndicatorDataAsync(500, ["Code1"], [2023]);
 
         // assert
-        result.Should().NotBeEmpty();
-        result.Should().HaveCount(1);
-        result.Should().BeEquivalentTo([
+        result.ShouldNotBeEmpty();
+        result.Count().ShouldBe(1);
+        result.ShouldBeEquivalentTo(new List<HealthMeasureModel>() {
                 TestHelper.BuildHealthMeasureModel("Code1", 2023, DateTime.Parse("2024-03-21 13:26"), 2, 500),
-            ]);
+            });
     }
 
     private async Task PopulateDatabase(string code, short year, int id = 1, int? indicatorId = null)

--- a/api/DHSC.FingertipsNext.Modules.HealthData/DHSC.FingertipsNext.Modules.HealthData.csproj
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/DHSC.FingertipsNext.Modules.HealthData.csproj
@@ -17,7 +17,6 @@
 
     <ItemGroup>
       <PackageReference Include="AutoMapper" Version="13.0.1" />
-      <PackageReference Include="FluentAssertions" Version="7.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
       <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">


### PR DESCRIPTION
# Description

Jira ticket: [DHSCT-213](https://bjss-enterprise.atlassian.net/browse/DHSCFT-213)

This ticket is to remove Fluent Assertions due to licensing changes and replace its functionality with Shouldly.

## Validation

Fluent Assertions is limited to unit testing - these have all be executed and pass.
