### PR TITLE
DHSCFT-358 - Clear indicator(s) selected on search change

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
@@ -1,6 +1,9 @@
 import { expect } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
-import { IndicatorSearchFormState } from './indicatorSearchActions';
+import {
+  IndicatorSearchFormState,
+  searchIndicator,
+} from './indicatorSearchActions';
 import { IndicatorSearchForm } from '.';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
@@ -1,9 +1,6 @@
 import { expect } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
-import {
-  IndicatorSearchFormState,
-  searchIndicator,
-} from './indicatorSearchActions';
+import { IndicatorSearchFormState } from './indicatorSearchActions';
 import { IndicatorSearchForm } from '.';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.test.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.test.ts
@@ -6,6 +6,7 @@ import {
   IndicatorSearchFormState,
   searchIndicator,
 } from './indicatorSearchActions';
+import { time } from 'console';
 
 jest.mock('next/navigation');
 const redirectMock = jest.mocked(redirect);
@@ -38,6 +39,10 @@ const areasSelectedState = JSON.stringify({
   [SearchParams.AreasSelected]: ['foo', 'bar'],
 });
 
+const indicatorsSelectedState = JSON.stringify({
+  [SearchParams.IndicatorsSelected]: ['1', '2'],
+});
+
 const initialStateWithoutAreas: IndicatorSearchFormState = {
   indicator: 'some indicator',
   searchState: noAreasSelectedState,
@@ -46,6 +51,11 @@ const initialStateWithoutAreas: IndicatorSearchFormState = {
 const initialStateWithAreas: IndicatorSearchFormState = {
   indicator: 'some indicator',
   searchState: areasSelectedState,
+};
+
+const initialStateWithIndicatorsSelected: IndicatorSearchFormState = {
+  indicator: 'some indicator',
+  searchState: indicatorsSelectedState,
 };
 
 describe('Search actions', () => {
@@ -102,6 +112,20 @@ describe('Search actions', () => {
     expect(state.indicator).toBe('');
     expect(state.message).toBe(
       'Please enter an indicator ID or select at least one area'
+    );
+  });
+
+  it('should redirect to search results and remove any indicators selected from URL', async () => {
+    const formData = getMockFormData({
+      indicator: 'boom',
+      searchState: indicatorsSelectedState,
+    });
+
+    await searchIndicator(initialStateWithIndicatorsSelected, formData);
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `/results?${SearchParams.SearchedIndicator}=boom`,
+      RedirectType.push
     );
   });
 });

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.test.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.test.ts
@@ -6,7 +6,6 @@ import {
   IndicatorSearchFormState,
   searchIndicator,
 } from './indicatorSearchActions';
-import { time } from 'console';
 
 jest.mock('next/navigation');
 const redirectMock = jest.mocked(redirect);

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
@@ -67,5 +67,7 @@ export async function searchIndicator(
     indicator
   );
 
+  searchStateManager.removeAllParamFromState(SearchParams.IndicatorsSelected);
+
   redirect(searchStateManager.generatePath('/results'), RedirectType.push);
 }

--- a/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/SelectAreasFilterPanel.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/SelectAreasFilterPanel.test.tsx
@@ -548,4 +548,66 @@ describe('SelectAreasFilterPanel', () => {
       });
     });
   });
+
+  it('should remove indicator from url when an area is selected', async () => {
+    const expectedPath = [
+      `${mockPath}`,
+      `?${SearchParams.AreasSelected}=${eastEnglandNHSRegion.code}`,
+      `&${SearchParams.AreaTypeSelected}=nhs-regions`,
+    ].join('');
+    const availableAreas = mockAvailableAreas['nhs-regions'];
+
+    render(
+      <SelectAreasFilterPanel
+        areaFilterData={{
+          availableAreaTypes: allAreaTypes,
+          availableAreas: availableAreas,
+        }}
+        searchState={{
+          [SearchParams.AreaTypeSelected]: 'nhs-regions',
+          [SearchParams.IndicatorsSelected]: ['1', '2'],
+        }}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('checkbox', { name: eastEnglandNHSRegion.name })
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(expectedPath, {
+      scroll: false,
+    });
+  });
+
+  it('should remove indicator url when an area is de-selected', async () => {
+    const expectedPath = [
+      `${mockPath}`,
+      `?${SearchParams.AreaTypeSelected}=nhs-regions`,
+    ].join('');
+    const availableAreas = mockAvailableAreas['nhs-regions'];
+
+    render(
+      <SelectAreasFilterPanel
+        areaFilterData={{
+          availableAreaTypes: allAreaTypes,
+          availableAreas: availableAreas,
+        }}
+        searchState={{
+          [SearchParams.AreaTypeSelected]: 'nhs-regions',
+          [SearchParams.AreasSelected]: ['E40000007'],
+          [SearchParams.IndicatorsSelected]: ['1', '2'],
+        }}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('checkbox', { name: eastEnglandNHSRegion.name })
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(expectedPath, {
+      scroll: false,
+    });
+  });
 });

--- a/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/index.tsx
@@ -92,6 +92,8 @@ export function SelectAreasFilterPanel({
       );
     }
 
+    searchStateManager.removeAllParamFromState(SearchParams.IndicatorsSelected);
+
     replace(searchStateManager.generatePath(pathname), { scroll: false });
   };
 

--- a/frontend/fingertips-frontend/components/molecules/SelectedAreasPanel/SelectedAreasPanel.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectedAreasPanel/SelectedAreasPanel.test.tsx
@@ -75,4 +75,33 @@ describe('SelectedAreasPanel', () => {
       scroll: false,
     });
   });
+
+  it('should remove the indicators selected from the state/url when the remove icon is clicked for the area selected', async () => {
+    const expectedPath = [
+      `${mockPath}`,
+      `?${SearchParams.AreasSelected}=E40000012`,
+      `&${SearchParams.AreaTypeSelected}=NHS+Regions`,
+    ].join('');
+
+    const user = userEvent.setup();
+    render(
+      <SelectedAreasPanel
+        selectedAreasData={mockSelectedAreasData}
+        searchState={{
+          [SearchParams.AreasSelected]: ['E40000012', 'E40000007'],
+          [SearchParams.AreaTypeSelected]: 'NHS Regions',
+          [SearchParams.IndicatorsSelected]: ['1', '2'],
+        }}
+      />
+    );
+
+    const firstSelectedAreaPill = screen.getAllByTestId('pill-container')[0];
+    await user.click(
+      within(firstSelectedAreaPill).getByTestId('remove-icon-div')
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(expectedPath, {
+      scroll: false,
+    });
+  });
 });

--- a/frontend/fingertips-frontend/components/molecules/SelectedAreasPanel/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectedAreasPanel/index.tsx
@@ -44,6 +44,9 @@ export function SelectedAreasPanel({
       SearchParams.AreasSelected,
       areaCode
     );
+
+    searchStateManager.removeAllParamFromState(SearchParams.IndicatorsSelected);
+
     replace(searchStateManager.generatePath(pathname), { scroll: false });
   };
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-358](https://bjss-enterprise.atlassian.net/browse/DHSCFT-358)

Added removal of indicators from URL when the area selected gets updated either by:
- selecting a new area
- deselecting an existing selected area via removal of pill
- deselecting an existing selected area by unchecking checkbox on filter panel
- clearing the search 

## Changes

- Added removal of indicators from URL on indicatorSearchActions, SelectAreasFilterPanel and SelectedAreasPanel
- Added unit tests to cover the change

## Validation

Added new unit tests to verify the correct functionality
