### PR TITLE
Add further conditions to prevent running on failed jobs

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -197,6 +197,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
@@ -214,6 +216,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.api_changed == 'true'
@@ -233,6 +237,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.frontend_changed == 'true'
@@ -261,6 +267,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
       github.ref_name == 'main' &&
       (
@@ -289,6 +297,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
       github.ref_name == 'main' &&
       (
@@ -357,6 +367,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       (
         github.head_ref == 'main' ||
         github.ref_name == 'main'
@@ -419,6 +431,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       (
         github.head_ref == 'main' ||
         github.ref_name == 'main'
@@ -483,6 +497,8 @@ jobs:
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
       (
         github.ref_name == 'main' &&


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-318](https://bjss-enterprise.atlassian.net/browse/DHSCFT-318)

Failed jobs are not causing dependent workflow jobs to skip. This is because other dependent jobs have succeeded. Added further conditions to prevent this behaviour.

## Changes

- Add further conditions to the success/failure of dependent jobs
