### PR TITLE
DHSCFT-142: line chart table benchmark colours rag

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/__snapshots__/LineChartTable.test.tsx.snap
@@ -2,7 +2,32 @@
 
 exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match snapshot 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c16 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1;
+  display: inline-block;
+  padding-top: 5px;
+  padding-right: 8px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  background-color: #1d70b8;
+  color: #ffffff;
+}
+
+.c2 {
   padding: 10px 20px 10px 0;
   border-bottom: 1px solid #bfc1c3;
   text-align: left;
@@ -84,12 +109,12 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
   padding-right: 0;
 }
 
-.c16 {
+.c18 {
   text-align: right;
   padding-right: 10px;
 }
 
-.c17 {
+.c19 {
   background-color: #B1B4B6;
   border-top: solid #F3F2F1 2px;
 }
@@ -119,6 +144,20 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
   align-items: center;
 }
 
+.c17 {
+  padding: 5px 8px 4px 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 0.3125em;
+  font-weight: 300;
+  text-transform: unset;
+  background-color: transparent;
+  color: #0B0C0C;
+  border: 1px solid #0B0C0C;
+}
+
 .c6 {
   width: 10%;
   padding: 1em 0;
@@ -141,6 +180,20 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
 
 .c5 {
   border: none;
+}
+
+@media print {
+  .c16 {
+    font-size: 14px;
+    line-height: 1;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    font-size: 16px;
+    line-height: 1;
+  }
 }
 
 @media print {
@@ -331,29 +384,35 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
           </td>
           <td
             class="c15 c13 c14"
-          />
+          >
+            <strong
+              class="c16 c17"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             267
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             703.420759
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             441.69151
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             578.32766
           </td>
           <td
-            class="c15 c13 c16 c17"
+            class="c15 c13 c18 c19"
             data-testid="grey-table-cell"
           >
             904.874
@@ -369,29 +428,35 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
           </td>
           <td
             class="c15 c13 c14"
-          />
+          >
+            <strong
+              class="c16 c17"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             222
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             890.305692
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             441.69151
           </td>
           <td
-            class="c12 c13 c16"
+            class="c12 c13 c18"
           >
             578.32766
           </td>
           <td
-            class="c15 c13 c16 c17"
+            class="c15 c13 c18 c19"
             data-testid="grey-table-cell"
           >
             965.9843
@@ -405,7 +470,32 @@ exports[`Line chart table suite 1 Indicator, 1 Area snapshot test - should match
 
 exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should match snapshot 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c18 {
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1;
+  display: inline-block;
+  padding-top: 5px;
+  padding-right: 8px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  background-color: #1d70b8;
+  color: #ffffff;
+}
+
+.c2 {
   padding: 10px 20px 10px 0;
   border-bottom: 1px solid #bfc1c3;
   text-align: left;
@@ -487,12 +577,12 @@ exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should matc
   padding-right: 0;
 }
 
-.c18 {
+.c20 {
   text-align: right;
   padding-right: 10px;
 }
 
-.c19 {
+.c21 {
   background-color: #B1B4B6;
   border-top: solid #F3F2F1 2px;
 }
@@ -520,6 +610,20 @@ exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should matc
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c19 {
+  padding: 5px 8px 4px 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 0.3125em;
+  font-weight: 300;
+  text-transform: unset;
+  background-color: transparent;
+  color: #0B0C0C;
+  border: 1px solid #0B0C0C;
 }
 
 .c6 {
@@ -554,6 +658,20 @@ exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should matc
 
 .c5 {
   border: none;
+}
+
+@media print {
+  .c18 {
+    font-size: 14px;
+    line-height: 1;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c18 {
+    font-size: 16px;
+    line-height: 1;
+  }
 }
 
 @media print {
@@ -804,52 +922,64 @@ exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should matc
           </td>
           <td
             class="c16 c14 c15 c17"
-          />
+          >
+            <strong
+              class="c18 c19"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             267
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             703.420759
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             441.69151
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             578.32766
           </td>
           <td
             class="c16 c14 c15 c17"
-          />
+          >
+            <strong
+              class="c18 c19"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             222
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             135.149304
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             441.69151
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             578.32766
           </td>
           <td
-            class="c16 c14 c18 c19"
+            class="c16 c14 c20 c21"
             data-testid="grey-table-cell"
           >
             904.874
@@ -865,52 +995,64 @@ exports[`Line chart table suite 1 Indicator, 2 Areas snapshot test - should matc
           </td>
           <td
             class="c16 c14 c15 c17"
-          />
+          >
+            <strong
+              class="c18 c19"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             222
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             890.305692
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             441.69151
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             578.32766
           </td>
           <td
             class="c16 c14 c15 c17"
-          />
+          >
+            <strong
+              class="c18 c19"
+            >
+              Not compared
+            </strong>
+          </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             222
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             135.149304
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             441.69151
           </td>
           <td
-            class="c13 c14 c18"
+            class="c13 c14 c20"
           >
             578.32766
           </td>
           <td
-            class="c16 c14 c18 c19"
+            class="c16 c14 c20 c21"
             data-testid="grey-table-cell"
           >
             965.9843

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { Table } from 'govuk-react';
-import { HealthDataForArea } from '@/generated-sources/ft-api-client';
+import {
+  HealthDataForArea,
+  HealthDataPointBenchmarkComparison,
+} from '@/generated-sources/ft-api-client';
 import styled from 'styled-components';
 import React, { ReactNode } from 'react';
 import { GovukColours } from '@/lib/styleHelpers/colours';
@@ -14,6 +17,8 @@ import {
   StyledGreyHeader,
   StyledGreyTableCellValue,
 } from '@/lib/tableHelpers';
+import { BenchmarkLabel } from '@/components/organisms/BenchmarkLabel';
+import { BenchmarkLabelGroupType } from '@/components/organisms/BenchmarkLabel/BenchmarkLabelTypes';
 
 export enum LineChartTableHeadingEnum {
   AreaPeriod = 'Period',
@@ -38,6 +43,7 @@ export interface LineChartTableRowData {
   value?: number;
   lower?: number;
   upper?: number;
+  benchmarkComparison?: HealthDataPointBenchmarkComparison;
 }
 
 const StyledAreaNameHeader = styled(StyledAlignLeftHeader)({
@@ -143,12 +149,24 @@ const getCellHeader = (
   );
 };
 
-const getBenchmarkCell = (areaCount: number) =>
-  areaCount < 2 ? (
-    <StyledAlignLeftTableCell></StyledAlignLeftTableCell>
-  ) : (
-    <StyledBenchmarkCellMultipleAreas></StyledBenchmarkCellMultipleAreas>
+const getBenchmarkCell = (
+  areaCount: number,
+  benchmarkComparison?: HealthDataPointBenchmarkComparison
+) => {
+  const benchmarkLabel = (
+    <BenchmarkLabel
+      type={benchmarkComparison?.outcome}
+      group={BenchmarkLabelGroupType.RAG}
+    />
   );
+  return areaCount < 2 ? (
+    <StyledAlignLeftTableCell>{benchmarkLabel}</StyledAlignLeftTableCell>
+  ) : (
+    <StyledBenchmarkCellMultipleAreas>
+      {benchmarkLabel}
+    </StyledBenchmarkCellMultipleAreas>
+  );
+};
 
 export const mapToLineChartTableData = (
   areaData: HealthDataForArea
@@ -159,6 +177,7 @@ export const mapToLineChartTableData = (
     value: healthPoint.value,
     lower: healthPoint.lowerCi,
     upper: healthPoint.upperCi,
+    benchmarkComparison: healthPoint.benchmarkComparison,
   }));
 
 const StyledTitleRow = styled(StyledAlignLeftHeader)({
@@ -287,7 +306,10 @@ export function LineChartTable({
               <React.Fragment
                 key={healthIndicatorData[areaIndex].areaCode + index}
               >
-                {getBenchmarkCell(healthIndicatorData.length)}
+                {getBenchmarkCell(
+                  healthIndicatorData.length,
+                  sortedAreaData[index].benchmarkComparison
+                )}
                 <StyledAlignRightTableCell numeric>
                   {sortedAreaData[index].count}
                 </StyledAlignRightTableCell>

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
@@ -2,7 +2,10 @@
  * @jest-environment node
  */
 
-import { IndicatorsApi } from '@/generated-sources/ft-api-client';
+import {
+  GetHealthDataForAnIndicatorComparisonMethodEnum,
+  IndicatorsApi,
+} from '@/generated-sources/ft-api-client';
 import { mockDeep } from 'jest-mock-extended';
 import OneIndicatorOneAreaView from '.';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
@@ -61,6 +64,7 @@ describe('OneIndicatorOneAreaView', () => {
       ).toHaveBeenNthCalledWith(1, {
         areaCodes: expectedAreaCodes,
         indicatorId: 1,
+        comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
       });
     }
   );

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
@@ -1,5 +1,8 @@
 import { OneIndicatorOneAreaViewPlots } from '@/components/viewPlots/OneIndicatorOneAreaViewPlots';
-import { HealthDataForArea } from '@/generated-sources/ft-api-client';
+import {
+  GetHealthDataForAnIndicatorComparisonMethodEnum,
+  HealthDataForArea,
+} from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
@@ -38,6 +41,7 @@ export default async function OneIndicatorOneAreaView({
     healthIndicatorData = await indicatorApi.getHealthDataForAnIndicator({
       indicatorId: Number(indicatorSelected),
       areaCodes: areaCodesToRequest,
+      comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
     });
   } catch (error) {
     console.error('error getting health indicator data for area', error);


### PR DESCRIPTION
DHSCFT-142: Benchmark labels in the Line Chart Table

# Description

Jira ticket: [DHSCFT-142](https://bjss-enterprise.atlassian.net/browse/DHSCFT-142)

Benchmark labels

## Changes

- Added benchmark labels to the line chart table

## Validation

### BOB
<img width="981" alt="bob" src="https://github.com/user-attachments/assets/0a61b548-023d-4a63-aa4f-edecd56162f4" />

### Rag 99 Higher is Better
<img width="974" alt="rag99HigherIsBetter" src="https://github.com/user-attachments/assets/5605d405-3924-4cba-8820-b39b2d51f043" />

### Rag 99 Lower is Better
<img width="979" alt="rag99LowerIsBetter" src="https://github.com/user-attachments/assets/7a675e54-a384-4c08-b41e-293a05fe94d4" />

### Rag Higher is Better
<img width="976" alt="ragHigherIsBetter" src="https://github.com/user-attachments/assets/745565f5-84b7-4654-95a4-9f7b0ddf8ec3" />

### Rag Lower is Better
<img width="971" alt="ragLowerIsBetter" src="https://github.com/user-attachments/assets/952c3620-af4c-4029-9037-11fc4221e29c" />

Polarities and benchmark group types still need to come from the api but not yet implemented, so the above screenshots are manipulated to demo the variants which will be available.
