### PR TITLE
Feature/DHSCFT-281_slack_message_build_fail

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Send slack message if e2e tests fail
         if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
-        run: npx slack-ctrf failed ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E test Failure against CD Environment"
+        run: npx slack-ctrf results ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance" --prefix "Test Prefix" --suffix "Test Suffix""

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: null
         type: string
+      send-slack-on-fail:
+        description: "optionally send a slack message on test failure"
+        required: false
+        default: "false"
+        type: string
 
 jobs:
   execute-e2e-tests:
@@ -53,3 +58,7 @@ jobs:
             ${{ env.frontend-directory }}/playwright-report/
             ${{ env.frontend-directory }}/test-results/*/*.png
           retention-days: 10
+
+      - name: Send slack message if e2e tests fail
+        if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
+        run: npx slack-ctrf failed ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E test Failure against CD Environment"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,4 +61,6 @@ jobs:
 
       - name: Send slack message if e2e tests fail
         if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
-        run: npx slack-ctrf results ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance" --prefix "Test Prefix" --suffix "Test Suffix""
+        run: npx slack-ctrf results ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance""
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/fingertips-api-deploy.yml
+++ b/.github/workflows/fingertips-api-deploy.yml
@@ -69,3 +69,4 @@ jobs:
     needs: api-deploy-development
     with:
       env-url: ${{ needs.api-deploy-development.outputs.frontend-dev-url }}
+      send-slack-on-fail: "true"

--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -74,3 +74,4 @@ jobs:
     needs: frontend-deploy-development
     with:
       env-url: ${{ needs.frontend-deploy-development.outputs.frontend-dev-url }}
+      send-slack-on-fail: "true"

--- a/frontend/fingertips-frontend/.gitignore
+++ b/frontend/fingertips-frontend/.gitignore
@@ -40,5 +40,6 @@ yarn-error.log*
 next-env.d.ts
 /test-results/
 /playwright-report/
+/ctrf/
 /blob-report/
 /playwright/.cache/

--- a/frontend/fingertips-frontend/package-lock.json
+++ b/frontend/fingertips-frontend/package-lock.json
@@ -55,6 +55,7 @@
         "jest-mock-extended": "^4.0.0-beta1",
         "jest-styled-components": "^7.2.0",
         "msw": "^2.6.8",
+        "playwright-ctrf-json-reporter": "^0.0.18",
         "playwright-webkit": "^1.50.0",
         "postcss": "^8.4.49",
         "prettier": "^3.4.2",
@@ -12231,6 +12232,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/playwright-ctrf-json-reporter": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.18.tgz",
+      "integrity": "sha512-AjFNpIMKI8zeyaktA2LBphYzy3ffiBjXobBXxEfrVUDov/Z8v5+y9FI0m3cBCr8yauk2brN+Er225vHsZDIu0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright-webkit": {
       "version": "1.50.0",

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -67,6 +67,7 @@
     "jest-mock-extended": "^4.0.0-beta1",
     "jest-styled-components": "^7.2.0",
     "msw": "^2.6.8",
+    "playwright-ctrf-json-reporter": "^0.0.18",
     "playwright-webkit": "^1.50.0",
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",

--- a/frontend/fingertips-frontend/playwright.config.ts
+++ b/frontend/fingertips-frontend/playwright.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
   workers: process.env.CI ? 2 : undefined,
   expect: process.env.CI ? { timeout: 10_000 } : { timeout: 5_000 },
   reporter: process.env.CI
-    ? [['list'], ['@estruyf/github-actions-reporter'], ['html']]
+    ? [
+        ['list'],
+        ['@estruyf/github-actions-reporter'],
+        ['html'],
+        ['playwright-ctrf-json-reporter', {}],
+      ]
     : [['list'], ['html']],
   use: {
     baseURL: url,

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
@@ -26,10 +26,12 @@ export default class ResultsPage extends BasePage {
     );
   }
 
-  async clickIndicatorCheckbox(indicatorId: string) {
-    await this.page
-      .getByTestId(`${this.indicatorCheckboxPrefix}-${indicatorId}`)
-      .click();
+  async clickIndicatorCheckboxes(indicatorIds: string[]) {
+    for (const indicatorId of indicatorIds) {
+      await this.page
+        .getByTestId(`${this.indicatorCheckboxPrefix}-${indicatorId}`)
+        .click();
+    }
   }
 
   async checkIndicatorCheckboxChecked(indicatorId: string) {

--- a/frontend/fingertips-frontend/playwright/testHelpers.ts
+++ b/frontend/fingertips-frontend/playwright/testHelpers.ts
@@ -1,10 +1,29 @@
 import { IndicatorDocument } from '@/lib/search/searchTypes';
+import AxeBuilder from '@axe-core/playwright';
+import { expect } from './page-objects/pageFactory';
 
-export function getIndicatorIDByName(
+function filterIndicatorsByName(
   indicators: IndicatorDocument[],
   searchTerm: string
 ): IndicatorDocument[] {
+  if (!searchTerm) return [];
+
+  const normalizedSearchTerm = searchTerm.toLowerCase();
+
   return indicators.filter((indicator) =>
-    indicator.name.toLowerCase().includes(searchTerm.toLowerCase())
+    indicator.name.toLowerCase().includes(normalizedSearchTerm)
   );
+}
+
+export function getIndicatorIdsByName(
+  indicators: IndicatorDocument[],
+  searchTerm: string
+): string[] {
+  return filterIndicatorsByName(indicators, searchTerm).map(
+    (indicator) => indicator.indicatorId
+  );
+}
+
+export async function expectNoAccessibilityViolations(axeBuilder: AxeBuilder) {
+  expect((await axeBuilder.analyze()).violations).toEqual([]);
 }

--- a/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
@@ -1,11 +1,13 @@
 import { SearchParams } from '@/lib/searchStateManager';
-import { expect, test } from '../page-objects/pageFactory';
-import { getIndicatorIDByName } from '../testHelpers';
+import { test } from '../page-objects/pageFactory';
+import {
+  expectNoAccessibilityViolations,
+  getIndicatorIdsByName,
+} from '../testHelpers';
 import indicatorData from '../../../../search-setup/assets/indicatorData.json';
 
 const searchTerm = 'mortality';
-let indicatorID1: string = '';
-let indicatorID2: string = '';
+let indicatorIDs: string[];
 
 test.describe('Search via indicator', () => {
   test.beforeAll(() => {
@@ -15,76 +17,72 @@ test.describe('Search via indicator', () => {
         lastUpdated: new Date(indicator.lastUpdated),
       };
     });
-    indicatorID1 = getIndicatorIDByName(typedIndicatorData, searchTerm)[0]
-      .indicatorId;
-    indicatorID2 = getIndicatorIDByName(typedIndicatorData, searchTerm)[1]
-      .indicatorId;
+
+    indicatorIDs = getIndicatorIdsByName(typedIndicatorData, searchTerm);
   });
-  test('assert displayed results, check the chart is displayed then navigate back through to search page', async ({
+  test('full end to end flow with accessibility checks', async ({
     homePage,
     resultsPage,
     chartPage,
     axeBuilder,
   }) => {
-    // Arrange
-    await homePage.navigateToSearch();
+    await test.step('Navigate to and verify search page', async () => {
+      await homePage.navigateToSearch();
+      await homePage.checkURLIsCorrect();
+      await expectNoAccessibilityViolations(axeBuilder);
+    });
 
-    // Assert
-    await homePage.checkURLIsCorrect();
-    expect((await axeBuilder.analyze()).violations).toEqual([]);
+    await test.step('Search for indicators and check results', async () => {
+      await homePage.typeIndicator(searchTerm);
+      await homePage.clickSearchButton();
 
-    // Act
-    await homePage.typeIndicator(searchTerm);
-    await homePage.clickSearchButton();
+      await resultsPage.checkURLIsCorrect(searchTerm);
+      await expectNoAccessibilityViolations(axeBuilder);
+      await resultsPage.checkSearchResults(searchTerm);
+    });
 
-    // Assert
-    await resultsPage.checkURLIsCorrect(searchTerm);
-    expect((await axeBuilder.analyze()).violations).toEqual([]);
-    await resultsPage.checkSearchResults(searchTerm);
+    await test.step('Select indicators and view charts', async () => {
+      await resultsPage.clickIndicatorCheckboxes(indicatorIDs);
+      await resultsPage.clickViewChartsButton();
 
-    // Act
-    await resultsPage.clickIndicatorCheckbox(indicatorID1);
-    await resultsPage.clickIndicatorCheckbox(indicatorID2);
-    await resultsPage.clickViewChartsButton();
+      await chartPage.checkURLIsCorrect(
+        `${searchTerm}&${SearchParams.IndicatorsSelected}=${indicatorIDs[0]}&${SearchParams.IndicatorsSelected}=${indicatorIDs[1]}`
+      );
+      await expectNoAccessibilityViolations(axeBuilder);
+      await chartPage.checkChartAndChartTable();
+    });
 
-    // Assert
-    await chartPage.checkURLIsCorrect(
-      `${searchTerm}&${SearchParams.IndicatorsSelected}=${indicatorID1}&${SearchParams.IndicatorsSelected}=${indicatorID2}`
-    );
-    expect((await axeBuilder.analyze()).violations).toEqual([]);
-    await chartPage.checkChartAndChartTable();
+    await test.step('Return to results page and verify selections are preselected', async () => {
+      await chartPage.clickBackLink();
 
-    // Act
-    await chartPage.clickBackLink();
+      await resultsPage.checkURLIsCorrect(
+        `${searchTerm}&${SearchParams.IndicatorsSelected}=${indicatorIDs[0]}&${SearchParams.IndicatorsSelected}=${indicatorIDs[1]}`
+      );
+      await resultsPage.checkSearchResults(searchTerm);
+      await resultsPage.checkIndicatorCheckboxChecked(indicatorIDs[0]);
+      await resultsPage.checkIndicatorCheckboxChecked(indicatorIDs[1]);
+    });
 
-    // Assert - check indicator selections previously made are prepopulated
-    await resultsPage.checkURLIsCorrect(
-      `${searchTerm}&${SearchParams.IndicatorsSelected}=${indicatorID1}&${SearchParams.IndicatorsSelected}=${indicatorID2}`
-    );
-    await resultsPage.checkSearchResults(searchTerm);
-    await resultsPage.checkIndicatorCheckboxChecked(indicatorID1);
-    await resultsPage.checkIndicatorCheckboxChecked(indicatorID2);
+    await test.step('Return to search page and verify fields are correctly prepopulated', async () => {
+      await resultsPage.clickBackLink();
 
-    // Act
-    await resultsPage.clickBackLink();
+      await homePage.checkURLIsCorrect(
+        `?${SearchParams.SearchedIndicator}=${searchTerm}`
+      );
+      await homePage.checkSearchFieldIsPrePopulatedWith(searchTerm);
+    });
 
-    // Assert - check search text previously entered is prepopulated
-    await homePage.checkURLIsCorrect(
-      `?${SearchParams.SearchedIndicator}=${searchTerm}`
-    );
-    await homePage.checkSearchFieldIsPrePopulatedWith(searchTerm);
+    await test.step('Verify search page validation prevents forward navigation', async () => {
+      await homePage.clearSearchIndicatorField();
+      await homePage.clickSearchButton();
 
-    // Act - clear the prepopulated search field and click search
-    await homePage.clearSearchIndicatorField();
-    await homePage.clickSearchButton();
-
-    // Assert - should be on the same page with search field still cleared and validation message displayed
-    await homePage.checkURLIsCorrect(
-      `?${SearchParams.SearchedIndicator}=${searchTerm}`
-    );
-    await homePage.checkSearchFieldIsPrePopulatedWith();
-    await homePage.checkSummaryValidation(
-      `There is a problemAt least one of the following fields must be populated:Search subjectSearch area`
-    );
+      await homePage.checkURLIsCorrect(
+        `?${SearchParams.SearchedIndicator}=${searchTerm}`
+      );
+      await homePage.checkSearchFieldIsPrePopulatedWith();
+      await homePage.checkSummaryValidation(
+        `There is a problemAt least one of the following fields must be populated:Search subjectSearch area`
+      );
+    });
   });
 });


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

When code merges into main that kicks off either the api or frontend deploy jobs it currently *could* fail and there would be no alert to this. This change is to add a Slack notification on failure of test tests. The message will go into the private channel - [dhsc-fingertips-next-build-notifications](https://grid-bjss.enterprise.slack.com/archives/C08AZ71A98B) using the Slack App - https://bjss.slack.com/marketplace/A08AL5K4NKZ-fingertipsnext-test-notifications and the https://github.com/ctrf-io/slack-test-reporter npm package (called via npx).

## Changes

- Added playwright-ctrf-json-reporter to create a ctrl formatted json report in CI that https://github.com/ctrf-io/slack-test-reporter can handle
- Added parameter to e2e test template yml so we can optionally send slack notifications on failure
- Added passing this param to the api and frontend deploy jobs
- Added new secret into github called SLACK_WEBHOOK_URL which is used by the new App mentioned above
- Refactoring of the e2e spec for readability so that when devs get directed to this the test step that failed can be highlighted


## Validation

E2E tests pass locally
E2E tests pass in CI
Will test E2E tests failing in CI and this slack message being sent