### PR TITLE
DHSCFT-209_also_allow_e2e_tests_to_be_triggered_manually

### DIFF
--- a/.github/workflows/fingertips-api-deploy.yml
+++ b/.github/workflows/fingertips-api-deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
   e2e-tests-development:
     uses: ./.github/workflows/e2e-tests.yml
-    if: ${{ github.event.workflow_run.event == 'push' }}
+    if: ${{ github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch' }}
     needs: api-deploy-development
     with:
       env-url: ${{ needs.api-deploy-development.outputs.frontend-dev-url }}

--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
   e2e-tests-development:
     uses: ./.github/workflows/e2e-tests.yml
-    if: ${{ github.event.workflow_run.event == 'push' }}
+    if: ${{ github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch' }}
     needs: frontend-deploy-development
     with:
       env-url: ${{ needs.frontend-deploy-development.outputs.frontend-dev-url }}


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-209](https://bjss-enterprise.atlassian.net/browse/DHSCFT-209)

To be able to manually run a pipeline to trigger the e2e tests on deploy of frontend or api we needed this change
