### PR TITLE
DHSCFT-374: Removed proportions related code

### DIFF
--- a/trend-analysis/TrendAnalysisApp.UnitTests/Calculator/IndicatorTestData.cs
+++ b/trend-analysis/TrendAnalysisApp.UnitTests/Calculator/IndicatorTestData.cs
@@ -10,7 +10,6 @@ public class IndicatorTestData
         IndicatorId = 241,
         IndicatorKey = 123,
         Polarity = "Not applicable",
-        UseProportionsForTrend = true,
         ValueType = "Proportion"
     };
 
@@ -69,7 +68,6 @@ public class IndicatorTestData
         IndicatorId = 93468,
         IndicatorKey = 1234,
         Polarity = "Not applicable",
-        UseProportionsForTrend = false,
         ValueType = "Proportion"
     };
 
@@ -118,7 +116,6 @@ public class IndicatorTestData
         IndicatorId = 30309,
         IndicatorKey = 12345,
         Polarity = "High is good",
-        UseProportionsForTrend = false,
         ValueType = "Proportion"
     };
 
@@ -177,7 +174,6 @@ public class IndicatorTestData
         IndicatorId = 41203,
         IndicatorKey = 12346,
         Polarity = "Low is good",
-        UseProportionsForTrend = false,
         ValueType = "Crude rate"
     };
 
@@ -236,7 +232,6 @@ public class IndicatorTestData
         IndicatorId = 41101,
         IndicatorKey = 12342,
         Polarity = "Low is good",
-        UseProportionsForTrend = false,
         ValueType = "Indirectly standardised proportion"
     };
 
@@ -295,7 +290,6 @@ public class IndicatorTestData
         IndicatorId = 40501,
         IndicatorKey = 357,
         Polarity = "Low is good",
-        UseProportionsForTrend = false,
         ValueType = "Directly standardised rate"
     };
 

--- a/trend-analysis/TrendAnalysisApp/Calculator/Legacy/Constants.cs
+++ b/trend-analysis/TrendAnalysisApp/Calculator/Legacy/Constants.cs
@@ -13,7 +13,6 @@ public class ComparatorMethodIds
     public const int NoComparison = -1;
     public const int SingleOverlappingCIsForOneCiLevel = 1;
     public const int SingleOverlappingCIsForSecondCiLevel = 18;
-    public const int SpcForProportions = 5;
     public const int SpcForDsr = 6;
     public const int DoubleOverlappingCIs = 12;
     public const int SuicidePreventionPlan = 14;

--- a/trend-analysis/TrendAnalysisApp/Calculator/Legacy/Models/TrendMarkerCalculatedValueForProportion.cs
+++ b/trend-analysis/TrendAnalysisApp/Calculator/Legacy/Models/TrendMarkerCalculatedValueForProportion.cs
@@ -1,8 +1,0 @@
-﻿namespace TrendAnalysisApp.Calculator.Legacy.Models
-{
-    public class TrendMarkerCalculatedValueForProportion
-    {
-        public double Value { get; set; }
-        public double MultipliedValue { get; set; }
-    }
-}

--- a/trend-analysis/TrendAnalysisApp/Calculator/TrendCalculator.cs
+++ b/trend-analysis/TrendAnalysisApp/Calculator/TrendCalculator.cs
@@ -20,7 +20,7 @@ public class TrendCalculator(TrendMarkerCalculator legacyCalculator, LegacyMappe
             return Trend.CannotBeCalculated;
         }
 
-        var legacyTrendRequest = legacyMapper.ToLegacy(mappedValueType, indicator.UseProportionsForTrend, healthMeasures);
+        var legacyTrendRequest = legacyMapper.ToLegacy(mappedValueType, healthMeasures);
         var legacyTrend = legacyCalculator.GetResults(legacyTrendRequest);
 
         return AdjustForPolarity(legacyMapper.TrendMarkerMap[legacyTrend.Marker], indicator.Polarity);

--- a/trend-analysis/TrendAnalysisApp/Mapper/LegacyMapper.cs
+++ b/trend-analysis/TrendAnalysisApp/Mapper/LegacyMapper.cs
@@ -36,16 +36,12 @@ public class LegacyMapper {
     /// <summary>
     /// Maps indicator metadata and a list of health measures to a valid legacy calculation request.
     /// </summary>
-    public TrendRequest ToLegacy(int valueTypeId, bool useProportions, IEnumerable<HealthMeasureModel> healthMeasures) {
+    public TrendRequest ToLegacy(int valueTypeId, IEnumerable<HealthMeasureModel> healthMeasures) {
         var legacyTrendRequest = new TrendRequest
         {
             YearRange = DefaultYearRange,
             ValueTypeId = valueTypeId
         };
-
-        if (useProportions) {
-            legacyTrendRequest.ComparatorMethodId = ComparatorMethodIds.SpcForProportions;
-        }
 
         legacyTrendRequest.Data = HealthMeasuresToLegacyDatasetList(healthMeasures);
         return legacyTrendRequest;

--- a/trend-analysis/TrendAnalysisApp/Repository/Models/IndicatorDimensionModel.cs
+++ b/trend-analysis/TrendAnalysisApp/Repository/Models/IndicatorDimensionModel.cs
@@ -10,6 +10,5 @@ public class IndicatorDimensionModel
     public string? Name { get; set; }
     public int IndicatorId { get; set; }
     public string? Polarity { get; set; }
-    public bool UseProportionsForTrend { get; set; }
     public string? ValueType { get; set; }
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-374](https://bjss-enterprise.atlassian.net/browse/DHSCFT-374)

A further addition to the ticket. Stakeholders from the DHSC side have confirmed that the `useProportionsForTrend` flag is not used, so I have removed references to it and any of the code that was being used for proportion flag specific calculation.

## Validation

I retested with 5 of the indicators that I had previously used. (Reference to this is on the ticket). I also ensured that some of these were ones which previously had the UseProportionsForTrend flag set to true. Clearly (at least for the data points tested) it did not make a difference. Can confirm that the results were unchanged.

Also the unit tests passed, which also assert using real data against the trend that is calculated.
