### PR TITLE
DHSCFT-287 fix to not run the create screenshot job in CD

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,11 +72,12 @@ jobs:
         if: inputs.e2e-test-container-image == null
         run: npx playwright install --with-deps chromium webkit
 
-      - name: Create base snapshots if none in cache, or during manual snapshot update or when merging to main
+      - name: Create base snapshots if none in cache, or during manual snapshot update or when merging to main - for CI test execution
         if: >
-          steps.cache.outputs.cache-hit != 'true' ||
+          inputs.e2e-test-container-image == null &&
+          (steps.cache.outputs.cache-hit != 'true' ||
           inputs.update-screenshots == 'true' ||
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         run: npm run test-e2e-ci-update-snapshots
 
       - name: Run Playwright tests in CI

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,9 +75,14 @@ jobs:
       - name: Create base snapshots if none in cache, or during manual snapshot update or when merging to main - for CI test execution
         if: >
           inputs.e2e-test-container-image == null &&
-          (steps.cache.outputs.cache-hit != 'true' ||
-          inputs.update-screenshots == 'true' ||
-          github.ref == 'refs/heads/main')
+          (
+            steps.cache.outputs.cache-hit != 'true' ||
+            inputs.update-screenshots == 'true'
+          ) &&
+          (
+            github.head_ref == 'main' ||
+            github.ref_name == 'main'
+          )
         run: npm run test-e2e-ci-update-snapshots
 
       - name: Run Playwright tests in CI


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-287](https://bjss-enterprise.atlassian.net/browse/DHSCFT-287)
By design we arnt running the screenshot comparison checks in the e2e test run against azure (in CD) but i forgot in https://github.com/dhsc-govuk/FingertipsNext/pull/203 to add a rule to that step to stop that job from running. This PR adds that.

kicked off a pipeline here (as yml changes dont) - https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13696786879

