### PR TITLE
DHSCFT-281 fix upload of new report for slack job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,6 +57,7 @@ jobs:
           path: |
             ${{ env.frontend-directory }}/playwright-report/
             ${{ env.frontend-directory }}/test-results/*/*.png
+            ${{ env.frontend-directory }}/ctrf/*.json
           retention-days: 10
 
       - name: Send slack message if e2e tests fail

--- a/.github/workflows/fingertips-api-deploy.yml
+++ b/.github/workflows/fingertips-api-deploy.yml
@@ -1,6 +1,7 @@
 name: Fingertips API Deploy
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [Fingertips API Build]
     types:

--- a/.github/workflows/fingertips-frontend-deploy.yml
+++ b/.github/workflows/fingertips-frontend-deploy.yml
@@ -1,6 +1,7 @@
 name: Fingertips Frontend Deploy
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [Fingertips Frontend Build]
     types:


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

Fix to upload the new report so that the followon slack job can send it. see https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13058665582/job/36436069494 for details where the e2e tests correctly failed and created a report:

playwright-ctrf-json-reporter: successfully written ctrf json to ctrf/ctrf-report.json

but then the slack job couldnt find it as it haddent been uploaded: 

Error: ENOENT: no such file or directory, open './frontend/fingertips-frontend/ctrf/ctrf-report.json'