### PR TITLE
Add workflow dependencies

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -313,6 +313,9 @@ jobs:
         check-changes,
         push-container-api,
         push-container-frontend,
+        frontend-build-and-test,
+        api-build-and-test,
+        e2e-tests-local-docker       
       ]
     environment: development
     runs-on: windows-latest
@@ -585,9 +588,10 @@ jobs:
     needs: [
       check-changes,
       deploy-db-dev,
+      run-trend-analysis-dev,
       search-setup-dev,
       deploy-api-dev,
-      deploy-frontend-dev
+      deploy-frontend-dev      
     ]
     uses: ./.github/workflows/e2e-tests.yml
     if: >


### PR DESCRIPTION
# Description

Add missing workflow dependencies to wait for jobs to complete before starting

## Changes

- Add dependency on db deploy to wait for API build and e2e tests
- Add dependency on CD e2e tests to wait for trend analysis

