### PR TITLE
DHSCFT-226: Add England benchmark data to Linechart table

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
@@ -17,7 +17,7 @@ public class IndicatorsController(IIndicatorsService indicatorsService)
     /// supplying one or more area codes and one or more years in the query string.
     /// </summary>
     /// <param name="indicatorId">The unique identifier of the indicator.</param>
-    /// <param name="areaCodes">A list of area codes. Up to 10 distinct area codes can be requested.</param>
+    /// <param name="area_codes">A list of area codes. Up to 10 distinct area codes can be requested.</param>
     /// <param name="years">A list of years. Up to 10 distinct years can be requested.</param>
     /// <returns></returns>
     /// <remarks>
@@ -28,12 +28,12 @@ public class IndicatorsController(IIndicatorsService indicatorsService)
     [Route("{indicatorId:int}/data")]
     public async Task<IActionResult> GetIndicatorDataAsync(
         [FromRoute] int indicatorId,
-        [FromQuery] string[]? areaCodes = null,
+        [FromQuery] string[]? area_codes = null,
         [FromQuery] int[]? years = null)
     {
         var indicatorData = await _indicatorsService.GetIndicatorDataAsync(
             indicatorId,
-            areaCodes ?? [],
+            area_codes ?? [],
             years ?? []
             );
 

--- a/database/fingertips-db/PostDeployment/PopulateFingertips.sql
+++ b/database/fingertips-db/PostDeployment/PopulateFingertips.sql
@@ -2814,6 +2814,19 @@ INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [Se
 INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687403, 46400, 1760, 3, 483, 1154, 23.66874, 22.32133, 25.07617, 2023)
 INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687407, 46404, 1760, 3, 483, 910, 16.28537, 15.2292, 17.39467, 2023)
 INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687408, 46405, 1760, 3, 483, 1343, 16.41459, 15.54743, 17.31749, 2023)
+GO
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687500, 46400, 1, 1, 483, 11605, 481.222, 472.49009, 490.07447, 2021)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687501, 46400, 1, 2, 483, 7274, 294.39232, 287.65557, 301.24685, 2018)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687502, 46400, 1, 1, 483, 10000, 437.04409, 428.48587, 445.72974, 2016)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687503, 46400, 1, 1, 483, 10387, 526.17993, 516.00793, 536.50052, 2006)
+GO
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687504, 3333, 1, 1, 483, 100922, 420.07872, 417.48423, 422.68529, 2023)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687505, 3333, 1, 1, 483, 108141, 447.98616, 445.31571, 450.66864, 2021)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687506, 3333, 1, 2, 483, 65274, 262.05943, 260.05037, 264.08015, 2018)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687507, 3333, 1, 1, 483, 92666, 405.20584, 402.59074, 407.83366, 2016)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687508, 3333, 1, 1, 483, 95771, 495.37177, 492.20542, 498.55326, 2006)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687509, 3333, 1, 2, 483, 67936, 267.43674, 265.4267, 269.45821, 2023)
+INSERT [dbo].[HealthMeasure] ([HealthMeasureKey], [AreaKey], [IndicatorKey], [SexKey], [AgeKey], [Count], [Value], [LowerCI], [UpperCI], [Year]) VALUES (1687510, 3333, 1, 3, 483, 168858, 341.57323, 339.94294, 343.20939, 2023)
 SET IDENTITY_INSERT [dbo].[HealthMeasure] OFF
 GO
 

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -78,7 +78,6 @@ describe('Chart Page', () => {
     expect(page.props.populationData).toEqual(expectedPopulateData);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);
-    expect(page.props.englandBenchmarkData).toEqual(mockHealthData['1'][1]);
   });
 
   it('should pass undefined if there was an error getting population data', async () => {
@@ -97,16 +96,5 @@ describe('Chart Page', () => {
     expect(page.props.populationData).toEqual(undefined);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);
-  });
-
-  it('should pass undefined if there was an error getting england data', async () => {
-    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
-    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
-
-    const page = await ChartPage({
-      searchParams: generateSearchParams(searchParams),
-    });
-
-    expect(page.props.englandBenchmarkData).toBeUndefined();
   });
 });

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -35,7 +35,8 @@ describe('Chart Page', () => {
     jest.clearAllMocks();
   });
 
