### PR TITLE
fix an issue with trailing spaces in indicator names

### DIFF
--- a/database/fingertips-db/PostDeployment/PopulateFingertips.sql
+++ b/database/fingertips-db/PostDeployment/PopulateFingertips.sql
@@ -141,7 +141,7 @@ SET @sqlInd = 'BULK INSERT #TempIndicatorData FROM ''' + @filePathInd + ''' WITH
 EXEC sp_executesql @sqlInd;
 
 INSERT INTO [dbo].[IndicatorDimension] (Name, IndicatorId, StartDate, EndDate)
-SELECT TRIM('"' FROM IndicatorName), IndicatorID, DATEADD(YEAR, -10, GETDATE()), DATEADD(YEAR, 10, GETDATE())
+SELECT REPLACE(REPLACE(IndicatorName, '"', ''), char(13),''), IndicatorID, DATEADD(YEAR, -10, GETDATE()), DATEADD(YEAR, 10, GETDATE())
 FROM #TempIndicatorData;
 
 DROP TABLE #TempIndicatorData;


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-439](https://bjss-enterprise.atlassian.net/browse/DHSCFT-439)

When inserting indicators ino the IndicatorDimension table trim trailing charcetrs and remove double quotes.

## Validation

Run the db-setup container and check the results in the database.
