### PR TITLE
Feature/dhscft 168 api return sex and age band

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataDbContext.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataDbContext.cs
@@ -18,4 +18,6 @@ public class HealthDataDbContext : DbContext
     public DbSet<HealthMeasureModel> HealthMeasure { get; set; }
     public DbSet<AreaDimensionModel> AreaDimension { get; set; }
     public DbSet<IndicatorDimensionModel> IndicatorDimension { get; set; }
+    public DbSet<AgeDimensionModel> AgeDimension { get; set; }
+    public DbSet<SexDimensionModel> SexDimension { get; set; }
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -20,6 +20,8 @@ public class HealthDataRepository : IRepository
             .Where(hm => years.Length == 0 || years.Contains(hm.Year))
             .OrderBy(hm => hm.Year)
             .Include(hm => hm.AreaDimension)
+            .Include(hm => hm.AgeDimension)
+            .Include(hm => hm.SexDimension)
             .Include(hm => hm.IndicatorDimension)
             .ToListAsync();
     }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
@@ -39,7 +39,7 @@ public class HealthDataPoint
     public float UpperConfidenceInterval { get; init; }
 
     /// <summary>
-    /// The upper confidence interval
+    /// Age band which the data are for.
     /// </summary>
     [JsonPropertyName("ageBand")]
     public string AgeBand { get; init; } = String.Empty;

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
@@ -45,7 +45,7 @@ public class HealthDataPoint
     public string AgeBand { get; init; } = String.Empty;
 
     /// <summary>
-    /// The upper confidence interval
+    /// Sex which the data are for.
     /// </summary>
     [JsonPropertyName("sex")]
     public string Sex { get; init; } = String.Empty ;

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
@@ -4,8 +4,7 @@ namespace DHSC.FingertipsNext.Modules.HealthData.Schemas;
 
 /// <summary>
 /// Represents a health data point for a public health indicator with
-/// a count, value, upper confidence interval, lower confidence interval
-/// and a year.
+/// a count, value, upper confidence interval, lower confidence interval, year, ageBand and sex.
 /// </summary>
 public class HealthDataPoint
 {

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/HealthDataPoint.cs
@@ -38,4 +38,16 @@ public class HealthDataPoint
     /// </summary>
     [JsonPropertyName("upperCi")]
     public float UpperConfidenceInterval { get; init; }
+
+    /// <summary>
+    /// The upper confidence interval
+    /// </summary>
+    [JsonPropertyName("ageBand")]
+    public string AgeBand { get; init; } = String.Empty;
+
+    /// <summary>
+    /// The upper confidence interval
+    /// </summary>
+    [JsonPropertyName("sex")]
+    public string Sex { get; init; } = String.Empty ;
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/AutoMapper/AutoMapperTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/AutoMapper/AutoMapperTests.cs
@@ -17,7 +17,7 @@ public class AutoMapperTests
 
     [Fact]
     public void
-        Mapper_ShouldMapAHeathMeasure_ToAHealthDataPoint()
+        Mapper_ShouldMapAHealthMeasure_ToAHealthDataPoint()
     {
         // arrange
         var healthMeasure = TestHelper.BuildHealthMeasureModel("Code1", 2007, DateTime.Now);

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/AutoMapper/AutoMapperTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/AutoMapper/AutoMapperTests.cs
@@ -1,0 +1,34 @@
+﻿using AutoMapper;
+using DHSC.FingertipsNext.Modules.HealthData.Mappings;
+using DHSC.FingertipsNext.Modules.HealthData.Schemas;
+using DHSC.FingertipsNext.Modules.HealthData.Tests.Helpers;
+using Shouldly;
+
+namespace DHSC.FingertipsNext.Modules.HealthData.Tests.AutoMapper;
+
+public class AutoMapperTests
+{
+    readonly Mapper _mapper;
+    public AutoMapperTests() {
+        var profiles = new AutoMapperProfiles();
+        var configuration = new MapperConfiguration(cfg => cfg.AddProfile(profiles));
+        _mapper = new Mapper(configuration);
+    }
+
+    [Fact]
+    public void
+        Mapper_ShouldMapAHeathMeasure_ToAHealthDataPoint()
+    {
+        // arrange
+        var healthMeasure = TestHelper.BuildHealthMeasureModel("Code1", 2007, DateTime.Now);
+        var expectedHealthData = TestHelper.BuildHealthDataPoint(
+            2007, "Name", "Name");
+
+        // act
+        var actual = _mapper.Map<HealthDataPoint>(healthMeasure);
+
+        // assert
+        actual.ShouldBeEquivalentTo(expectedHealthData);
+
+    }
+}

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
@@ -83,7 +83,9 @@ public class IndicatorControllerTests
                     Count = 1,
                     Value = 1,
                     LowerConfidenceInterval = 1.1111f,
-                    UpperConfidenceInterval = 2.2222f
+                    UpperConfidenceInterval = 2.2222f,
+                    AgeBand = "Sample Age Band",
+                    Sex = "Sample Sex"
                 }
             ]
         }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Helpers/TestHelper.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Helpers/TestHelper.cs
