### PR TITLE
add trend not available tag

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/TrendTag/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/TrendTag/index.tsx
@@ -29,7 +29,7 @@ const StyledDefaultTag = styled(Tag)<{
   trendCondition?: TrendCondition;
 }>(({ trend, trendCondition }) => {
   const trendConditionColours =
-    trend !== Trend.NO_SIGNIFICANT_CHANGE
+    trend !== Trend.NO_SIGNIFICANT_CHANGE && trend !== Trend.NOT_AVAILABLE
       ? getTrendConditionColours(trendCondition)
       : null;
 
@@ -58,6 +58,7 @@ const arrowDirectionMap: Partial<Record<Trend, Direction>> = {
   [Trend.INCREASING]: Direction.UP,
   [Trend.DECREASING]: Direction.DOWN,
   [Trend.NO_SIGNIFICANT_CHANGE]: Direction.RIGHT,
+  [Trend.NOT_AVAILABLE]: undefined,
 };
 
 export const TrendTag = ({
@@ -67,7 +68,7 @@ export const TrendTag = ({
 }: Readonly<TagProps>) => {
   const arrowDirection = useArrow ? arrowDirectionMap[trend] : null;
   const trendMessage =
-    trend === Trend.NO_SIGNIFICANT_CHANGE
+    trend === Trend.NO_SIGNIFICANT_CHANGE || trend === Trend.NOT_AVAILABLE
       ? trend
       : trend + ' ' + displayTrendCondition(trendCondition);
 

--- a/frontend/fingertips-frontend/components/molecules/TrendTag/trendTag.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/TrendTag/trendTag.test.tsx
@@ -68,6 +68,16 @@ describe('Trend Tag Suite', () => {
       expect(screen.getByTestId('arrow-down')).toBeInTheDocument();
       expect(screen.getByRole('paragraph')).toHaveTextContent('Decreasing');
     });
+
+    it('should render trend not available', () => {
+      render(<TrendTag trend={Trend.NOT_AVAILABLE} />);
+      expect(
+        screen.queryByTestId('arrow', { exact: false })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('paragraph')).toHaveTextContent(
+        'No trend data available'
+      );
+    });
   });
 
   it('snapshot test', () => {

--- a/frontend/fingertips-frontend/components/molecules/TrendTag/trendTagConfig.ts
+++ b/frontend/fingertips-frontend/components/molecules/TrendTag/trendTagConfig.ts
@@ -16,6 +16,11 @@ export const getTrendColour = (trend: Trend) => {
       return {
         backgroundColor: TagColours.LightBlue,
       };
+    case Trend.NOT_AVAILABLE:
+      return {
+        backgroundColor: TagColours.GreyBackground,
+        color: TagColours.GreyText,
+      };
     default:
       return null;
   }

--- a/frontend/fingertips-frontend/lib/common-types/index.ts
+++ b/frontend/fingertips-frontend/lib/common-types/index.ts
@@ -2,6 +2,7 @@ export enum Trend {
   INCREASING = 'Increasing',
   DECREASING = 'Decreasing',
   NO_SIGNIFICANT_CHANGE = 'No significant change',
+  NOT_AVAILABLE = 'No trend data available',
 }
 
 export enum TrendCondition {


### PR DESCRIPTION
https://bjss-enterprise.atlassian.net/browse/DHSCFT-457

add "data not available" to the existing set of trend tags

![image](https://github.com/user-attachments/assets/62dc2f56-73a3-44f7-85d9-5a7e39f3946e)

unit tested like the rest of them.