### PR TITLE
DHSCFT-488: Refactored trend analysis application to work in parallel

### DIFF
--- a/trend-analysis/TrendAnalysisApp/README.md
+++ b/trend-analysis/TrendAnalysisApp/README.md
@@ -3,7 +3,9 @@
 This is a dotnet console application to be used during the data loading process. It will calculate the latest trend for each Health Measure with unique dimensions - i.e. a given indicator e.g `Under 75 mortality rate from all causes` associated with a given area, sex and age group - and then set this value in the database. This will mean that the frontend can simply retrieve trend data and will not have to perform any calculations.
 
 ## How to run
-It is not envisaged that developers will need to run this locally, as it is intended to be invoked as an automated pipeline job. However, if ever required locally e.g. for debugging please do the following:
+Typically, a developer will not need to invoke this package directly, as it is run, when required, via Docker compose and within automated jobs in the pipeline
+
+However, if you are making changes in here and prefer to run directly via the CLI e.g. for debugging please do the following:
 
 ```
 Ensure the fingertips-db is already running

--- a/trend-analysis/TrendAnalysisApp/TrendDataProcessor.cs
+++ b/trend-analysis/TrendAnalysisApp/TrendDataProcessor.cs
@@ -1,57 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
 using TrendAnalysisApp.Calculator;
+using TrendAnalysisApp.Calculator.Legacy;
+using TrendAnalysisApp.Mapper;
 using TrendAnalysisApp.Repository;
+using TrendAnalysisApp.Repository.Models;
 
 namespace TrendAnalysisApp;
 
 /// <summary>
 /// The Trend Data Processor Class.
 /// </summary>
-/// <param name="healthMeasureRepo">Repository for health measure data</param>
-/// <param name="trendCalculator"></param
+/// <param name="indicatorRepo"></param
 public class TrendDataProcessor(
-    HealthMeasureRepository healthMeasureRepo,
-    IndicatorRepository indicatorRepo,
-    TrendCalculator trendCalculator
+    IndicatorRepository indicatorRepo
 )
 {
-    private readonly HealthMeasureRepository _healthMeasureRepo = healthMeasureRepo;
     private readonly IndicatorRepository _indicatorRepo = indicatorRepo;
-    private readonly TrendCalculator _trendCalculator = trendCalculator;
 
+    /// <summary>
+    /// Static helper method which can be used in a parallel context.
+    /// It will calculate and save all trends relating to a given indicator
+    /// across multiple dimensions e.g. age, deprivation, sex, area.
+    /// </summary>
+    /// <param name="indicator"></param>
+    /// <param name="healthMeasureRepository"></param>
+    /// <param name="trendCalculator"></param>
+    private static async Task ProcessOne(
+        IndicatorDimensionModel indicator,
+        HealthMeasureRepository healthMeasureRepository,
+        TrendCalculator trendCalculator
+    )
+    {
+        var healthMeasures = await healthMeasureRepository.GetByIndicator(indicator.IndicatorKey);
+        var groupedHealthMeasures = healthMeasures
+            .GroupBy(hm => new {
+                hm.AgeKey,
+                hm.AreaKey,
+                hm.DeprivationKey,
+                hm.SexKey
+            });
+
+        foreach (var hmGroup in groupedHealthMeasures) {
+            var mostRecentDataPoints = hmGroup
+                .OrderByDescending(hm => hm.Year)
+                .Take(TrendCalculator.RequiredNumberOfDataPoints);
+            
+            if (
+                !mostRecentDataPoints.Any() ||
+                mostRecentDataPoints.First().TrendDimension.Name != Constants.Trend.NotYetCalculatedDbString
+            ) { continue; }
+
+            var trend = trendCalculator.CalculateTrend(indicator, mostRecentDataPoints);
+            healthMeasureRepository.UpdateTrendKey(mostRecentDataPoints.First(), (byte) trend);
+        }
+
+        await healthMeasureRepository.SaveChanges();
+        Console.WriteLine($"Processed indicator: ({indicator.IndicatorKey}) {indicator.Name}");
+    }
 
     /// <summary>
     /// Entrypoint for processing the trend data.
     /// </summary>
-    public async Task Process()
+    public async Task Process(ServiceProvider serviceProvider)
     {
         var indicators = await _indicatorRepo.GetAll();
 
-        foreach (var indicator in indicators) {
-            var healthMeasures = await _healthMeasureRepo.GetByIndicator(indicator.IndicatorKey);
-            var groupedHealthMeasures = healthMeasures
-                .GroupBy(hm => new {
-                    hm.AgeKey,
-                    hm.AreaKey,
-                    hm.DeprivationKey,
-                    hm.SexKey
-                });
+        Parallel.ForEach(indicators, indicator =>
+        {
+            using var scope = serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<HealthMeasureDbContext>();
+            var healthMeasureRepository = new HealthMeasureRepository(dbContext);
 
-            foreach (var hmGroup in groupedHealthMeasures) {
-                var mostRecentDataPoints = hmGroup
-                    .OrderByDescending(hm => hm.Year)
-                    .Take(TrendCalculator.RequiredNumberOfDataPoints);
-                
-                if (
-                    !mostRecentDataPoints.Any() ||
-                    mostRecentDataPoints.First().TrendDimension.Name != Constants.Trend.NotYetCalculatedDbString
-                ) { continue; }
+            var legacyMapper = serviceProvider.GetRequiredService<LegacyMapper>();
+            var scopedLegacyCalculator = scope.ServiceProvider.GetRequiredService<TrendMarkerCalculator>();
+            var trendCalculator = new TrendCalculator(scopedLegacyCalculator, legacyMapper);
 
-                var trend = _trendCalculator.CalculateTrend(indicator, mostRecentDataPoints);
-                _healthMeasureRepo.UpdateTrendKey(mostRecentDataPoints.First(), (byte) trend);
-            }
-
-            await _healthMeasureRepo.SaveChanges();
-            Console.WriteLine($"Processed indicator: ({indicator.IndicatorKey}) {indicator.Name}");
-        }
+            ProcessOne(indicator, healthMeasureRepository, trendCalculator).Wait();
+        });
     }
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-488](https://bjss-enterprise.atlassian.net/browse/DHSCFT-488)

Quick little PR to make the trend analysis application process the trend data in parallel to improve performance.

## Changes

- Microsoft Entity Framework is not thread safe, therefore modified the creation of service/DI so that each thread will receive a unique DB context.
- Likewise for the Legacy Calculator - there is a dictionary that multiple threads could write to simultaneously so I decided it was best to keep this transient too rather than risk any refactoring of the internal legacy calc code.

## Validation

**Retested** 10 scenarios from the original test plan - all trends were found to be unchanged.

**Performance** - since new data has been added, on `main` my PC is now taking 70-80 seconds to load the DB data and 90-100 seconds to apply the trends.

After refactoring, it now takes 50-60 seconds to apply the trend data, representing a very decent time saving. Also, for some reason (Azure/network latency), the job takes 7-9 minutes in the pipeline so this should also cut a decent bit of time off that too.

