### PR TITLE
Feature/dhscft 274 change areas endpoint swagger

### DIFF
--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -44,13 +44,33 @@ paths:
         - $ref: "#/components/parameters/hierarchy_type"
       responses:
         "200":
-          description: The available area types e.g. ICB, PCN or GP Surgery
+          description: The available area types e.g. ICB, PCN or GP Surgery, together with related data
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  type: string
+                  $ref: "#/components/schemas/AreaType"
+        "500":
+          $ref: "#/components/responses/InternalServerErrror"
+  /areas/areatypes/{area_type}/areas:
+    get:
+      tags:
+        - areas
+      summary: Get member areas for an area type
+      description: Get the areas that have a given area type
+      operationId: getAreaTypeMembers
+      parameters:
+        - $ref: "#/components/parameters/area_type"
+      responses:
+        "200":
+          description: The available areas for the area type
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Area"
         "500":
           $ref: "#/components/responses/InternalServerErrror"
   /areas/{area_code}:
@@ -64,7 +84,6 @@ paths:
         - $ref: "#/components/parameters/area_code"
         - $ref: "#/components/parameters/includeChildren"
         - $ref: "#/components/parameters/includeSiblings"
-        - $ref: "#/components/parameters/includeCousins"
         - $ref: "#/components/parameters/includeAncestors"
       responses:
         "200":
@@ -171,6 +190,26 @@ paths:
       operationId: getHealthDataForAnIndicator
 components:
   schemas:
+    AreaType:
+      type: object
+      description: An area type e.g. PCN or GP
+      required:
+        - name
+        - level
+        - hierarchyName
+      properties:
+        name:
+          type: string
+          example: "PCN"
+          description: The name of the area type
+        level:
+          type: integer
+          example: "3"
+          description: The level in the hierarchy
+        hierarchyName:
+          type: string
+          example: "NHS"
+          description: The name of the associated hierarchy for the area / geography
     RootArea:
       type: object
       description: The root node of the area / geography hierarchies
@@ -227,10 +266,6 @@ components:
               items:
                 $ref: "#/components/schemas/Area"
             siblings:
-              type: array
-              items:
-                $ref: "#/components/schemas/Area"
-            cousins:
               type: array
               items:
                 $ref: "#/components/schemas/Area"
@@ -361,6 +396,16 @@ components:
       explode: false
       required: true
       description: The area code of the area/ geography
+    area_type:
+      in: path
+      name: area_type
+      style: simple
+      schema:
+        type: string
+        example: PCN
+      explode: false
+      required: true
+      description: The area type
     includeChildren:
       in: query
       name: includeChildren

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -71,6 +71,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Area"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerErrror"
   /areas/{area_code}:
@@ -92,8 +94,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AreaWithRelations"
-        "400":
-          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerErrror"
   /areas/root:

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -84,9 +84,9 @@ paths:
       operationId: getArea
       parameters:
         - $ref: "#/components/parameters/area_code"
-        - $ref: "#/components/parameters/includeChildren"
-        - $ref: "#/components/parameters/includeSiblings"
-        - $ref: "#/components/parameters/includeAncestors"
+        - $ref: "#/components/parameters/include_children"
+        - $ref: "#/components/parameters/include_siblings"
+        - $ref: "#/components/parameters/include_ancestors"
       responses:
         "200":
           description: The area node
@@ -408,27 +408,21 @@ components:
       explode: false
       required: true
       description: The area type
-    includeChildren:
+    include_children:
       in: query
-      name: includeChildren
+      name: include_children
       description: include the child areas
       schema:
         type: boolean
-    includeSiblings:
+    include_siblings:
       in: query
-      name: includeSiblings
+      name: include_siblings
       description: include the sibling areas
       schema:
         type: boolean
-    includeCousins:
+    include_ancestors:
       in: query
-      name: includeCousins
-      description: include the cousin areas
-      schema:
-        type: boolean
-    includeAncestors:
-      in: query
-      name: includeAncestors
+      name: include_ancestors
       description: include the ancestor areas
       schema:
         type: boolean


### PR DESCRIPTION
# Description

Jira ticket: dhscft 274 

For some new requirements for the area filter panel we need some new  / changed API endpoints. This is the design first swagger file changes that documents those changes

## Changes

- Remove the ?includeCousins query parameter from /areas/{area_code} endpoint. It is not needed
- Change the /areas/areatypes endpoint to return more detail, enabling it to be used to populate the group type dropdown

## Validation

Discussed the planned changes in 3 amigos
