### PR TITLE
DHSCFT-476: Optimise GetDescendants

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
@@ -136,13 +136,31 @@ public class AreaRepository : IAreaRepository
             .DenormalisedAreaWithAreaType
             .FromSql(
                 $"""
-                    WITH recursive_cte(
-                AreaKey,
-                AreaCode,
-                AreaName,
-                AreaTypeKey,
-                AreaLevel,
-                ParentAreaKey) AS (
+                WITH 
+                StartingArea as (
+                Select
+                	*
+                FROM
+                    Areas.Areas area
+                WHERE
+                    area.AreaKey = {startingArea.AreaKey}
+                ),
+                TargetAreaType as (
+                Select
+                    *
+                FROM 
+                    Areas.AreaTypes at
+                WHERE
+                --- this is the taget areaType
+                   at.AreaTypeKey = {childAreaTypeKey}
+                ),
+                recursive_cte(
+                    AreaKey,
+                    AreaCode,
+                    AreaName,
+                    AreaTypeKey,
+                    AreaLevel,
+                    ParentAreaKey) AS (
                 SELECT
                    	ar.ChildAreaKey as AreaKey,
                     a.AreaCode,
@@ -155,9 +173,9 @@ public class AreaRepository : IAreaRepository
                 JOIN
                     Areas.Areas a ON a.AreaKey = ar.ChildAreaKey
                 JOIN
+                    StartingArea sa ON ar.ParentAreaKey = sa.AreaKey
+                JOIN
                    	Areas.AreaTypes at2 ON at2.AreaTypeKey = a.AreaTypeKey
-                WHERE
-                   	ar.ParentAreaKey = {startingArea.AreaKey}
                 UNION ALL
                 SELECT
                    	ar.ChildAreaKey as AreaKey,
@@ -174,24 +192,27 @@ public class AreaRepository : IAreaRepository
                    	Areas.AreaTypes at2 ON at2.AreaTypeKey = a.AreaTypeKey
                 INNER JOIN
                     recursive_cte ON recursive_cte.AreaKey = ar.ParentAreaKey
-
+                CROSS JOIN 
+                    TargetAreaType tat
+                WHERE
+                    at2.[Level] <= tat.[Level]
+                AND
+                    at2.HierarchyType = tat.HierarchyType
                 )
                 SELECT DISTINCT
                     AreaKey,
                     AreaCode,
                     AreaName,
-                    rc.AreaTypeKey as AreaTypeKey,
-                    at.Level as Level,
-                    at.HierarchyType as HierarchyType,
-                    at.AreaTypeName as AreaTypeName
+                    tat.AreaTypeKey as AreaTypeKey,
+                    tat.Level as Level,
+                    tat.HierarchyType as HierarchyType,
+                    tat.AreaTypeName as AreaTypeName
                 FROM
                     recursive_cte rc
                 JOIN
-                    Areas.AreaTypes at
+                    TargetAreaType tat
                 ON
-                    rc.AreaTypeKey = at.AreaTypeKey
-                WHERE
-                    rc.AreaTypeKey = {childAreaTypeKey}
+                    rc.AreaTypeKey = tat.AreaTypeKey
                 """
             )
             .ToListAsync();


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-476](https://bjss-enterprise.atlassian.net/browse/DHSCFT-476)

This provides some further optimisation to the GetDescendants SQL query by having the recursive SQL exit early when it can.
Tests suggest a 30% performance improvement.

## Changes

- Update GetDescendants recursive SQL to exit once the areaType level is higher value than the target level
- Or to exit if the Hierarchy type is not equal to the target heirarchyType

## Validation

Tests have been performed on getting descendants of England for each area type and comparing main against the feature branch. See attached word doc.