@@ -57,17 +57,6 @@ public static class TestHelper
         };
     }
 
-    /// <summary>
-    /// build a HealtDataPoint 
-    /// </summary>
-    /// <param name="year"></param>
-    /// <param name="count"></param>
-    /// <param name="value"></param>
-    /// <param name="lowerConfidenceInterval"></param>
-    /// <param name="upperConfidenceInterval"></param>
-    /// <param name="ageBand"></param>
-    /// <param name="sex"></param>
-    /// <returns></returns>
     public static HealthDataPoint BuildHealthDataPoint(int year, string ageBand, string sex,  float count = 1, float value = 1, float lowerConfidenceInterval = 1, float upperConfidenceInterval = 1)
     {
         return new HealthDataPoint

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Helpers/TestHelper.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Helpers/TestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using DHSC.FingertipsNext.Modules.HealthData.Repository.Models;
+using DHSC.FingertipsNext.Modules.HealthData.Schemas;
 
 namespace DHSC.FingertipsNext.Modules.HealthData.Tests.Helpers;
 
@@ -54,5 +55,31 @@ public static class TestHelper
             IndicatorDimension = indicatorDimension,
             SexDimension = sexDimension
         };
+    }
+
+    /// <summary>
+    /// build a HealtDataPoint 
+    /// </summary>
+    /// <param name="year"></param>
+    /// <param name="count"></param>
+    /// <param name="value"></param>
+    /// <param name="lowerConfidenceInterval"></param>
+    /// <param name="upperConfidenceInterval"></param>
+    /// <param name="ageBand"></param>
+    /// <param name="sex"></param>
+    /// <returns></returns>
+    public static HealthDataPoint BuildHealthDataPoint(int year, string ageBand, string sex,  float count = 1, float value = 1, float lowerConfidenceInterval = 1, float upperConfidenceInterval = 1)
+    {
+        return new HealthDataPoint
+        {
+            Year = year,
+            Count = count,
+            Value = value,
+            LowerConfidenceInterval = lowerConfidenceInterval,
+            UpperConfidenceInterval = upperConfidenceInterval,
+            AgeBand = ageBand,
+            Sex = sex
+        };
+
     }
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/get-indicator-data.http
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/get-indicator-data.http
@@ -1,5 +1,5 @@
 ﻿### get some sample data
-GET http://localhost:5144/Indicators/100/data
+GET http://localhost:5144/Indicators/108/data
     ?areaCodes=areaCode1
     &years=1970
     &years=1980

--- a/api/DHSC.FingertipsNext.Modules.HealthData/Mappings/AutoMapperProfiles.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Mappings/AutoMapperProfiles.cs
@@ -15,6 +15,8 @@ public class AutoMapperProfiles : Profile
         CreateMap<SexDimensionModel, SexDimension>();
         CreateMap<HealthMeasureModel, HealthDataPoint>()
             .ForMember(dest => dest.LowerConfidenceInterval, options => options.MapFrom(src => src.LowerCI))
-            .ForMember(dest => dest.UpperConfidenceInterval, options => options.MapFrom(src => src.UpperCI));
+            .ForMember(dest => dest.UpperConfidenceInterval, options => options.MapFrom(src => src.UpperCI))
+            .ForMember(dest => dest.AgeBand, options => options.MapFrom(src => src.AgeDimension.Name))
+            .ForMember(dest => dest.Sex, options => options.MapFrom(src => src.SexDimension.Name));
     }
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-168](https://bjss-enterprise.atlassian.net/browse/DHSCFT-168)

Add `ageBand` and `sex` fields to API response for `/indicators/{indicator_id}/data`

## Changes
- add AgeDimension and SexDimension to db context
- include AgeDimension and SexDimension in healthData repository 
- add ageBand and sex to HealthDataPoint schema
- add functions to automapper profiles for ageBand and sex in healthDataPoint
- create test for bespoke automapper mappings, with associated helper function

## Validation
- clean build
- all tests passed
- get request responds with expected data: 
![image](https://github.com/user-attachments/assets/37c4f84b-8651-43f8-95b4-1039e74650c5)
- FE renders db data as expected with `npm run dev:loacl-api`
![image](https://github.com/user-attachments/assets/1bb59808-c4ea-4490-a33d-04f28d901d9e)

