### PR TITLE
Remove default branch

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -316,16 +316,13 @@ jobs:
       ]
     environment: development
     runs-on: windows-latest
-    defaults:
-      run:
-        working-directory: ./database/fingertips-db
     if: >
       always() &&
       contains(needs.*.result, 'success') &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'main' &&
+      github.ref_name == 'feature/DHSCFT-TECH_remove-default-branch' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -322,7 +322,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'feature/DHSCFT-TECH_remove-default-branch' &&
+      github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||


### PR DESCRIPTION
# Description

Remove the default directorywithin the database deploy job which is preventing long file paths from being enabled

## Changes

- Remove default directory within database deploy job

## Validation

Tested workflow manually against the branch and I'm able to enable long file paths and deploy the dacpac
