### PR TITLE
DHSCFT-209_make_e2e_test_stable_after_deploy

### DIFF
--- a/frontend/fingertips-frontend/package-lock.json
+++ b/frontend/fingertips-frontend/package-lock.json
@@ -32,7 +32,7 @@
         "@axe-core/playwright": "^4.10.1",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@estruyf/github-actions-reporter": "^1.9.2",
+        "@estruyf/github-actions-reporter": "^1.10.0",
         "@faker-js/faker": "^9.3.0",
         "@openapitools/openapi-generator-cli": "^2.15.3",
         "@playwright/test": "^1.50.0",
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@estruyf/github-actions-reporter": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@estruyf/github-actions-reporter/-/github-actions-reporter-1.9.2.tgz",
-      "integrity": "sha512-D2+ePwTjbd4siY7VIWX1dJrE1bU3x9OO+FOj99hqU4zQhVGwMm0ozgNDUzJgHxdRZKtFoGcYWV5YLfZettR38A==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@estruyf/github-actions-reporter/-/github-actions-reporter-1.10.0.tgz",
+      "integrity": "sha512-u54QKI8TgUqkhNpOjyNh0hFktFSQhiQH1hs9o8jJ/FwCTlJeNCryzknzP9+B1R/jeg0cXY9QuwLcJNZCBc+Ajw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -44,7 +44,7 @@
     "@axe-core/playwright": "^4.10.1",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@estruyf/github-actions-reporter": "^1.9.2",
+    "@estruyf/github-actions-reporter": "^1.10.0",
     "@faker-js/faker": "^9.3.0",
     "@openapitools/openapi-generator-cli": "^2.15.3",
     "@playwright/test": "^1.50.0",

--- a/frontend/fingertips-frontend/playwright.config.ts
+++ b/frontend/fingertips-frontend/playwright.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI, // fails the build on CI if you accidentally left test.only in the source code.
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
+  expect: process.env.CI ? { timeout: 10_000 } : { timeout: 5_000 },
   reporter: process.env.CI
     ? [['list'], ['@estruyf/github-actions-reporter'], ['html']]
     : [['list'], ['html']],


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-209](https://bjss-enterprise.atlassian.net/browse/DHSCFT-209)

As part of 209 we need the e2e test reliably and consistently passing when it is run after api and frontend deploys. This PR is to make that so.

## Changes

- Set workers to 2 when in CI mode as recommended by playwright - [playwright docs](https://playwright.dev/docs/test-parallel#limit-workers)
- Double expect timeout in CI

## Validation

CI e2e tests passed.
Will validate CD e2e once merged.
