### PR TITLE
add empty dependency array to useeffect

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
@@ -95,7 +95,7 @@ export function ThematicMap({
     loadHighchartsModules(async () => {
       setOptions(mapOptions);
     });
-  });
+  }, []);
 
   if (!options) {
     return null;


### PR DESCRIPTION
No ticket attached. Solves performance issues & timeout with the highcharts map rendering.

Previously, the useEffect that was used to load the map didn't have a dependency array, causing it to reload the map in an infinite loop.

Validated locally. 

There are still some performance issues when mousing over regions with complex borders, but this should resolve the immediate issues.