### PR TITLE
bugfix/DHSCFT-TECH handle direct indicator click when no area selected

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
@@ -4,6 +4,7 @@ import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { formatDate } from '@/lib/dateHelpers/dateHelpers';
+import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 const mockPath = 'some-mock-path';
 const mockReplace = jest.fn();
@@ -159,8 +160,8 @@ describe('IndicatorSelectionForm', () => {
 
   it('should have appropriate direct link for each indicator regardless of checkbox state', () => {
     const expectedPaths = [
-      `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[0].indicatorID.toString()}`,
-      `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[1].indicatorID.toString()}`,
+      `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[0].indicatorID.toString()}&${SearchParams.AreasSelected}=${areaCodeForEngland}`,
+      `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[1].indicatorID.toString()}&${SearchParams.AreasSelected}=${areaCodeForEngland}`,
     ];
 
     render(

--- a/frontend/fingertips-frontend/components/molecules/Result/__snapshots__/searchResult.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/Result/__snapshots__/searchResult.test.tsx.snap
@@ -419,7 +419,7 @@ exports[`Indicator Checkbox snapshot test 1`] = `
             >
               <a
                 class="c8"
-                href="/chart?si=test&is=1"
+                href="/chart?si=test&is=1&as=Area1"
               >
                 NHS
               </a>

--- a/frontend/fingertips-frontend/components/molecules/Result/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Result/index.tsx
@@ -19,6 +19,7 @@ import {
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { TagColours } from '@/lib/styleHelpers/colours';
 import { formatDate, isWithinOneMonth } from '@/lib/dateHelpers/dateHelpers';
+import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 type SearchResultProps = {
   result: IndicatorDocument;
@@ -86,6 +87,16 @@ export function SearchResult({
       SearchParams.IndicatorsSelected,
       indicatorId
     );
+
+    const areasSelected =
+      stateManager.getSearchState()[SearchParams.AreasSelected];
+
+    if (!areasSelected || areasSelected.length < 1) {
+      stateManager.addParamValueToState(
+        SearchParams.AreasSelected,
+        areaCodeForEngland
+      );
+    }
 
     return stateManager.generatePath(chartPath);
   };

--- a/frontend/fingertips-frontend/components/molecules/Result/searchResult.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Result/searchResult.test.tsx
@@ -4,6 +4,8 @@ import { SearchResult } from '.';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
+import { string } from 'zod';
+import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 let user: UserEvent;
 
@@ -56,6 +58,7 @@ const mockHandleClick = jest.fn();
 
 const initialSearchState: SearchStateParams = {
   [SearchParams.SearchedIndicator]: 'test',
+  [SearchParams.AreasSelected]: ['Area1'],
 };
 
 beforeEach(() => {
@@ -279,11 +282,29 @@ describe('Indicator Checkbox', () => {
   });
 
   it('should have a direct link to the indicator chart', () => {
-    const expectedPath = `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[0].indicatorID.toString()}`;
+    const expectedPath = `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[0].indicatorID.toString()}&${SearchParams.AreasSelected}=${initialSearchState[SearchParams.AreasSelected]}`;
     render(
       <SearchResult
         result={MOCK_DATA[0]}
         searchState={initialSearchState}
+        handleClick={mockHandleClick}
+      />
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', expectedPath);
+  });
+
+  it('should populate the area selected parameter with the code for england if no area is selected', () => {
+    const expectedPath = `/chart?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=${MOCK_DATA[0].indicatorID.toString()}&${SearchParams.AreasSelected}=${areaCodeForEngland}`;
+    const searchState: SearchStateParams = {
+      ...initialSearchState,
+    };
+    searchState[SearchParams.AreasSelected] = undefined;
+
+    render(
+      <SearchResult
+        result={MOCK_DATA[0]}
+        searchState={searchState}
         handleClick={mockHandleClick}
       />
     );

--- a/frontend/fingertips-frontend/components/molecules/Result/searchResult.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Result/searchResult.test.tsx
@@ -4,7 +4,6 @@ import { SearchResult } from '.';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
-import { string } from 'zod';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 let user: UserEvent;

--- a/frontend/fingertips-frontend/components/views/ViewsContext.test.tsx
+++ b/frontend/fingertips-frontend/components/views/ViewsContext.test.tsx
@@ -68,4 +68,13 @@ describe('ViewsContext', () => {
       expect(correctView).toHaveBeenCalled();
     }
   );
+
+  it('should error if an invalid state is provided', () => {
+    const searchState: SearchStateParams = {
+      [SearchParams.IndicatorsSelected]: ['1'],
+      [SearchParams.AreasSelected]: undefined,
+    };
+
+    expect(() => render(<ViewsContext searchState={searchState} />)).toThrow();
+  });
 });

--- a/frontend/fingertips-frontend/components/views/ViewsContext.tsx
+++ b/frontend/fingertips-frontend/components/views/ViewsContext.tsx
@@ -35,7 +35,11 @@ function viewSelector(
     return <TwoOrMoreIndicatorsEnglandView searchState={searchState} />;
   }
 
-  return <TwoOrMoreIndicatorsAreasView searchState={searchState} />;
+  if (indicators.length >= 2 && areaCodes.length >= 1) {
+    return <TwoOrMoreIndicatorsAreasView searchState={searchState} />;
+  }
+
+  throw new Error('Parameters do not match any known view');
 }
 
 export function ViewsContext({ searchState }: Readonly<ViewProps>) {


### PR DESCRIPTION
no ticket

tl;dr we didn't have any e2e testing for the direct click indicator link. When this path was implemented, we didn't require an area selected.

Link broke, now it's fixed.

We also throw an error if the url search parameters don't align to any of the known chart views, instead of defaulting to the "2 indicators, any areas" view.