### PR TITLE
DHSCFT-488: Increase timeout for trend processing in pipeline

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -325,7 +325,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'feature/DHSCFT-488_fix-trends-in-pipeline' &&
+      github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||
@@ -375,7 +375,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'feature/DHSCFT-488_fix-trends-in-pipeline' &&
+      github.ref_name == 'main' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||

--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -325,7 +325,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       github.event_name != 'pull_request' &&
-      github.ref_name == 'main' &&
+      github.ref_name == 'feature/DHSCFT-488_fix-trends-in-pipeline' &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.check-changes.outputs.db_changed == 'true' ||
@@ -368,8 +368,19 @@ jobs:
           arguments: '/p:DropObjectsNotInSource=true /p:BlockOnPossibleDataLoss=false /p:GenerateSmartDefaults=true /v:UseAzureBlob=1 /v:BlobStorageLocation=${{ vars.BLOB_STORAGE_LOCATION }} /v:MasterKeyPassword=${{ secrets.SQL_MASTER_KEY_PASSWORD }}'
 
   run-trend-analysis-dev:
-    # Only run job if the DB has had a clean deploy
     needs: deploy-db-dev
+    if: >
+      always() &&
+      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      github.event_name != 'pull_request' &&
+      github.ref_name == 'feature/DHSCFT-488_fix-trends-in-pipeline' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.check-changes.outputs.db_changed == 'true' ||
+        needs.check-changes.outputs.trend_analysis_changed == 'true'
+      )
     environment: development
     name: Run Trend Analysis App
     runs-on: ubuntu-latest

--- a/trend-analysis/TrendAnalysisApp/Constants.cs
+++ b/trend-analysis/TrendAnalysisApp/Constants.cs
@@ -7,6 +7,8 @@ public static class Constants {
     public static class Database {
         // The name for the Fingertips DB: used in the environment variable for the connection string.
         public const string FingertipsDbName = "FINGERTIPS_DB";
+        // With the current DB settings, when running load-heavy processes we may need longer than the default 30s.
+        public const int CommandTimeout = 90;
     }
 
     public static class Polarity {

--- a/trend-analysis/TrendAnalysisApp/Program.cs
+++ b/trend-analysis/TrendAnalysisApp/Program.cs
@@ -30,7 +30,10 @@ internal static class Program
         return new ServiceCollection()
             .AddSingleton<IConfiguration>(configuration)
             .AddDbContext<HealthMeasureDbContext>(
-                options => options.UseSqlServer(connString),
+                options => options.UseSqlServer(
+                    connString,
+                    sqlServerOptions => sqlServerOptions.CommandTimeout(Constants.Database.CommandTimeout)
+                ),
                 ServiceLifetime.Transient
             )
             .AddSingleton<TrendDataProcessor>()


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-488](https://bjss-enterprise.atlassian.net/browse/DHSCFT-488)

First time running in the pipeline after parallelizing, we ran into an issue where one of the threads had a SQL query timeout issue. The assumption is that because it is now running in parallel the DB is under greater strain and one of the threads took more than the default 30 seconds.

Therefore bumped up the timeout. We allowed running from this branch in the initial commit so we could do some testing:
https://github.com/dhsc-govuk/FingertipsNext/actions/runs/13924455569/job/38971302889

It completed in 5 minutes rather than the 8-9 minutes that it was taking previously.

This PR also introduces a more stringent if statement for the job.

## Validation

Ran test pipeline against this branch.
