### PR TITLE
DHSCFT-446: Fix db deployment

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -331,7 +331,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'main' &&
+      github.ref_name == 'feature/DHSCFT-446_fix-db-deployment' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true'

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -331,7 +331,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'feature/DHSCFT-446_fix-db-deployment' &&
+      github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true'

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -366,7 +366,7 @@ jobs:
           connection-string: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
           path: 'fingertips-db.dacpac'
           action: 'publish'
-          arguments: '/p:DropObjectsNotInSource=true /p:BlockOnPossibleDataLoss=false /v:UseAzureBlob=1 /v:BlobStorageLocation=${{ vars.BLOB_STORAGE_LOCATION }} /v:MasterKeyPassword=${{ secrets.SQL_MASTER_KEY_PASSWORD }}'
+          arguments: '/p:DropObjectsNotInSource=true /p:BlockOnPossibleDataLoss=false /p:GenerateSmartDefaults=true /v:UseAzureBlob=1 /v:BlobStorageLocation=${{ vars.BLOB_STORAGE_LOCATION }} /v:MasterKeyPassword=${{ secrets.SQL_MASTER_KEY_PASSWORD }}'
 
   search-setup-dev:
     needs: [check-changes, deploy-db-dev]


### PR DESCRIPTION
# Description

The table definitions are loaded in our SQL project before the post-deployment script runs. We had an issue where we had updated a table to specify that a column should be NOT NULL, but there was already existing data which was NULL.

`p:GenerateSmartDefaults=true`  Adding this resolves the error, as it will set a value instead of falling over. I think this is ok, as the PostDeployment script deletes all data and then reloads fresh each time. However, I'm equally open to us deleting/adjusting data manually before this is job is run on this particular occasion.

On the second commit, I allowed this to be run from this branch. Here is the successful pipeline: https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13808202768/job/38623655433