### PR TITLE
DHSCFT-281 add condition to new download step

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,7 @@ jobs:
           retention-days: 10
 
       - name: Download ctrf report for slack message
+        if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
         uses: actions/download-artifact@v4
         id: download-artifacts
         with:


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

In the previous [PR](https://github.com/dhsc-govuk/FingertipsNext/pull/108) i added a new step to download the new test report but forgot to add the condition to only run on failure+if an optional parameter has been passed in. This PR adds the condition in.
