### PR TITLE
DHSCFT-468: cache api request on FE

### DIFF
--- a/frontend/fingertips-frontend/app/(home)/page.test.tsx
+++ b/frontend/fingertips-frontend/app/(home)/page.test.tsx
@@ -97,12 +97,20 @@ describe('Home page', () => {
         searchParams: generateSearchParams(searchState),
       });
 
-      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(1, {
-        areaCode: eastEnglandNHSRegion.code,
-      });
-      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(2, {
-        areaCode: londonNHSRegion.code,
-      });
+      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCode: eastEnglandNHSRegion.code,
+        },
+        { next: { revalidate: 3600 } }
+      );
+      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCode: londonNHSRegion.code,
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(page.props.selectedAreasData).toEqual([
         eastEnglandNHSRegion,
         londonNHSRegion,

--- a/frontend/fingertips-frontend/app/(home)/page.test.tsx
+++ b/frontend/fingertips-frontend/app/(home)/page.test.tsx
@@ -7,7 +7,10 @@ import HomePage from './page';
 import { getAreaFilterData } from '@/lib/areaFilterHelpers/getAreaFilterData';
 import { AreasApi } from '@/generated-sources/ft-api-client';
 import { mockDeep } from 'jest-mock-extended';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import {
   allAreaTypes,
   nhsRegionsAreaType,
@@ -102,14 +105,14 @@ describe('Home page', () => {
         {
           areaCode: eastEnglandNHSRegion.code,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
         2,
         {
           areaCode: londonNHSRegion.code,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(page.props.selectedAreasData).toEqual([
         eastEnglandNHSRegion,

--- a/frontend/fingertips-frontend/app/(home)/page.tsx
+++ b/frontend/fingertips-frontend/app/(home)/page.tsx
@@ -31,7 +31,12 @@ export default async function Page(
     const selectedAreasData =
       areasSelected && areasSelected.length > 0
         ? await Promise.all(
-            areasSelected.map((area) => areasApi.getArea({ areaCode: area }))
+            areasSelected.map((area) =>
+              areasApi.getArea(
+                { areaCode: area },
+                { next: { revalidate: 3600 } }
+              )
+            )
           )
         : [];
 

--- a/frontend/fingertips-frontend/app/(home)/page.tsx
+++ b/frontend/fingertips-frontend/app/(home)/page.tsx
@@ -7,7 +7,10 @@ import {
   SearchStateParams,
 } from '@/lib/searchStateManager';
 import { connection } from 'next/server';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { ErrorPage } from '@/components/pages/error';
 import { getAreaFilterData } from '@/lib/areaFilterHelpers/getAreaFilterData';
 
@@ -32,10 +35,7 @@ export default async function Page(
       areasSelected && areasSelected.length > 0
         ? await Promise.all(
             areasSelected.map((area) =>
-              areasApi.getArea(
-                { areaCode: area },
-                { next: { revalidate: 3600 } }
-              )
+              areasApi.getArea({ areaCode: area }, API_CACHE_CONFIG)
             )
           )
         : [];

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -11,7 +11,10 @@ import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { preparePopulationData } from '@/lib/chartHelpers/preparePopulationData';
 import { mockDeep } from 'jest-mock-extended';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { IndicatorsApi } from '@/generated-sources/ft-api-client';
 import { getMapData } from '@/lib/thematicMapUtils/getMapData';
 import NHSRegionsMap from '@/assets/maps/NHS_England_Regions_January_2024_EN_BSC_7500404208533377417.geo.json';
@@ -57,7 +60,7 @@ describe('Chart Page', () => {
           indicatorId: 1,
           inequalities: ['sex'],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
@@ -67,7 +70,7 @@ describe('Chart Page', () => {
           areaCodes: ['A001', areaCodeForEngland],
           indicatorId: indicatorIdForPopulation,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     });
 
@@ -95,7 +98,7 @@ describe('Chart Page', () => {
           indicatorId: 1,
           inequalities: [],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
@@ -106,7 +109,7 @@ describe('Chart Page', () => {
           indicatorId: 2,
           inequalities: [],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
@@ -116,7 +119,7 @@ describe('Chart Page', () => {
           areaCodes: ['A001', areaCodeForEngland],
           indicatorId: indicatorIdForPopulation,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     });
   });
@@ -148,7 +151,7 @@ describe('Chart Page', () => {
           indicatorId: 333,
           inequalities: ['sex'],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
@@ -158,7 +161,7 @@ describe('Chart Page', () => {
           areaCodes: [mockAreaCode, areaCodeForEngland],
           indicatorId: indicatorIdForPopulation,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     });
 
@@ -187,7 +190,7 @@ describe('Chart Page', () => {
           indicatorId: 333,
           inequalities: ['sex'],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
@@ -197,7 +200,7 @@ describe('Chart Page', () => {
           areaCodes: [mockAreaCode, areaCodeForEngland],
           indicatorId: indicatorIdForPopulation,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     });
 

--- a/frontend/fingertips-frontend/app/chart/page.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.test.tsx
@@ -50,17 +50,25 @@ describe('Chart Page', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: ['A001', areaCodeForEngland],
-        indicatorId: 1,
-        inequalities: ['sex'],
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: ['A001', areaCodeForEngland],
+          indicatorId: 1,
+          inequalities: ['sex'],
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(2, {
-        areaCodes: ['A001', areaCodeForEngland],
-        indicatorId: indicatorIdForPopulation,
-      });
+      ).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCodes: ['A001', areaCodeForEngland],
+          indicatorId: indicatorIdForPopulation,
+        },
+        { next: { revalidate: 3600 } }
+      );
     });
 
     it('should make 3 calls for get health data, when there are 2 indicators selected - first two for the indicators the last one for the population data', async () => {
@@ -80,24 +88,36 @@ describe('Chart Page', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: ['A001', areaCodeForEngland],
-        indicatorId: 1,
-        inequalities: [],
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: ['A001', areaCodeForEngland],
+          indicatorId: 1,
+          inequalities: [],
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(2, {
-        areaCodes: ['A001', areaCodeForEngland],
-        indicatorId: 2,
-        inequalities: [],
-      });
+      ).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCodes: ['A001', areaCodeForEngland],
+          indicatorId: 2,
+          inequalities: [],
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(3, {
-        areaCodes: ['A001', areaCodeForEngland],
-        indicatorId: indicatorIdForPopulation,
-      });
+      ).toHaveBeenNthCalledWith(
+        3,
+        {
+          areaCodes: ['A001', areaCodeForEngland],
+          indicatorId: indicatorIdForPopulation,
+        },
+        { next: { revalidate: 3600 } }
+      );
     });
   });
 
@@ -121,17 +141,25 @@ describe('Chart Page', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: [mockAreaCode, areaCodeForEngland, mockParentAreaCode],
-        indicatorId: 333,
-        inequalities: ['sex'],
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: [mockAreaCode, areaCodeForEngland, mockParentAreaCode],
+          indicatorId: 333,
+          inequalities: ['sex'],
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(2, {
-        areaCodes: [mockAreaCode, areaCodeForEngland],
-        indicatorId: indicatorIdForPopulation,
-      });
+      ).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCodes: [mockAreaCode, areaCodeForEngland],
+          indicatorId: indicatorIdForPopulation,
+        },
+        { next: { revalidate: 3600 } }
+      );
     });
 
     it('should not include groupSelected in the API call if England is the groupSelected', async () => {
@@ -152,17 +180,25 @@ describe('Chart Page', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: [mockAreaCode, areaCodeForEngland],
-        indicatorId: 333,
-        inequalities: ['sex'],
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: [mockAreaCode, areaCodeForEngland],
+          indicatorId: 333,
+          inequalities: ['sex'],
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(2, {
-        areaCodes: [mockAreaCode, areaCodeForEngland],
-        indicatorId: indicatorIdForPopulation,
-      });
+      ).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCodes: [mockAreaCode, areaCodeForEngland],
+          indicatorId: indicatorIdForPopulation,
+        },
+        { next: { revalidate: 3600 } }
+      );
     });
 
     describe('Check correct props are passed to Chart page component', () => {

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -14,7 +14,10 @@ import {
   areaCodeForEngland,
   indicatorIdForPopulation,
 } from '@/lib/chartHelpers/constants';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import {
   AreaTypeKeysForMapMeta,
   getMapData,
@@ -68,7 +71,7 @@ export default async function ChartPage(
             ? [GetHealthDataForAnIndicatorInequalitiesEnum.Sex]
             : [],
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       )
     )
   );
@@ -80,7 +83,7 @@ export default async function ChartPage(
         indicatorId: indicatorIdForPopulation,
         areaCodes: [...areasSelected, areaCodeForEngland],
       },
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
   } catch (error) {
     console.log('error getting population data ', error);

--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -57,25 +57,31 @@ export default async function ChartPage(
 
   const healthIndicatorData = await Promise.all(
     indicatorsSelected.map((indicatorId) =>
-      indicatorApi.getHealthDataForAnIndicator({
-        indicatorId: Number(indicatorId),
-        areaCodes: areaCodesToRequest,
-        inequalities: shouldDisplayInequalities(
-          indicatorsSelected,
-          areasSelected
-        )
-          ? [GetHealthDataForAnIndicatorInequalitiesEnum.Sex]
-          : [],
-      })
+      indicatorApi.getHealthDataForAnIndicator(
+        {
+          indicatorId: Number(indicatorId),
+          areaCodes: areaCodesToRequest,
+          inequalities: shouldDisplayInequalities(
+            indicatorsSelected,
+            areasSelected
+          )
+            ? [GetHealthDataForAnIndicatorInequalitiesEnum.Sex]
+            : [],
+        },
+        { next: { revalidate: 3600 } }
+      )
     )
   );
 
   let rawPopulationData: HealthDataForArea[] | undefined;
   try {
-    rawPopulationData = await indicatorApi.getHealthDataForAnIndicator({
-      indicatorId: indicatorIdForPopulation,
-      areaCodes: [...areasSelected, areaCodeForEngland],
-    });
+    rawPopulationData = await indicatorApi.getHealthDataForAnIndicator(
+      {
+        indicatorId: indicatorIdForPopulation,
+        areaCodes: [...areasSelected, areaCodeForEngland],
+      },
+      { next: { revalidate: 3600 } }
+    );
   } catch (error) {
     console.log('error getting population data ', error);
   }

--- a/frontend/fingertips-frontend/app/results/page.test.tsx
+++ b/frontend/fingertips-frontend/app/results/page.test.tsx
@@ -179,6 +179,7 @@ describe('Results Page', () => {
     });
 
     it('should pass the selectedAreasData prop with data from getArea for each areaSelected', async () => {
+      mockGetAreaFilterData.mockResolvedValue({});
       mockAreasApi.getArea.mockResolvedValueOnce(eastEnglandNHSRegion);
       mockAreasApi.getArea.mockResolvedValueOnce(londonNHSRegion);
 
@@ -192,12 +193,20 @@ describe('Results Page', () => {
         searchParams: generateSearchParams(searchState),
       });
 
-      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(1, {
-        areaCode: eastEnglandNHSRegion.code,
-      });
-      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(2, {
-        areaCode: londonNHSRegion.code,
-      });
+      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCode: eastEnglandNHSRegion.code,
+        },
+        { next: { revalidate: 3600 } }
+      );
+      expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
+        2,
+        {
+          areaCode: londonNHSRegion.code,
+        },
+        { next: { revalidate: 3600 } }
+      );
       expect(page.props.selectedAreasData).toEqual([
         eastEnglandNHSRegion,
         londonNHSRegion,

--- a/frontend/fingertips-frontend/app/results/page.test.tsx
+++ b/frontend/fingertips-frontend/app/results/page.test.tsx
@@ -10,7 +10,10 @@ import {
 } from '@/lib/search/searchTypes';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 import { mockDeep } from 'jest-mock-extended';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { AreasApi } from '@/generated-sources/ft-api-client';
 import {
   mockAreaDataForNHSRegion,
@@ -198,14 +201,14 @@ describe('Results Page', () => {
         {
           areaCode: eastEnglandNHSRegion.code,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(mockAreasApi.getArea).toHaveBeenNthCalledWith(
         2,
         {
           areaCode: londonNHSRegion.code,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
       expect(page.props.selectedAreasData).toEqual([
         eastEnglandNHSRegion,

--- a/frontend/fingertips-frontend/app/results/page.tsx
+++ b/frontend/fingertips-frontend/app/results/page.tsx
@@ -33,7 +33,12 @@ export default async function Page(
     const selectedAreasData =
       areasSelected && areasSelected.length > 0
         ? await Promise.all(
-            areasSelected.map((area) => areasApi.getArea({ areaCode: area }))
+            areasSelected.map((area) =>
+              areasApi.getArea(
+                { areaCode: area },
+                { next: { revalidate: 3600 } }
+              )
+            )
           )
         : [];
 

--- a/frontend/fingertips-frontend/app/results/page.tsx
+++ b/frontend/fingertips-frontend/app/results/page.tsx
@@ -9,7 +9,10 @@ import { ErrorPage } from '@/components/pages/error';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 import { IndicatorSelectionState } from '@/components/forms/IndicatorSelectionForm/indicatorSelectionActions';
 import { getAreaFilterData } from '@/lib/areaFilterHelpers/getAreaFilterData';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 
 export default async function Page(
   props: Readonly<{
@@ -34,10 +37,7 @@ export default async function Page(
       areasSelected && areasSelected.length > 0
         ? await Promise.all(
             areasSelected.map((area) =>
-              areasApi.getArea(
-                { areaCode: area },
-                { next: { revalidate: 3600 } }
-              )
+              areasApi.getArea({ areaCode: area }, API_CACHE_CONFIG)
             )
           )
         : [];

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
@@ -61,11 +61,15 @@ describe('OneIndicatorOneAreaView', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: expectedAreaCodes,
-        indicatorId: 1,
-        comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: expectedAreaCodes,
+          indicatorId: 1,
+          comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
+        },
+        { next: { revalidate: 3600 } }
+      );
     }
   );
 

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
@@ -10,7 +10,10 @@ import { mockDeep } from 'jest-mock-extended';
 import OneIndicatorOneAreaView from '.';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { IIndicatorSearchService } from '@/lib/search/searchTypes';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
@@ -68,7 +71,7 @@ describe('OneIndicatorOneAreaView', () => {
           indicatorId: 1,
           comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     }
   );

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
@@ -3,7 +3,10 @@ import {
   GetHealthDataForAnIndicatorComparisonMethodEnum,
   HealthDataForArea,
 } from '@/generated-sources/ft-api-client';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { connection } from 'next/server';
@@ -44,7 +47,7 @@ export default async function OneIndicatorOneAreaView({
         areaCodes: areaCodesToRequest,
         comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
       },
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
   } catch (error) {
     console.error('error getting health indicator data for area', error);

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
@@ -38,11 +38,14 @@ export default async function OneIndicatorOneAreaView({
 
   let healthIndicatorData: HealthDataForArea[] | undefined;
   try {
-    healthIndicatorData = await indicatorApi.getHealthDataForAnIndicator({
-      indicatorId: Number(indicatorSelected[0]),
-      areaCodes: areaCodesToRequest,
-      comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
-    });
+    healthIndicatorData = await indicatorApi.getHealthDataForAnIndicator(
+      {
+        indicatorId: Number(indicatorSelected[0]),
+        areaCodes: areaCodesToRequest,
+        comparisonMethod: GetHealthDataForAnIndicatorComparisonMethodEnum.Rag,
+      },
+      { next: { revalidate: 3600 } }
+    );
   } catch (error) {
     console.error('error getting health indicator data for area', error);
     throw new Error('error getting health indicator data for area');

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -7,7 +7,10 @@ import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { mockDeep } from 'jest-mock-extended';
 import OneIndicatorTwoOrMoreAreasView from '.';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 import { IIndicatorSearchService } from '@/lib/search/searchTypes';
@@ -76,7 +79,7 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
           areaCodes: expectedAreaCodes,
           indicatorId: 1,
         },
-        { next: { revalidate: 3600 } }
+        API_CACHE_CONFIG
       );
     }
   );

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -70,10 +70,14 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
 
       expect(
         mockIndicatorsApi.getHealthDataForAnIndicator
-      ).toHaveBeenNthCalledWith(1, {
-        areaCodes: expectedAreaCodes,
-        indicatorId: 1,
-      });
+      ).toHaveBeenNthCalledWith(
+        1,
+        {
+          areaCodes: expectedAreaCodes,
+          indicatorId: 1,
+        },
+        { next: { revalidate: 3600 } }
+      );
     }
   );
 

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
@@ -3,7 +3,10 @@ import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { connection } from 'next/server';
 import { ViewProps } from '../ViewsContext';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { HealthDataForArea } from '@/generated-sources/ft-api-client';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
@@ -44,7 +47,7 @@ export default async function OneIndicatorTwoOrMoreAreasView({
         indicatorId: Number(indicatorSelected[0]),
         areaCodes: areaCodesToRequest,
       },
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
   } catch (error) {
     console.error('error getting health indicator data for areas', error);

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
@@ -39,10 +39,13 @@ export default async function OneIndicatorTwoOrMoreAreasView({
 
   let healthIndicatorData: HealthDataForArea[] | undefined;
   try {
-    healthIndicatorData = await indicatorApi.getHealthDataForAnIndicator({
-      indicatorId: Number(indicatorSelected[0]),
-      areaCodes: areaCodesToRequest,
-    });
+    healthIndicatorData = await indicatorApi.getHealthDataForAnIndicator(
+      {
+        indicatorId: Number(indicatorSelected[0]),
+        areaCodes: areaCodesToRequest,
+      },
+      { next: { revalidate: 3600 } }
+    );
   } catch (error) {
     console.error('error getting health indicator data for areas', error);
     throw new Error('error getting health indicator data for areas');

--- a/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.test.ts
+++ b/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.test.ts
@@ -1,6 +1,12 @@
 import { AreasApi, IndicatorsApi } from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from './apiClientFactory';
 
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ test: 100 }),
+  })
+) as jest.Mock;
+
 describe('apiClientFactory', () => {
   it('getAreasApiClient return an instance of the AreasApi', () => {
     const apiClient = ApiClientFactory.getAreasApiClient();

--- a/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
+++ b/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
@@ -16,6 +16,7 @@ export class ApiClientFactory {
       const apiUrl = readEnvVar('FINGERTIPS_API_URL');
       const config: Configuration = new Configuration({
         basePath: apiUrl,
+        fetchApi: fetch,
       });
 
       this.areasApiInstance = new AreasApi(config);
@@ -29,6 +30,7 @@ export class ApiClientFactory {
       const apiUrl = readEnvVar('FINGERTIPS_API_URL');
       const config: Configuration = new Configuration({
         basePath: apiUrl,
+        fetchApi: fetch,
       });
 
       this.indicatorsApiInstance = new IndicatorsApi(config);
@@ -42,6 +44,7 @@ export class ApiClientFactory {
       const apiUrl = readEnvVar('FINGERTIPS_API_URL');
       const config: Configuration = new Configuration({
         basePath: apiUrl,
+        fetchApi: fetch,
       });
 
       this.systemApiInstance = new SystemApi(config);

--- a/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
+++ b/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
@@ -6,6 +6,8 @@ import {
 } from '@/generated-sources/ft-api-client';
 import { readEnvVar } from '../envUtils';
 
+export const API_CACHE_CONFIG = { next: { revalidate: 3600 } };
+
 export class ApiClientFactory {
   private static areasApiInstance: AreasApi | null;
   private static indicatorsApiInstance: IndicatorsApi | null;

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -1,5 +1,8 @@
 import { AreasApi, AreaType } from '@/generated-sources/ft-api-client';
-import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '@/lib/apiClient/apiClientFactory';
 import { mockDeep } from 'jest-mock-extended';
 import { getAreaFilterData } from './getAreaFilterData';
 import {
@@ -35,7 +38,7 @@ describe('getAreaFilterData', () => {
 
     expect(mockAreasApi.getAreaTypes).toHaveBeenCalledWith(
       {},
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
     expect(availableAreaTypes).toEqual(mockSortedAreaTypes);
   });
@@ -64,7 +67,7 @@ describe('getAreaFilterData', () => {
       {
         areaTypeKey: nhsRegionsAreaType.key,
       },
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
     expect(availableGroups).toEqual(allAreasForICBAreaType);
   });
@@ -90,7 +93,7 @@ describe('getAreaFilterData', () => {
         includeChildren: true,
         childAreaType: nhsIntegratedCareBoardsAreaType.key,
       },
-      { next: { revalidate: 3600 } }
+      API_CACHE_CONFIG
     );
     expect(availableAreas).toEqual(areasSortedAlphabetically);
   });

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -33,7 +33,10 @@ describe('getAreaFilterData', () => {
 
     const { availableAreaTypes } = await getAreaFilterData({});
 
-    expect(mockAreasApi.getAreaTypes).toHaveBeenCalled();
+    expect(mockAreasApi.getAreaTypes).toHaveBeenCalledWith(
+      {},
+      { next: { revalidate: 3600 } }
+    );
     expect(availableAreaTypes).toEqual(mockSortedAreaTypes);
   });
 
@@ -57,9 +60,12 @@ describe('getAreaFilterData', () => {
       [SearchParams.GroupTypeSelected]: nhsRegionsAreaType.key,
     });
 
-    expect(mockAreasApi.getAreaTypeMembers).toHaveBeenCalledWith({
-      areaTypeKey: nhsRegionsAreaType.key,
-    });
+    expect(mockAreasApi.getAreaTypeMembers).toHaveBeenCalledWith(
+      {
+        areaTypeKey: nhsRegionsAreaType.key,
+      },
+      { next: { revalidate: 3600 } }
+    );
     expect(availableGroups).toEqual(allAreasForICBAreaType);
   });
 
@@ -78,11 +84,14 @@ describe('getAreaFilterData', () => {
       [SearchParams.GroupSelected]: eastEnglandNHSRegion.code,
     });
 
-    expect(mockAreasApi.getArea).toHaveBeenCalledWith({
-      areaCode: eastEnglandNHSRegion.code,
-      includeChildren: true,
-      childAreaType: nhsIntegratedCareBoardsAreaType.key,
-    });
+    expect(mockAreasApi.getArea).toHaveBeenCalledWith(
+      {
+        areaCode: eastEnglandNHSRegion.code,
+        includeChildren: true,
+        childAreaType: nhsIntegratedCareBoardsAreaType.key,
+      },
+      { next: { revalidate: 3600 } }
+    );
     expect(availableAreas).toEqual(areasSortedAlphabetically);
   });
 

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
@@ -38,7 +38,10 @@ export const getAreaFilterData = async (
 
   const areasApi = ApiClientFactory.getAreasApiClient();
 
-  const availableAreaTypes = await areasApi.getAreaTypes();
+  const availableAreaTypes = await areasApi.getAreaTypes(
+    {},
+    { next: { revalidate: 3600 } }
+  );
   const sortedByLevelAreaTypes = availableAreaTypes?.toSorted(
     (a, b) => a.level - b.level
   );
@@ -70,9 +73,12 @@ export const getAreaFilterData = async (
     determinedSelectedGroupType
   );
 
-  const availableGroups = await areasApi.getAreaTypeMembers({
-    areaTypeKey: determinedSelectedGroupType,
-  });
+  const availableGroups = await areasApi.getAreaTypeMembers(
+    {
+      areaTypeKey: determinedSelectedGroupType,
+    },
+    { next: { revalidate: 3600 } }
+  );
 
   const determinedSelectedGroup = determineSelectedGroup(
     selectedGroup,
@@ -83,11 +89,14 @@ export const getAreaFilterData = async (
     determinedSelectedGroup
   );
 
-  const availableArea: AreaWithRelations = await areasApi.getArea({
-    areaCode: determinedSelectedGroup,
-    includeChildren: true,
-    childAreaType: determinedSelectedAreaType,
-  });
+  const availableArea: AreaWithRelations = await areasApi.getArea(
+    {
+      areaCode: determinedSelectedGroup,
+      includeChildren: true,
+      childAreaType: determinedSelectedAreaType,
+    },
+    { next: { revalidate: 3600 } }
+  );
   const availableAreas = determineAvailableAreas(
     determinedSelectedAreaType,
     availableArea

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
@@ -3,7 +3,10 @@ import {
   AreaType,
   AreaWithRelations,
 } from '@/generated-sources/ft-api-client';
-import { ApiClientFactory } from '../apiClient/apiClientFactory';
+import {
+  API_CACHE_CONFIG,
+  ApiClientFactory,
+} from '../apiClient/apiClientFactory';
 import {
   SearchParams,
   SearchStateManager,
@@ -38,10 +41,7 @@ export const getAreaFilterData = async (
 
   const areasApi = ApiClientFactory.getAreasApiClient();
 
-  const availableAreaTypes = await areasApi.getAreaTypes(
-    {},
-    { next: { revalidate: 3600 } }
-  );
+  const availableAreaTypes = await areasApi.getAreaTypes({}, API_CACHE_CONFIG);
   const sortedByLevelAreaTypes = availableAreaTypes?.toSorted(
     (a, b) => a.level - b.level
   );
@@ -77,7 +77,7 @@ export const getAreaFilterData = async (
     {
       areaTypeKey: determinedSelectedGroupType,
     },
-    { next: { revalidate: 3600 } }
+    API_CACHE_CONFIG
   );
 
   const determinedSelectedGroup = determineSelectedGroup(
@@ -95,7 +95,7 @@ export const getAreaFilterData = async (
       includeChildren: true,
       childAreaType: determinedSelectedAreaType,
     },
-    { next: { revalidate: 3600 } }
+    API_CACHE_CONFIG
   );
   const availableAreas = determineAvailableAreas(
     determinedSelectedAreaType,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-468](https://bjss-enterprise.atlassian.net/browse/DHSCFT-468)

Adds caching config to all api requests for 1 hour before revalidating

## Validation

Tested locally - first requests to an endpoint will fetch from the API. Subsequent requests to the same endpoint will fetch from cache
