### PR TITLE
DHSCFT-291_fix_for_e2e_CD

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run Playwright tests in CD
         if: inputs.e2e-test-container-image != null
-        run: npx playwright test
+        run: npm run test-e2e-ci-azure
         env:
           FINGERTIPS_FRONTEND_URL: ${{ vars.FINGERTIPS_FRONTEND_URL }}
 

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -21,6 +21,7 @@
     "test-ui-local-mocks": "playwright test isolated_ui_tests",
     "test-e2e-local-docker": "MOCK_SERVER=false npm run start:all && playwright test fully_integrated_e2e_tests --ui || true && npm run stop:all",
     "test-e2e-ci-docker": "MOCK_SERVER=false npm run start:all && playwright test fully_integrated_e2e_tests",
+    "test-e2e-ci-azure": "MOCK_SERVER=false playwright test fully_integrated_e2e_tests",
     "prettier": "prettier --write .",
     "prettier-ci": "prettier . --check"
   },

--- a/frontend/fingertips-frontend/playwright.config.ts
+++ b/frontend/fingertips-frontend/playwright.config.ts
@@ -1,13 +1,12 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices, PlaywrightTestConfig } from '@playwright/test';
 
 const url = process.env.FINGERTIPS_FRONTEND_URL || 'http://localhost:3000';
 const jobUrl = process.env.JOB_URL;
 const runCommand =
-  process.env.MOCK_SERVER === 'false' || process.env.FINGERTIPS_FRONTEND_URL
-    ? 'npm run dev-no-mocks'
-    : 'npm run dev';
+  process.env.MOCK_SERVER === 'false' ? 'npm run dev-no-mocks' : 'npm run dev';
 
-export default defineConfig({
+// Create the base config
+const config: PlaywrightTestConfig = {
   testDir: './playwright/tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI, // fails the build on CI if you accidentally left test.only in the source code.
@@ -45,11 +44,15 @@ export default defineConfig({
       use: { ...devices['Desktop Safari'] },
     },
   ],
+};
 
-  // Run your local dev server before starting the tests
-  webServer: {
+// Add to base config to spin up a webServer if FINGERTIPS_FRONTEND_URL is not passed
+if (!process.env.FINGERTIPS_FRONTEND_URL) {
+  config.webServer = {
     command: runCommand,
     url: url,
     reuseExistingServer: true,
-  },
-});
+  };
+}
+
+export default defineConfig(config);


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-291](https://bjss-enterprise.atlassian.net/browse/DHSCFT-291)

Followup fix for an issue introduced in the first PR for 291 - https://github.com/dhsc-govuk/FingertipsNext/pull/181

## Changes

- changed config to only spin up a dev server if the FINGERTIPS_FRONTEND_URL isnt passed
- added new npm command to run the e2e tests against azure
- pointed the e2e yml template to use this new command

## Validation

ui tests pass locally
e2e tests pass against docker locally
both pass in CI 
