### PR TITLE
DHSCFT-408 add url capture to logs for test fails

### DIFF
--- a/frontend/fingertips-frontend/playwright/tests/fully_integrated_e2e_tests/core_journeys.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/fully_integrated_e2e_tests/core_journeys.spec.ts
@@ -20,14 +20,14 @@ const coreTestJourneys: TestParams[] = [
     indicatorMode: IndicatorMode.ONE_INDICATOR,
     areaMode: AreaMode.ONE_AREA,
   },
-  // {
-  //   indicatorMode: IndicatorMode.TWO_INDICATORS,
-  //   areaMode: AreaMode.TWO_AREAS,
-  // },
-  // {
-  //   indicatorMode: IndicatorMode.MULTIPLE_INDICATORS,
-  //   areaMode: AreaMode.ENGLAND_AREA,
-  // },
+  {
+    indicatorMode: IndicatorMode.TWO_INDICATORS,
+    areaMode: AreaMode.TWO_AREAS,
+  },
+  {
+    indicatorMode: IndicatorMode.MULTIPLE_INDICATORS,
+    areaMode: AreaMode.ENGLAND_AREA,
+  },
 ];
 
 /**
@@ -88,4 +88,19 @@ test.describe(`Search via search term ${searchTerm}`, () => {
       });
     });
   });
+});
+
+// log out current url when a test fails
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    // Test failed - capture the URL
+    const url = page.url();
+    console.log(`Test failed! Current URL: ${url}`);
+
+    // You can also attach it to the test report
+    await testInfo.attach('failed-url', {
+      body: url,
+      contentType: 'text/plain',
+    });
+  }
 });

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -192,3 +192,18 @@ test.describe(`Navigation, accessibility and validation tests`, () => {
     });
   });
 });
+
+// log out current url when a test fails
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    // Test failed - capture the URL
+    const url = page.url();
+    console.log(`Test failed! Current URL: ${url}`);
+
+    // You can also attach it to the test report
+    await testInfo.attach('failed-url', {
+      body: url,
+      contentType: 'text/plain',
+    });
+  }
+});


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-408](https://bjss-enterprise.atlassian.net/browse/DHSCFT-408)

To aid investigations into playwright test failures, especially the e2e ones against azure 

## Changes

- added simple capture of the current url at the end of each test - if it fails

## Validation

tests pass locally
shown the failures working correctly in github - https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13566618907
