### PR TITLE
DHSCFT-304 Add jest lint rules into eslint and tidy up existing list issues in main

### DIFF
--- a/frontend/fingertips-frontend/README.md
+++ b/frontend/fingertips-frontend/README.md
@@ -108,7 +108,7 @@ npm run test-e2e-local-docker
 ```
 You will need to have docker running locally first before executing this command.
 
-If you wish to use UI mode when running against a containerised fingertips instance you will need to add the --ui parameter to the playwright test command in the `test-e2e-local-docker` script.
+If you wish to use UI mode when running against a containerised fingertips instance you will need to add the --ui parameter to the `playwright test` part of the command in the `test-e2e-local-docker` script.
 
 Note that each test will be executed in parallel using Chromium and Webkit as defined in playwright.config.ts. Also note we use the full chromium headless mode offered by recent playwright versions see https://playwright.dev/docs/release-notes#try-new-chromium-headless for details, we do to this make our e2e testing as close to real world as possible.
 
@@ -118,7 +118,7 @@ Currently performed at the E2E stage. Libraries used: @axe-core/playwright and a
 
 Configured to the WCAG2.2 AA standard in the following file playwright/page-objects/pageFactory.ts.
 
-To check there are 0 accessibility violations call expect((await axeBuilder.analyze()).violations).toEqual([]);.
+To check there are 0 accessibility violations call expectNoAccessibilityViolations();.
 
 Any violations of this standard cause a test failure unless the rule violated has been accepted in pageFactory.ts.
 

--- a/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
+++ b/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
@@ -18,7 +18,7 @@ function* iteratorFromList<T>(list: T[]): IterableIterator<T> {
   }
 }
 
-export const getMockFormData = (formData: Record<string, string>) =>
+const getMockFormData = (formData: Record<string, string>) =>
   mockDeep<FormData>({
     entries: jest.fn().mockImplementation(() => {
       const formDataEntries = Object.entries(formData);
@@ -70,6 +70,6 @@ describe('getSearchSuggestions', () => {
   it('should return a maximum of 20 suggestions', async () => {
     SearchServiceFactory.reset();
     process.env.DHSC_AI_SEARCH_USE_MOCK_SERVICE = 'true';
-    expect((await getSearchSuggestions('Surgery')).length).toEqual(20);
+    expect(await getSearchSuggestions('Surgery')).toHaveLength(20);
   });
 });

--- a/frontend/fingertips-frontend/components/molecules/result/searchResult.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/result/searchResult.test.tsx
@@ -90,7 +90,7 @@ describe('Indicator Checkbox', () => {
 
     await user.click(screen.getByRole('checkbox'));
 
-    expect(mockReplace).toBeCalledWith(
+    expect(mockReplace).toHaveBeenCalledWith(
       `${mockPath}?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=1`,
       {
         scroll: false,
@@ -103,7 +103,7 @@ describe('Indicator Checkbox', () => {
 
     await user.click(screen.getByRole('checkbox'));
 
-    expect(mockReplace).toBeCalledWith(
+    expect(mockReplace).toHaveBeenCalledWith(
       `${mockPath}?${SearchParams.SearchedIndicator}=test`,
       {
         scroll: false,

--- a/frontend/fingertips-frontend/components/pages/home/home.test.tsx
+++ b/frontend/fingertips-frontend/components/pages/home/home.test.tsx
@@ -75,5 +75,5 @@ it('should focus on the input boxes when there is a validation error', async () 
       screen.getByRole('textbox', { name: /Search by subject/i })
     ).toHaveFocus();
   });
-  expect(scrollMock).toBeCalledTimes(1);
+  expect(scrollMock).toHaveBeenCalledWith(1);
 });

--- a/frontend/fingertips-frontend/components/pages/results/Results.test.tsx
+++ b/frontend/fingertips-frontend/components/pages/results/Results.test.tsx
@@ -205,7 +205,7 @@ describe('Search Results Suite', () => {
     await user.click(errorLink);
 
     expect(screen.getByRole('checkbox', { name: /NHS/i })).toHaveFocus();
-    expect(scrollMock).toBeCalledTimes(1);
+    expect(scrollMock).toHaveBeenCalledWith(1);
   });
 
   it('should have appropriate direct link for each indicator regardless of checkbox state', () => {

--- a/frontend/fingertips-frontend/eslint.config.mjs
+++ b/frontend/fingertips-frontend/eslint.config.mjs
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import js from '@eslint/js';
 import { FlatCompat } from '@eslint/eslintrc';
+import pluginJest from 'eslint-plugin-jest';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -14,6 +15,10 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    plugins: { jest: pluginJest },
+    languageOptions: {
+      globals: pluginJest.environments.globals.globals,
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -21,6 +26,11 @@ const eslintConfig = [
           varsIgnorePattern: '^_',
         },
       ],
+      'jest/no-focused-tests': 'error',
+      'jest/no-disabled-tests': 'warn',
+      'jest/no-identical-title': 'error',
+      'jest/prefer-to-have-length': 'error',
+      'jest/valid-expect': 'error',
     },
   },
 ];

--- a/frontend/fingertips-frontend/package-lock.json
+++ b/frontend/fingertips-frontend/package-lock.json
@@ -50,6 +50,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^9.17.0",
         "eslint-config-next": "^15.1.3",
+        "eslint-plugin-jest": "^28.11.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-mock-extended": "^4.0.0-beta1",
@@ -7699,6 +7700,32 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "28.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test-ci": "jest --ci --silent",
     "test-e2e": "playwright test",
-    "test-e2e-local-docker": "START_DOCKER_WEBSERVER=true npm run start:all && playwright test || true && npm run stop:all",
+    "test-e2e-local-docker": "MOCK_SERVER=false npm run start:all && playwright test || true && npm run stop:all",
     "prettier": "prettier --write .",
     "prettier-ci": "prettier . --check"
   },
@@ -66,6 +66,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9.17.0",
     "eslint-config-next": "^15.1.3",
+    "eslint-plugin-jest": "^28.11.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-mock-extended": "^4.0.0-beta1",

--- a/frontend/fingertips-frontend/playwright.config.ts
+++ b/frontend/fingertips-frontend/playwright.config.ts
@@ -3,9 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 const url = process.env.FINGERTIPS_FRONTEND_URL || 'http://localhost:3000';
 const jobUrl = process.env.JOB_URL;
 const runCommand =
-  process.env.START_DOCKER_WEBSERVER === 'true'
-    ? 'npm run dev-docker'
-    : 'npm run dev';
+  process.env.MOCK_SERVER === 'true' ? 'npm run dev' : 'npm run dev-docker';
 
 export default defineConfig({
   testDir: './playwright/tests',


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-304](https://bjss-enterprise.atlassian.net/browse/DHSCFT-304)

This PR is adding jest linting rules to the eslint config to prevent things like .only being committed into main. It also addresses existing linting issues with the jest unit tests already in main.

## Changes

- Add jest linting config
- Address existing lint issues with the jest unit tests
- Addressing an issue from a previous PR about the `test-e2e-local-docker` command to run the e2e tests against local docker from @gareth-allan-bjss - https://bjss.slack.com/archives/C085Q20RZU0/p1738687494514829?thread_ts=1738681757.832509&cid=C085Q20RZU0

## Validation

Ran lint locally and passes
Ran unit tests locally and passes
All tests pass in CI
Have run `test-e2e-local-docker` command locally and e2e tests pass
