### PR TITLE
Container App Minimum Replicas

### DIFF
--- a/terraform/locals.container-app.tf
+++ b/terraform/locals.container-app.tf
@@ -26,16 +26,6 @@ locals {
       max_replicas    = var.max_replicas
       revision_suffix = var.revision_suffix
       volume          = []
-      custom_scale_rules = [
-        {
-          name             = "cpu-scale-rule"
-          custom_rule_type = "cpu"
-          metadata = {
-            type  = "utilization"
-            value = 70
-          }
-        }
-      ]
     }
 
     ingress = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,7 +75,7 @@ variable "startup_probe" {
 variable "min_replicas" {
   description = "The minimum number of replicas for the container app."
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "max_replicas" {


### PR DESCRIPTION
# Description

Change minimum replicas on container apps from 0 to 1 to prevent scaling to 0.

## Changes

- Change default minimum replicas
- Remove CPU scaling rule (by default it will scale on incoming requests)
