### PR TITLE
Enable long paths

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -332,6 +332,10 @@ jobs:
         needs.check-changes.outputs.trend_analysis_changed == 'true'
       )
     steps:
+      - name: Set git core.longpaths flag
+        run: |
+          git config --system core.longpaths true
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

Pipelines failing on database deploy job due to long file paths in the git repo. Fix the git config on Windows hosted runner to enable long file path support

## Changes

- Enable long file paths before git checkout on the Windows runner
