### PR TITLE
Add workflow job to e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,17 +60,26 @@ jobs:
             ${{ env.frontend-directory }}/ctrf/ctrf-report.json
           retention-days: 10
 
+  send-slack-notification:
+    name: Send Slack Notification
+    needs: execute-e2e-tests
+    if: ${{ needs.execute-e2e-tests.result == 'failure' }}
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.frontend-directory }}
+
+    steps:
       - name: Download ctrf report for slack message
-        if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
         uses: actions/download-artifact@v4
         id: download-artifacts
         with:
           name: playwright-failure-artefacts
           path: ${{ env.frontend-directory }}/downloaded
-          pattern: /ctrf/ctrf-report.json
+          pattern: ctrf/ctrf-report.json
 
       - name: Send slack message if e2e tests fail
-        if: ${{ failure() && inputs.send-slack-on-fail  == 'true' }}
         run: |
           ls ${{ steps.download-artifacts.outputs.download-path }}
           npx slack-ctrf results ${{ steps.download-artifacts.outputs.download-path }}/ctrf-report.json --title "E2E Test Failure - Deployed Fingertips Instance"


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-281](https://bjss-enterprise.atlassian.net/browse/DHSCFT-281)

Add separate job to e2e to send slack notification

## Changes

- Add separate job in e2e tests to download artifact and send notifications

