### PR TITLE
Change Azure Container Registry Server and Authentication Method

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,11 +20,11 @@ on:
         required: true
         type: string
     secrets:
-      acr-username:
-        description: 'Azure Container Registry username'
+      arm-client-id:
+        description: 'Service Principal Client ID'
         required: true
-      acr-password:
-        description: 'Azure Container Registry password'
+      arm-client-secret:
+        description: 'Service Principal Client Secret'
         required: true
       acr-server:
         description: 'Azure Container Registry server'
@@ -46,8 +46,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ACR_SERVER }}
-          username: ${{ secrets.ARM_CLIENT_ID }}
-          password: ${{ secrets.ARM_CLIENT_SECRET }}
+          username: ${{ secrets.arm-client-id }}
+          password: ${{ secrets.arm-client-secret }}
 
       - name: Generate container metadata
         id: meta

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -43,11 +43,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Azure Container Registry Login
-        uses: Azure/docker-login@v1
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.acr-username }}
-          password: ${{ secrets.acr-password }}
-          login-server: ${{ secrets.acr-server }}
+          registry: ${{ secrets.ACR_SERVER }}
+          username: ${{ secrets.ARM_CLIENT_ID }}
+          password: ${{ secrets.ARM_CLIENT_SECRET }}
 
       - name: Generate container metadata
         id: meta

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Azure Container Registry Login
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.ACR_SERVER }}
+          registry: ${{ secrets.acr-server }}
           username: ${{ secrets.arm-client-id }}
           password: ${{ secrets.arm-client-secret }}
 

--- a/.github/workflows/fingertips-api-build.yml
+++ b/.github/workflows/fingertips-api-build.yml
@@ -65,7 +65,7 @@ jobs:
       git-semver: ${{ needs.determine-version.outputs.sem-ver }}
       git-full-semver: ${{ needs.determine-version.outputs.full-sem-ver }}
     secrets:
-      acr-username: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-      acr-password: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
-      acr-server: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+      arm-client-id: ${{ secrets.ARM_CLIENT_ID }}
+      arm-client-secret: ${{ secrets.ARM_CLIENT_SECRET }}
+      acr-server: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
 

--- a/.github/workflows/fingertips-api-deploy.yml
+++ b/.github/workflows/fingertips-api-deploy.yml
@@ -34,11 +34,11 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Azure Container Registry Login
-        uses: Azure/docker-login@v1
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-          password: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
-          login-server: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+          registry: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.ARM_CLIENT_ID }}
+          password: ${{ secrets.ARM_CLIENT_SECRET }}
 
       - uses: Azure/login@v1
         with:
@@ -58,11 +58,11 @@ jobs:
       - name: Build and deploy Container App
         uses: azure/container-apps-deploy-action@v1
         with:
-          imageToDeploy: "${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}/dhsc.fingertipsnext.api:${{ needs.determine-version.outputs.sem-ver }}"
+          imageToDeploy: "${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}/dhsc.fingertipsnext.api:${{ needs.determine-version.outputs.sem-ver }}"
           containerAppName: fingertips-api
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppEnvironment: ${{ vars.CONTAINER_APP_ENVIRONMENT }}
-          registryUrl: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+          registryUrl: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
           registryUsername: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
           registryPassword: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
           targetPort: 8080

--- a/.github/workflows/fingertips-api-deploy.yml
+++ b/.github/workflows/fingertips-api-deploy.yml
@@ -62,9 +62,6 @@ jobs:
           containerAppName: fingertips-api
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppEnvironment: ${{ vars.CONTAINER_APP_ENVIRONMENT }}
-          registryUrl: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
-          registryUsername: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-          registryPassword: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
           targetPort: 8080
           environmentVariables: |
             DB_NAME=${{ steps.azure-keyvault-secrets.outputs.fingertips-sql-hostname }}

--- a/.github/workflows/fingertips-frontend-build.yml
+++ b/.github/workflows/fingertips-frontend-build.yml
@@ -76,6 +76,6 @@ jobs:
       git-semver: ${{ needs.determine-version.outputs.sem-ver }}
       git-full-semver: ${{ needs.determine-version.outputs.full-sem-ver }}
     secrets:
-      acr-username: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-      acr-password: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
-      acr-server: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+      arm-client-id: ${{ secrets.ARM_CLIENT_ID }}
+      arm-client-secret: ${{ secrets.ARM_CLIENT_SECRET }}
+      acr-server: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}

--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -47,9 +47,6 @@ jobs:
           containerAppName: fingertips-frontend
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppEnvironment: ${{ vars.CONTAINER_APP_ENVIRONMENT }}
-          registryUrl: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
-          registryUsername: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-          registryPassword: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
           targetPort: 3000
           environmentVariables: "FINGERTIPS_API_URL=${{ vars.FINGERTIPS_API_URL }} DHSC_AI_SEARCH_USE_MOCK_SERVICE=true"
           azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -34,20 +34,20 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Azure Container Registry Login
-        uses: Azure/docker-login@v1
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
-          password: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
-          login-server: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+          registry: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.ARM_CLIENT_ID }}
+          password: ${{ secrets.ARM_CLIENT_SECRET }}
 
       - name: Build and deploy Container App
         uses: azure/container-apps-deploy-action@v1
         with:
-          imageToDeploy: "${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}/dhsc.fingertipsnext.frontend:${{ needs.determine-version.outputs.sem-ver }}"
+          imageToDeploy: "${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}/dhsc.fingertipsnext.frontend:${{ needs.determine-version.outputs.sem-ver }}"
           containerAppName: fingertips-frontend
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppEnvironment: ${{ vars.CONTAINER_APP_ENVIRONMENT }}
-          registryUrl: ${{ secrets.AZURE_CONTAINERREGISTRY_SERVER }}
+          registryUrl: ${{ secrets.AZURE_CONTAINER_REGISTRY_LOGIN_SERVER }}
           registryUsername: ${{ secrets.AZURE_CONTAINERREGISTRY_USERNAME }}
           registryPassword: ${{ secrets.AZURE_CONTAINERREGISTRY_PASSWORD }}
           targetPort: 3000


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-271](https://bjss-enterprise.atlassian.net/browse/DHSCFT-271)

Current builds are pushing images to a manually created ACR in Azure and use a username/password authentication. Refactoring is required in order to point a new ACR created in Terraform, then authenticate using Service Principal authentication. This change will also be reflected in the deployment workflows, to pull images.

## Changes

- Update GitHub Action to a supported version
- Change authentication to use Service Principal authentication
- Update ACR login server to point at the new ACR created in Terraform

## Validation

Branch has been run manually and is able to push the image successfully to the new ACR
