### PR TITLE
DHSCFT-367: Pipeline step for trends

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -324,7 +324,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'feature/DHSCFT-367_pipeline-step-for-trends' &&
+      github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -324,7 +324,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'main' &&
+      github.ref_name == 'feature/DHSCFT-367_pipeline-step-for-trends' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -159,6 +159,7 @@ jobs:
     needs: [check-changes, determine-version]
     if: >
       github.event_name == 'workflow_dispatch' ||
+      needs.check-changes.outputs.db_changed == 'true' ||
       needs.check-changes.outputs.trend_analysis_changed == 'true'
     name: Test Trend Analysis App
     runs-on: ubuntu-latest
@@ -326,7 +327,8 @@ jobs:
       github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
-        needs.check-changes.outputs.db_changed == 'true'
+        needs.check-changes.outputs.db_changed == 'true' ||
+        needs.check-changes.outputs.trend_analysis_changed == 'true'
       )
     steps:
       - name: Checkout code
@@ -359,6 +361,32 @@ jobs:
           path: 'fingertips-db.dacpac'
           action: 'publish'
           arguments: '/p:DropObjectsNotInSource=true /p:BlockOnPossibleDataLoss=false /p:GenerateSmartDefaults=true /v:UseAzureBlob=1 /v:BlobStorageLocation=${{ vars.BLOB_STORAGE_LOCATION }} /v:MasterKeyPassword=${{ secrets.SQL_MASTER_KEY_PASSWORD }}'
+
+  run-trend-analysis-dev:
+    # Only run job if the DB has had a clean deploy
+    needs: deploy-db-dev
+    environment: development
+    name: Run Trend Analysis App
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['9.0.x']
+    defaults:
+      run:
+        working-directory: ./trend-analysis/TrendAnalysisApp
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup dotnet ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Process trends
+        env:
+          SQLCONNSTR_FINGERTIPS_DB: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+        run: dotnet run
 
   search-setup-dev:
     needs: [check-changes, deploy-db-dev]

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,6 +53,20 @@ services:
       SA_PASSWORD: ${DB_PASSWORD}
       TRUST_CERT: "True"
 
+  db-apply-trends:
+    profiles:
+      - all
+      - db
+      - api
+
+    depends_on:
+      db-setup:
+        condition: service_completed_successfully
+
+    build: trend-analysis/TrendAnalysisApp
+    environment:
+      SQLCONNSTR_FINGERTIPS_DB: Server=db;Database=${DB_NAME};User Id=${DB_USER};Password=${DB_PASSWORD};Encrypt=False;TrustServerCertificate=False;
+
   db:
     profiles:
       - all

--- a/trend-analysis/TrendAnalysisApp/Dockerfile
+++ b/trend-analysis/TrendAnalysisApp/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0
+WORKDIR /trend-analysis/TrendAnalysisApp
+COPY ["/", "."]
+ENTRYPOINT ["dotnet", "run"]


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-367](https://bjss-enterprise.atlassian.net/browse/DHSCFT-367)

Extend GH Actions pipeline and local docker compose so that trend analysis will be executed.

## Changes

- Compose: post db-setup completing, then the new job will be executed. A Dockerfile has been added to the trend-analysis directory to run the command.
- Github Actions pipeline: the logic I ended up with is that we only want to execute the trend analysis in the pipeline if a change has been made to the DB. I.e. the data will have loaded fresh with the default trend values so trends will need to be recalculated.
- In addition to this, I have ensured that A. the Trend Analysis unit tests also get run if the DB has been changed, since this means the trend analysis will be run, so it's nice to check even if nothing in its own directory has been changed. And B. the db-deploy job gets run (main only) if the trend-analysis app was updated. I do not predict many if any changes to the trend-analysis app. But let's say we had some functional changes to make - then we would need to freshly load the data and run trend analysis again as if it were the first time.

Also worth noting, by making the Docker compose change, we will be able to test trends locally and this will support us adding e2e tests, if we want, for checking trends in a local running context.

## Validation

Tested locally and verified that trend data was now loaded locally. ** Maybe should ensure another developer can run this successfully.

See ticket for full evidence, but here was a successful pipeline run: https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13840121089/job/38727027884

I will address slowness in the pipeline in the channel as this is a wider issue than just this PR.
