### PR TITLE
DHSCFT-281 switch indicator to something that passes in CI but failes in CD

### DIFF
--- a/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../testHelpers';
 import indicatorData from '../../../../search-setup/assets/indicatorData.json';
 
-const searchTerm = 'mortality';
+const searchTerm = 'Waiting';
 let indicatorIDs: string[];
 
 test.describe('Search via indicator', () => {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

Test out the work just merged in https://github.com/dhsc-govuk/FingertipsNext/pull/102 as discussed https://bjss.slack.com/archives/C085Q20RZU0/p1738253797006199?thread_ts=1738253729.474319&cid=C085Q20RZU0

## Changes

- switch searched indicator in e2e test to 'Waiting' as this passes in CI but fails in CD

## Validation

E2E tests pass in CI
