### PR TITLE
DHSCFT-208 - remove search from url passed to test template

### DIFF
--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -58,4 +58,4 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
     needs: frontend-deploy
     with:
-      env-url: http://4.158.39.145/search
+      env-url: http://4.158.39.145/


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-208](https://bjss-enterprise.atlassian.net/browse/DHSCFT-208)

Just after my last PR merged in, another PR merged in removing the search bit of the url. But in the deploy job when we call the e2e test template we are still passing search in the env-url. This needs removing.

## Changes

- Removing 'search' out of env-url passed to e2e test template job

## Validation

Test on merge to main only
