### PR TITLE
DHSCFT-281 - fix trailing double quotes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,6 @@ jobs:
 
       - name: Send slack message if e2e tests fail
         if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
-        run: npx slack-ctrf results ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance""
+        run: npx slack-ctrf results ${{ env.frontend-directory }}/ctrf/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

Fix trailing double quotes at the end of the new slack command