-  it('should make 2 calls for get health data - first one for the indicator the next one for the population data', async () => {
+  it('should make 3 calls for get health data - first one for the indicator, second one for the population data, third one for England data', async () => {
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
 
@@ -55,6 +56,12 @@ describe('Chart Page', () => {
       areaCodes: ['A001', areaCodeForEngland],
       indicatorId: indicatorIdForPopulation,
     });
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(3, {
+      areaCodes: [areaCodeForEngland],
+      indicatorId: 1,
+    });
   });
 
   it('should pass the correct props to the Chart page', async () => {
@@ -64,20 +71,24 @@ describe('Chart Page', () => {
     );
 
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
-      mockHealthData['A1425']
+      mockHealthData['1']
     );
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockHealthData[`${indicatorIdForPopulation}`]
     );
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([
+      mockHealthData['1'][1],
+    ]);
 
     const page = await ChartPage({
       searchParams: generateSearchParams(searchParams),
     });
 
-    expect(page.props.data).toEqual(mockHealthData['A1425']);
+    expect(page.props.data).toEqual(mockHealthData['1']);
     expect(page.props.populationData).toEqual(expectedPopulateData);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);
+    expect(page.props.englandBenchmarkData).toEqual([mockHealthData['1'][1]]);
   });
 
   it('should pass undefined if there was an error getting population data', async () => {
@@ -96,5 +107,19 @@ describe('Chart Page', () => {
     expect(page.props.populationData).toEqual(undefined);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);
+  });
+
+  it('should pass undefined if there was an error getting england data', async () => {
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockRejectedValueOnce(
+      'error England data'
+    );
+
+    const page = await ChartPage({
+      searchParams: generateSearchParams(searchParams),
+    });
+
+    expect(page.props.englandBenchmarkData).toBeUndefined();
   });
 });

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -75,13 +75,13 @@ describe('Chart Page', () => {
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator
     ).toHaveBeenNthCalledWith(1, {
-      areaCodes: ['A001'],
+      areaCodes: ['A001', areaCodeForEngland],
       indicatorId: 1,
     });
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator
     ).toHaveBeenNthCalledWith(2, {
-      areaCodes: ['A001'],
+      areaCodes: ['A001', areaCodeForEngland],
       indicatorId: 2,
     });
     expect(
@@ -109,7 +109,7 @@ describe('Chart Page', () => {
       searchParams: generateSearchParams(searchParams),
     });
 
-    expect(page.props.data).toEqual(mockHealthData['1']);
+    expect(page.props.data).toEqual([mockHealthData['1']]);
     expect(page.props.populationData).toEqual(expectedPopulateData);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -35,8 +35,7 @@ describe('Chart Page', () => {
     jest.clearAllMocks();
   });
 
-  it('should make 3 calls for get health data - first one for the indicator, second one for the population data, third one for England data', async () => {
-    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
+  it('should make 2 calls for get health data - first one for the indicator and England benchmark data, then for the population data', async () => {
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
 
@@ -47,7 +46,7 @@ describe('Chart Page', () => {
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator
     ).toHaveBeenNthCalledWith(1, {
-      areaCodes: ['A001'],
+      areaCodes: ['A001', areaCodeForEngland],
       indicatorId: 1,
     });
     expect(
@@ -55,12 +54,6 @@ describe('Chart Page', () => {
     ).toHaveBeenNthCalledWith(2, {
       areaCodes: ['A001', areaCodeForEngland],
       indicatorId: indicatorIdForPopulation,
-    });
-    expect(
-      mockIndicatorsApi.getHealthDataForAnIndicator
-    ).toHaveBeenNthCalledWith(3, {
-      areaCodes: [areaCodeForEngland],
-      indicatorId: 1,
     });
   });
 
@@ -76,9 +69,6 @@ describe('Chart Page', () => {
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockHealthData[`${indicatorIdForPopulation}`]
     );
-    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([
-      mockHealthData['1'][1],
-    ]);
 
     const page = await ChartPage({
       searchParams: generateSearchParams(searchParams),
@@ -88,7 +78,7 @@ describe('Chart Page', () => {
     expect(page.props.populationData).toEqual(expectedPopulateData);
     expect(page.props.searchedIndicator).toEqual('testing');
     expect(page.props.indicatorsSelected).toEqual(['1']);
-    expect(page.props.englandBenchmarkData).toEqual([mockHealthData['1'][1]]);
+    expect(page.props.englandBenchmarkData).toEqual(mockHealthData['1'][1]);
   });
 
   it('should pass undefined if there was an error getting population data', async () => {
@@ -112,9 +102,6 @@ describe('Chart Page', () => {
   it('should pass undefined if there was an error getting england data', async () => {
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce([]);
-    mockIndicatorsApi.getHealthDataForAnIndicator.mockRejectedValueOnce(
-      'error England data'
-    );
 
     const page = await ChartPage({
       searchParams: generateSearchParams(searchParams),

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -8,6 +8,22 @@ import {
   indicatorIdForPopulation,
 } from '@/lib/chartHelpers/constants';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import { IndicatorsApi } from '@/generated-sources/ft-api-client';
+
+const getEnglandBenchmarkData = async (
+  indicatorApi: IndicatorsApi,
+  indicatorId: string
+) => {
+  try {
+    const data = await indicatorApi.getHealthDataForAnIndicator({
+      indicatorId: Number(indicatorId),
+      areaCodes: [areaCodeForEngland],
+    });
+    return data;
+  } catch (error) {
+    console.log('error getting England benchmark data', error);
+  }
+};
 
 export default async function ChartPage(
   props: Readonly<{
@@ -49,12 +65,18 @@ export default async function ChartPage(
     );
   }
 
+  const englandBenchmarkData = await getEnglandBenchmarkData(
+    indicatorApi,
+    indicatorsSelected[0]
+  );
+
   return (
     <Chart
       populationData={preparedPopulationData}
       data={data}
       searchedIndicator={searchedIndicator}
       indicatorsSelected={indicatorsSelected}
+      englandBenchmarkData={englandBenchmarkData}
     />
   );
 }

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -30,7 +30,7 @@ export default async function ChartPage(
     indicatorsSelected.map((indicatorId) =>
       indicatorApi.getHealthDataForAnIndicator({
         indicatorId: Number(indicatorId),
-        areaCodes: areaCodes,
+        areaCodes: [...areaCodes, areaCodeForEngland],
       })
     )
   );

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -8,22 +8,6 @@ import {
   indicatorIdForPopulation,
 } from '@/lib/chartHelpers/constants';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
-import { IndicatorsApi } from '@/generated-sources/ft-api-client';
-
-const getEnglandBenchmarkData = async (
-  indicatorApi: IndicatorsApi,
-  indicatorId: string
-) => {
-  try {
-    const data = await indicatorApi.getHealthDataForAnIndicator({
-      indicatorId: Number(indicatorId),
-      areaCodes: [areaCodeForEngland],
-    });
-    return data;
-  } catch (error) {
-    console.log('error getting England benchmark data', error);
-  }
-};
 
 export default async function ChartPage(
   props: Readonly<{
@@ -43,7 +27,7 @@ export default async function ChartPage(
   const indicatorApi = ApiClientFactory.getIndicatorsApiClient();
   const data = await indicatorApi.getHealthDataForAnIndicator({
     indicatorId: Number(indicatorsSelected[0]),
-    areaCodes: areaCodes,
+    areaCodes: [...areaCodes, areaCodeForEngland],
   });
 
   let rawPopulationData = undefined;
@@ -65,9 +49,8 @@ export default async function ChartPage(
     );
   }
 
-  const englandBenchmarkData = await getEnglandBenchmarkData(
-    indicatorApi,
-    indicatorsSelected[0]
+  const englandBenchmarkData = data.find(
+    (area) => area.areaCode === areaCodeForEngland
   );
 
   return (

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -49,17 +49,12 @@ export default async function ChartPage(
     );
   }
 
-  const englandBenchmarkData = data.find(
-    (area) => area.areaCode === areaCodeForEngland
-  );
-
   return (
     <Chart
       populationData={preparedPopulationData}
       data={data}
       searchedIndicator={searchedIndicator}
       indicatorsSelected={indicatorsSelected}
-      englandBenchmarkData={englandBenchmarkData}
     />
   );
 }

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -82,7 +82,7 @@ describe('Line chart table suite', () => {
     );
   });
 
-  it('should display table with periods sorted in descending order', () => {
+  it('should display table with periods sorted in ascending order', () => {
     render(
       <LineChartTable
         data={MOCK_HEALTH_DATA}
@@ -93,7 +93,7 @@ describe('Line chart table suite', () => {
     const sortedHealthData = {
       ...MOCK_HEALTH_DATA,
       healthData: MOCK_HEALTH_DATA.healthData.toSorted(
-        (a, b) => b.year - a.year
+        (a, b) => a.year - b.year
       ),
     };
 

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -9,21 +9,37 @@ import { mockHealthData } from '@/mock/data/healthdata';
 
 describe('Line chart table suite', () => {
   const MOCK_HEALTH_DATA = mockHealthData['1'][0];
+  const MOCK_ENGLAND_DATA = mockHealthData['1'][1];
   const CELLS_PER_ROW = 7;
 
   it('snapshot test - should match snapshot', () => {
-    const container = render(<LineChartTable data={MOCK_HEALTH_DATA} />);
+    const container = render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={MOCK_ENGLAND_DATA}
+      />
+    );
     expect(container.asFragment()).toMatchSnapshot();
   });
 
   it('should render the LineChartTable component', () => {
-    render(<LineChartTable data={MOCK_HEALTH_DATA} />);
+    render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={MOCK_ENGLAND_DATA}
+      />
+    );
     const lineChart = screen.getByTestId('lineChartTable-component');
     expect(lineChart).toBeInTheDocument();
   });
 
   it('should render expected elements', () => {
-    render(<LineChartTable data={MOCK_HEALTH_DATA} />);
+    render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={MOCK_ENGLAND_DATA}
+      />
+    );
 
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getAllByRole('columnheader')[1]).toHaveTextContent(
@@ -46,7 +62,12 @@ describe('Line chart table suite', () => {
       LineChartTableHeadingEnum
     ).findIndex((value) => value === LineChartTableHeadingEnum.BenchmarkValue);
 
-    render(<LineChartTable data={MOCK_HEALTH_DATA} />);
+    render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={MOCK_ENGLAND_DATA}
+      />
+    );
 
     screen.getAllByTestId('grey-table-cell').forEach((greyCell) => {
       expect(greyCell).toHaveStyle(`background-color: ${LIGHT_GREY}`);
@@ -62,7 +83,12 @@ describe('Line chart table suite', () => {
   });
 
   it('should display table with periods sorted in descending order', () => {
-    render(<LineChartTable data={MOCK_HEALTH_DATA} />);
+    render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={MOCK_ENGLAND_DATA}
+      />
+    );
 
     const sortedHealthData = {
       ...MOCK_HEALTH_DATA,
@@ -74,6 +100,25 @@ describe('Line chart table suite', () => {
     for (let i = 0; i < MOCK_HEALTH_DATA.healthData.length; i++) {
       expect(screen.getAllByRole('cell')[i * CELLS_PER_ROW]).toHaveTextContent(
         String(sortedHealthData.healthData[i].year)
+      );
+    }
+  });
+
+  it('should render dashes if England benchmark prop is undefined', () => {
+    render(
+      <LineChartTable
+        data={MOCK_HEALTH_DATA}
+        englandBenchmarkData={undefined}
+      />
+    );
+
+    for (
+      let i = CELLS_PER_ROW - 1;
+      i < MOCK_HEALTH_DATA.healthData.length;
+      i += CELLS_PER_ROW - 1
+    ) {
+      expect(screen.getAllByRole('cell')[i * CELLS_PER_ROW]).toHaveTextContent(
+        '-'
       );
     }
   });

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
@@ -493,7 +493,7 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
           <td
             class="0 c12 c13 c14"
           >
-            2020
+            2004
           </td>
           <td
             class="0 c15 c13 c14"
@@ -501,12 +501,12 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
           <td
             class="1 c12 c13 c16"
           >
-            200
+            267
           </td>
           <td
             class="1 c12 c13 c16"
           >
-            9.7%
+            7.0%
           </td>
           <td
             class="1 c12 c13 c16"
@@ -522,83 +522,7 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
           >
-            7.3%
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="0 c12 c13 c14"
-          >
-            2012
-          </td>
-          <td
-            class="0 c15 c13 c14"
-          />
-          <td
-            class="1 c12 c13 c16"
-          >
-            300
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            6.0%
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            4.4%
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            5.8%
-          </td>
-          <td
-            class="1 c15 c13 c16 c17"
-            data-testid="grey-table-cell"
-          >
-            9.1%
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="0 c12 c13 c14"
-          >
-            2008
-          </td>
-          <td
-            class="0 c15 c13 c14"
-          />
-          <td
-            class="1 c12 c13 c16"
-          >
-            222
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            8.9%
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            4.4%
-          </td>
-          <td
-            class="1 c12 c13 c16"
-          >
-            5.8%
-          </td>
-          <td
-            class="1 c15 c13 c16 c17"
-            data-testid="grey-table-cell"
-          >
-            9.7%
+            9.0%
           </td>
         </tr>
         <tr
@@ -645,7 +569,7 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
           <td
             class="0 c12 c13 c14"
           >
-            2004
+            2008
           </td>
           <td
             class="0 c15 c13 c14"
@@ -653,12 +577,12 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
           <td
             class="1 c12 c13 c16"
           >
-            267
+            222
           </td>
           <td
             class="1 c12 c13 c16"
           >
-            7.0%
+            8.9%
           </td>
           <td
             class="1 c12 c13 c16"
@@ -674,7 +598,83 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
           >
-            9.0%
+            9.7%
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class="0 c12 c13 c14"
+          >
+            2012
+          </td>
+          <td
+            class="0 c15 c13 c14"
+          />
+          <td
+            class="1 c12 c13 c16"
+          >
+            300
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            6.0%
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            4.4%
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            5.8%
+          </td>
+          <td
+            class="1 c15 c13 c16 c17"
+            data-testid="grey-table-cell"
+          >
+            9.1%
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class="0 c12 c13 c14"
+          >
+            2020
+          </td>
+          <td
+            class="0 c15 c13 c14"
+          />
+          <td
+            class="1 c12 c13 c16"
+          >
+            200
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            9.7%
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            4.4%
+          </td>
+          <td
+            class="1 c12 c13 c16"
+          >
+            5.8%
+          </td>
+          <td
+            class="1 c15 c13 c16 c17"
+            data-testid="grey-table-cell"
+          >
+            7.3%
           </td>
         </tr>
       </tbody>

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
 }
 
 .c6 {
-  width: 5%;
+  width: 10%;
   padding: 1em 0;
 }
 
@@ -519,9 +519,11 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             5.8%
           </td>
           <td
-            class="2 c15 c13 c17"
+            class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
-          />
+          >
+            7.3%
+          </td>
         </tr>
         <tr
           class=""
@@ -555,9 +557,11 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             5.8%
           </td>
           <td
-            class="2 c15 c13 c17"
+            class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
-          />
+          >
+            9.1%
+          </td>
         </tr>
         <tr
           class=""
@@ -591,9 +595,11 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             5.8%
           </td>
           <td
-            class="2 c15 c13 c17"
+            class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
-          />
+          >
+            9.7%
+          </td>
         </tr>
         <tr
           class=""
@@ -627,9 +633,11 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             5.8%
           </td>
           <td
-            class="2 c15 c13 c17"
+            class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
-          />
+          >
+            7.1%
+          </td>
         </tr>
         <tr
           class=""
@@ -663,9 +671,11 @@ exports[`Line chart table suite snapshot test - should match snapshot 1`] = `
             5.8%
           </td>
           <td
-            class="2 c15 c13 c17"
+            class="1 c15 c13 c16 c17"
             data-testid="grey-table-cell"
-          />
+          >
+            9.0%
+          </td>
         </tr>
       </tbody>
     </table>

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -12,6 +12,7 @@ import {
 
 interface TableProps {
   data: HealthDataForArea;
+  englandBenchmarkData: HealthDataForArea | undefined;
 }
 
 interface LineChartTableRowData {
@@ -50,7 +51,7 @@ const StyledAlignLeftHeader = styled(StyledTableCellHeader)({
 });
 
 const StyledAreaNameHeader = styled(StyledAlignLeftHeader)({
-  width: '5%',
+  width: '10%',
   padding: '1em 0',
 });
 
@@ -81,7 +82,7 @@ const StyledAlignRightTableCell = styled(StyledTableCell)({
   textAlign: 'right',
 });
 
-const StyledBenchmarkValueTableCell = styled(StyledTableCell)({
+const StyledBenchmarkValueTableCell = styled(StyledAlignRightTableCell)({
   backgroundColor: LIGHT_GREY,
   borderTop: `solid #F3F2F1 2px`,
 });
@@ -103,6 +104,10 @@ const mapToTableData = (areaData: HealthDataForArea): LineChartTableRowData[] =>
     lower: healthPoint.lowerCi,
     upper: healthPoint.upperCi,
   }));
+
+const sortPeriodDesc = (
+  tableRowData: LineChartTableRowData[]
+): LineChartTableRowData[] => tableRowData.sort((a, b) => b.period - a.period);
 
 const convertToPercentage = (value: number): string => {
   // dummy function to do percentage conversions until real conversion logic is provided
@@ -157,11 +162,16 @@ const getCellHeader = (heading: string, index: number): ReactNode => {
   );
 };
 
-export function LineChartTable({ data }: Readonly<TableProps>) {
+export function LineChartTable({
+  data,
+  englandBenchmarkData,
+}: Readonly<TableProps>) {
   const tableData = mapToTableData(data);
-  const dataSortedByPeriodDesc = tableData.toSorted(
-    (a, b) => b.period - a.period
-  );
+  const englandData = englandBenchmarkData
+    ? mapToTableData(englandBenchmarkData)
+    : [];
+  const dataSortedByPeriodDesc = sortPeriodDesc(tableData);
+  const englandRowDataDesc = sortPeriodDesc(englandData);
   return (
     <>
       <StyledDiv>
@@ -212,7 +222,11 @@ export function LineChartTable({ data }: Readonly<TableProps>) {
               <StyledAlignRightTableCell numeric>
                 {convertToPercentage(point.upper)}
               </StyledAlignRightTableCell>
-              <StyledBenchmarkValueTableCell data-testid="grey-table-cell"></StyledBenchmarkValueTableCell>
+              <StyledBenchmarkValueTableCell data-testid="grey-table-cell">
+                {englandRowDataDesc.length
+                  ? convertToPercentage(englandRowDataDesc[index].value)
+                  : '-'}
+              </StyledBenchmarkValueTableCell>
             </Table.Row>
           ))}
         </StyledTable>

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -171,8 +171,8 @@ export function LineChartTable({
   const englandData = englandBenchmarkData
     ? mapToTableData(englandBenchmarkData)
     : [];
-  const dataSortedByPeriodDesc = sortPeriod(tableData);
-  const englandRowDataDesc = sortPeriod(englandData);
+  const dataSortedByPeriod = sortPeriod(tableData);
+  const englandRowData = sortPeriod(englandData);
   return (
     <>
       <StyledDiv>
@@ -205,7 +205,7 @@ export function LineChartTable({
             </>
           }
         >
-          {dataSortedByPeriodDesc.map((point, index) => (
+          {dataSortedByPeriod.map((point, index) => (
             <Table.Row key={`${data.areaCode}-${point.period}--${index}`}>
               <StyledAlignLeftTableCell numeric>
                 {point.period}
@@ -224,8 +224,8 @@ export function LineChartTable({
                 {convertToPercentage(point.upper)}
               </StyledAlignRightTableCell>
               <StyledBenchmarkValueTableCell data-testid="grey-table-cell">
-                {englandRowDataDesc.length
-                  ? convertToPercentage(englandRowDataDesc[index].value)
+                {englandRowData.length
+                  ? convertToPercentage(englandRowData[index].value)
                   : '-'}
               </StyledBenchmarkValueTableCell>
             </Table.Row>

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -107,7 +107,8 @@ const mapToTableData = (areaData: HealthDataForArea): LineChartTableRowData[] =>
 
 const sortPeriodDesc = (
   tableRowData: LineChartTableRowData[]
-): LineChartTableRowData[] => tableRowData.sort((a, b) => b.period - a.period);
+): LineChartTableRowData[] =>
+  tableRowData.toSorted((a, b) => b.period - a.period);
 
 const convertToPercentage = (value: number): string => {
   // dummy function to do percentage conversions until real conversion logic is provided

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -105,10 +105,10 @@ const mapToTableData = (areaData: HealthDataForArea): LineChartTableRowData[] =>
     upper: healthPoint.upperCi,
   }));
 
-const sortPeriodDesc = (
+const sortPeriod = (
   tableRowData: LineChartTableRowData[]
 ): LineChartTableRowData[] =>
-  tableRowData.toSorted((a, b) => b.period - a.period);
+  tableRowData.toSorted((a, b) => a.period - b.period);
 
 const convertToPercentage = (value: number): string => {
   // dummy function to do percentage conversions until real conversion logic is provided
@@ -171,8 +171,8 @@ export function LineChartTable({
   const englandData = englandBenchmarkData
     ? mapToTableData(englandBenchmarkData)
     : [];
-  const dataSortedByPeriodDesc = sortPeriodDesc(tableData);
-  const englandRowDataDesc = sortPeriodDesc(englandData);
+  const dataSortedByPeriodDesc = sortPeriod(tableData);
+  const englandRowDataDesc = sortPeriod(englandData);
   return (
     <>
       <StyledDiv>

--- a/frontend/fingertips-frontend/components/pages/chart/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/chart/index.tsx
@@ -8,20 +8,19 @@ import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { BarChart } from '@/components/organisms/BarChart';
 import { PopulationPyramid } from '@/components/organisms/PopulationPyramid';
 import { PopulationData } from '@/lib/chartHelpers/preparePopulationData';
+import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 type ChartProps = {
   data: HealthDataForArea[];
   populationData?: PopulationData;
   searchedIndicator?: string;
   indicatorsSelected?: string[];
-  englandBenchmarkData?: HealthDataForArea;
 };
 
 export function Chart({
   data,
   populationData,
   searchedIndicator,
-  englandBenchmarkData,
   indicatorsSelected = [],
 }: Readonly<ChartProps>) {
   const searchState = new SearchStateManager({
@@ -29,6 +28,11 @@ export function Chart({
     [SearchParams.IndicatorsSelected]: indicatorsSelected,
   });
   const backLinkPath = searchState.generatePath('/results');
+
+  const englandBenchmarkData = data
+    .flat()
+    .find((areaData) => areaData.areaCode === areaCodeForEngland);
+
   return (
     <>
       <BackLink

--- a/frontend/fingertips-frontend/components/pages/chart/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/chart/index.tsx
@@ -14,12 +14,14 @@ type ChartProps = {
   populationData?: PopulationData;
   searchedIndicator?: string;
   indicatorsSelected?: string[];
+  englandBenchmarkData?: HealthDataForArea[];
 };
 
 export function Chart({
   data,
   populationData,
   searchedIndicator,
+  englandBenchmarkData,
   indicatorsSelected = [],
 }: Readonly<ChartProps>) {
   const searchState = new SearchStateManager({
@@ -62,7 +64,12 @@ export function Chart({
         accessibilityLabel="A bar chart showing healthcare data"
       />
       <br />
-      <LineChartTable data={data[0]}></LineChartTable>
+      <LineChartTable
+        data={data[0]}
+        englandBenchmarkData={
+          englandBenchmarkData ? englandBenchmarkData[0] : undefined
+        }
+      ></LineChartTable>
     </>
   );
 }

--- a/frontend/fingertips-frontend/components/pages/chart/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/chart/index.tsx
@@ -9,7 +9,7 @@ import { BarChart } from '@/components/organisms/BarChart';
 import { PopulationPyramid } from '@/components/organisms/PopulationPyramid';
 import { PopulationData } from '@/lib/chartHelpers/preparePopulationData';
 import { ScatterChart } from '@/components/organisms/ScatterChart';
-import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
+import { getEnglandDataForIndicatorIndex } from '@/lib/chartHelpers/chartHelpers';
 
 type ChartProps = {
   data: HealthDataForArea[][];
@@ -30,9 +30,7 @@ export function Chart({
   });
   const backLinkPath = searchState.generatePath('/results');
 
-  const englandBenchmarkData = data
-    .flat()
-    .find((areaData) => areaData.areaCode === areaCodeForEngland);
+  const englandBenchmarkData = getEnglandDataForIndicatorIndex(data, 0);
 
   return (
     <>

--- a/frontend/fingertips-frontend/components/pages/chart/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/chart/index.tsx
@@ -14,7 +14,7 @@ type ChartProps = {
   populationData?: PopulationData;
   searchedIndicator?: string;
   indicatorsSelected?: string[];
-  englandBenchmarkData?: HealthDataForArea[];
+  englandBenchmarkData?: HealthDataForArea;
 };
 
 export function Chart({
@@ -67,7 +67,7 @@ export function Chart({
       <LineChartTable
         data={data[0]}
         englandBenchmarkData={
-          englandBenchmarkData ? englandBenchmarkData[0] : undefined
+          englandBenchmarkData ? englandBenchmarkData : undefined
         }
       ></LineChartTable>
     </>

--- a/frontend/fingertips-frontend/components/pages/chart/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/chart/index.tsx
@@ -66,9 +66,7 @@ export function Chart({
       <br />
       <LineChartTable
         data={data[0]}
-        englandBenchmarkData={
-          englandBenchmarkData ? englandBenchmarkData : undefined
-        }
+        englandBenchmarkData={englandBenchmarkData}
       ></LineChartTable>
     </>
   );

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -1,8 +1,10 @@
 import {
   generateSeriesData,
+  getEnglandDataForIndicatorIndex,
   sortHealthDataByDate,
   sortHealthDataByYearDescending,
 } from '@/lib/chartHelpers/chartHelpers';
+import { mockHealthData } from '@/mock/data/healthdata';
 
 const mockData = [
   {
@@ -139,5 +141,18 @@ describe('sortHealthDataByYearDescending', () => {
 
     const result = sortHealthDataByYearDescending(mockData);
     expect(result).toEqual(mockSortedData);
+  });
+});
+
+describe('getEnglandDataForIndicatorIndex', () => {
+  it('should find England data for specified indicator id', () => {
+    const data = [mockHealthData['337'], mockHealthData['1']];
+
+    expect(getEnglandDataForIndicatorIndex(data, 0)).toEqual(
+      mockHealthData['337'][0]
+    );
+    expect(getEnglandDataForIndicatorIndex(data, 1)).toEqual(
+      mockHealthData['1'][1]
+    );
   });
 });

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -1,5 +1,6 @@
 import Highcharts from 'highcharts';
 import { HealthDataForArea } from '@/generated-sources/ft-api-client';
+import { areaCodeForEngland } from './constants';
 
 export function sortHealthDataByDate(
   data: HealthDataForArea[]
@@ -27,6 +28,15 @@ export function sortHealthDataByYearDescending(
     ...item,
     healthData: item.healthData.toSorted((a, b) => b.year - a.year),
   }));
+}
+
+export function getEnglandDataForIndicatorIndex(
+  data: HealthDataForArea[][],
+  indicatorIndex: number
+) {
+  return data[indicatorIndex].find(
+    (areaData) => areaData.areaCode === areaCodeForEngland
+  );
 }
 
 export enum LineChartTableHeadingEnum {

--- a/frontend/fingertips-frontend/mock/data/healthdata.ts
+++ b/frontend/fingertips-frontend/mock/data/healthdata.ts
@@ -1100,11 +1100,62 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
       ],
     },
     {
+      areaCode: 'E92000001',
+      areaName: 'England',
+      healthData: [
+        {
+          year: 2004,
+          count: 200,
+          value: 904.874,
+          lowerCi: 0,
+          upperCi: 0,
+          ageBand: '0-4',
+          sex: 'Female',
+        },
+        {
+          year: 2006,
+          count: 179,
+          value: 709.7645,
+          lowerCi: 0,
+          upperCi: 0,
+          ageBand: '5-9',
+          sex: 'Female',
+        },
+        {
+          year: 2008,
+          count: 500,
+          value: 965.9843,
+          lowerCi: 0,
+          upperCi: 0,
+          ageBand: '10-14',
+          sex: 'Female',
+        },
+        {
+          year: 2012,
+          count: 400,
+          value: 908.8475,
+          lowerCi: 0,
+          upperCi: 0,
+          ageBand: '15-19',
+          sex: 'Female',
+        },
+        {
+          year: 2020,
+          count: 100,
+          value: 734.8973,
+          lowerCi: 0,
+          upperCi: 0,
+          ageBand: '20-24',
+          sex: 'Female',
+        },
+      ],
+    },
+    {
       areaCode: 'A1426',
       areaName: 'South FooBar',
       healthData: [
         {
-          year: 2010,
+          year: 2006,
           count: 157,
           value: 723.090354,
           lowerCi: 441.69151,
@@ -1113,7 +1164,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2022,
+          year: 2020,
           count: 256,
           value: 905.145997,
           lowerCi: 441.69151,
@@ -1122,7 +1173,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2005,
+          year: 2004,
           count: 222,
           value: 135.149304,
           lowerCi: 441.69151,
@@ -1131,7 +1182,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2007,
+          year: 2008,
           count: 131,
           value: 890.328253,
           lowerCi: 441.69151,
@@ -1140,7 +1191,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2006,
+          year: 2012,
           count: 452,
           value: 478.996862,
           lowerCi: 441.69151,
@@ -1155,7 +1206,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
       areaName: 'Area 1427',
       healthData: [
         {
-          year: 2024,
+          year: 2020,
           count: 411,
           value: 579.848756,
           lowerCi: 441.69151,
@@ -1164,7 +1215,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2018,
+          year: 2008,
           count: 367,
           value: 383.964067,
           lowerCi: 441.69151,
@@ -1173,7 +1224,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2010,
+          year: 2012,
           count: 289,
           value: 851.163104,
           lowerCi: 441.69151,
@@ -1191,7 +1242,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2019,
+          year: 2006,
           count: 489,
           value: 290.465304,
           lowerCi: 441.69151,
@@ -1206,7 +1257,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
       areaName: 'Area 1428',
       healthData: [
         {
-          year: 2024,
+          year: 2020,
           count: 311,
           value: 400.848756,
           lowerCi: 441.69151,
@@ -1215,7 +1266,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2019,
+          year: 2004,
           count: 469,
           value: 320.964067,
           lowerCi: 441.69151,
@@ -1224,7 +1275,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2015,
+          year: 2006,
           count: 120,
           value: 600.163104,
           lowerCi: 441.69151,
@@ -1233,7 +1284,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2004,
+          year: 2012,
           count: 250,
           value: 650.129883,
           lowerCi: 441.69151,
@@ -1242,7 +1293,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2006,
+          year: 2008,
           count: 344,
           value: 500.650389,
           lowerCi: 441.69151,
@@ -1266,7 +1317,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2018,
+          year: 2012,
           count: 234,
           value: 472.7613425,
           lowerCi: 441.69151,
@@ -1275,7 +1326,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2005,
+          year: 2008,
           count: 299,
           value: 582.306765,
           lowerCi: 441.69151,
@@ -1284,7 +1335,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2017,
+          year: 2020,
           count: 435,
           value: 563.4002,
           lowerCi: 441.69151,
@@ -1293,7 +1344,7 @@ export const mockHealthData: Record<string, HealthDataForArea[]> = {
           sex: 'Persons',
         },
         {
-          year: 2023,
+          year: 2004,
           count: 277,
           value: 627.899536,
           lowerCi: 441.69151,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-226](https://bjss-enterprise.atlassian.net/browse/DHSCFT-226)

Include a summary of what this pull request is changing and any relevant background context.

## Changes

- Added API call to retrieve England benchmark data
- Displayed England data on Linechart table
- Added data to database post deploy script to enable testing with API

## Validation

validated against API

![image](https://github.com/user-attachments/assets/656d740d-e221-4322-ba87-d80c66011f92)

