### PR TITLE
DHSCFT-236: Revert "e2e test added (#169)"

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/AreaFilter/__snapshots__/AreaFilter.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/AreaFilter/__snapshots__/AreaFilter.test.tsx.snap
@@ -347,7 +347,6 @@ exports[`Area Filter snapshot test 1`] = `
     >
       <div
         class="c4"
-        data-testid="selected-areas-container"
       >
         <span
           class="c5 c6"
@@ -373,7 +372,6 @@ exports[`Area Filter snapshot test 1`] = `
         >
           <label
             class="c13 c14"
-            data-testid="area-type-selector-container"
           >
             <span
               class="c5"
@@ -386,7 +384,6 @@ exports[`Area Filter snapshot test 1`] = `
           </label>
           <label
             class="c13 c14"
-            data-testid="group-type-selector-container"
           >
             <span
               class="c5"

--- a/frontend/fingertips-frontend/components/organisms/AreaFilter/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/AreaFilter/index.tsx
@@ -121,7 +121,7 @@ export function AreaFilter({
       </StyledFilterPaneHeader>
       <SectionBreak visible={true} />
       <StyledFilterDiv>
-        <StyledFilterSelectedAreaDiv data-testid="selected-areas-container">
+        <StyledFilterSelectedAreaDiv>
           <StyledFilterLabel>
             {`Selected areas (${selectedAreasData?.length ?? 0})`}
           </StyledFilterLabel>
@@ -139,7 +139,6 @@ export function AreaFilter({
 
         <ShowHideContainer summary="Add or change areas">
           <StyledFilterSelect
-            data-testid="area-type-selector-container"
             label="Select an area type"
             input={{
               onChange: (e) =>
@@ -156,7 +155,6 @@ export function AreaFilter({
           </StyledFilterSelect>
 
           <StyledFilterSelect
-            data-testid="group-type-selector-container"
             label="Select a group type"
             input={{
               onChange: (e) =>

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
@@ -14,66 +14,13 @@ export default class ResultsPage extends BasePage {
   readonly indicatorSearchError = `indicator-search-form-error`;
   readonly indicatorSearchButton = `indicator-search-form-submit`;
   readonly areaFilterContainer = 'area-filter-container';
-  readonly areaTypeSelector = 'area-type-selector-container';
-  readonly groupTypeSelector = 'group-type-selector-container';
-  readonly selectedAreasContainer = 'selected-areas-container';
-  readonly pillContainer = 'pill-container';
-  readonly filterName = 'filter-name';
-  readonly removeIcon = 'remove-icon-div';
-
-  async navigateToResults(
-    searchIndicator: string,
-    selectedAreaCodes: string[]
-  ) {
-    const asQuery = selectedAreaCodes.reduce(
-      (accumulator, currentValue) =>
-        accumulator + `&${SearchParams.AreasSelected}=${currentValue}`,
-      ''
-    );
-
-    await this.page.goto(
-      `results?${SearchParams.SearchedIndicator}=${searchIndicator}${asQuery}`
-    );
-  }
-
-  areaFilterPills() {
-    return this.page
-      .getByTestId(this.areaFilterContainer)
-      .getByTestId(this.pillContainer);
-  }
-
-  async areaFilterPillsText() {
-    const pillFilterNames = await this.areaFilterPills()
-      .getByTestId(this.filterName)
-      .all();
-
-    return Promise.all(pillFilterNames.map(async (l) => await l.textContent()));
-  }
-
-  async closeAreaFilterPill(index: number) {
-    const pills = await this.areaFilterPills()
-      .getByTestId(this.removeIcon)
-      .all();
-
-    await pills[index].click();
-  }
-
-  areaFilterCombobox() {
-    return this.page
-      .getByTestId(this.areaFilterContainer)
-      .getByTestId(this.areaTypeSelector)
-      .locator('select');
-  }
-
-  areaFilterOptions() {
-    return this.page
-      .getByTestId(this.areaFilterContainer)
-      .getByTestId(this.areaTypeSelector)
-      .getByRole('option');
-  }
 
   async areaFilterOptionsText() {
-    const options = await this.areaFilterOptions().all();
+    const options = await this.page
+      .getByTestId(this.areaFilterContainer)
+      .getByRole('option')
+      .all();
+
     return Promise.all(options.map((l) => l.textContent()));
   }
 

--- a/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/search_results_and_view_chart.spec.ts
@@ -168,79 +168,11 @@ test.describe('Search via indicator', () => {
         'NHS Primary Care Networks',
         'GPs',
       ];
-      await test
-        .expect(resultsPage.areaFilterOptions())
-        .toHaveCount(expectedOptions.length);
-
       const options = await resultsPage.areaFilterOptionsText();
+      test.expect(options).toHaveLength(expectedOptions.length);
       test
         .expect(sortAlphabetically(options))
         .toEqual(sortAlphabetically(expectedOptions));
-    });
-  });
-
-  test('check area type pills on results page when areas specified in url', async ({
-    resultsPage,
-  }) => {
-    await test.step('Search for a test indicator', async () => {
-      await resultsPage.navigateToResults('smoking', [
-        'E40000012',
-        'E40000011',
-        'E40000010',
-      ]);
-    });
-
-    await test.step('Check selected area pills matches those specified in url', async () => {
-      const expectdPillTexts = [
-        'North East and Yorkshire NHS Region',
-        'Midlands NHS Region',
-        'North West NHS Region',
-      ];
-      await test
-        .expect(resultsPage.areaFilterPills())
-        .toHaveCount(expectdPillTexts.length);
-
-      const filterPillNames = await resultsPage.areaFilterPillsText();
-      test
-        .expect(sortAlphabetically(filterPillNames))
-        .toEqual(sortAlphabetically(expectdPillTexts));
-
-      await test.expect(resultsPage.areaFilterCombobox()).toBeDisabled();
-    });
-
-    await test.step('Click remove one area pill and re-check area pills', async () => {
-      await resultsPage.closeAreaFilterPill(1);
-
-      const expectdPillTexts = [
-        'North East and Yorkshire NHS Region',
-        'North West NHS Region',
-      ];
-      await test
-        .expect(resultsPage.areaFilterPills())
-        .toHaveCount(expectdPillTexts.length);
-
-      const filterPillNames = await resultsPage.areaFilterPillsText();
-      test
-        .expect(sortAlphabetically(filterPillNames))
-        .toEqual(sortAlphabetically(expectdPillTexts));
-
-      await test.expect(resultsPage.areaFilterCombobox()).toBeDisabled();
-    });
-
-    await test.step('Check url has been updated after area pill removal', async () => {
-      await test.expect(resultsPage.page).toHaveURL(/&as=E40000012/);
-      await test.expect(resultsPage.page).not.toHaveURL(/&as=E40000011/);
-      await test.expect(resultsPage.page).toHaveURL(/&as=E40000010/);
-    });
-
-    await test.step('Remove all pills and check url and area type combobox', async () => {
-      await resultsPage.closeAreaFilterPill(0);
-      await test.expect(resultsPage.page).not.toHaveURL(/&as=E40000012/);
-
-      await resultsPage.closeAreaFilterPill(0);
-      await test.expect(resultsPage.page).not.toHaveURL(/&as=/);
-
-      await test.expect(resultsPage.areaFilterCombobox()).toBeEnabled();
     });
   });
 


### PR DESCRIPTION
This reverts #169.

# Description

Jira ticket: [DHSCFT-236](https://bjss-enterprise.atlassian.net/browse/DHSCFT-236)

The test changes in #169 are causing issues when run against the deployed environment. There are also some questions around whether we should be doing all this testing at E2E level (and with fixed data). Reverting for now, and these tests will be reinstated by @williamwillis11 in DHSCFT-291.

## Changes

- Revert 842b871

## Validation

Ensure E2E tests still pass in the CI workflow.