### PR TITLE
DHSCFT-340 - add back in to not check pop pyramid is displayed

### DIFF
--- a/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
@@ -45,7 +45,10 @@ export default class ChartPage extends BasePage {
     indicatorMode: IndicatorMode,
     areaMode: AreaMode
   ): ScenarioConfig {
-    const defaultVisible = [this.populationPyramidComponent];
+    // Temporarily disabled until the pop pyramid is implemented fully under DHSCFT-148.
+    // const defaultVisible = [this.populationPyramidComponent];
+    const defaultVisible: never[] = [];
+
     const defaultHidden = [
       this.lineChartComponent,
       this.lineChartTableComponent,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-340](https://bjss-enterprise.atlassian.net/browse/DHSCFT-340)

this fixes a known issue where we are expecting the e2e tests to fail du to expecting ‘populationPyramid-component’ to be visible but it is not visible.

this is because this [PR](https://github.com/dhsc-govuk/FingertipsNext/pull/136) removed the pop pyramid e2e check. but then when this [PR](https://github.com/dhsc-govuk/FingertipsNext/pull/138) has gone in after it, it has reintroduced the check.

## Validation

ran tests locally using mocks and docker and both passed
running in CI passed
