### PR TITLE
DHSCFT-489 - Add e2e test for clearing indicator on search change

### DIFF
--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -220,10 +220,10 @@ test.describe(`Navigation, accessibility and validation tests`, () => {
     });
 
     await test.step('Clear search bar and search, verify url is updated to remove indicator', async () => {
-      await resultsPage.clearIndicatorSearchBox()
-      await resultsPage.clickIndicatorSearchButton()
-      await test.expect(resultsPage.page).not.toHaveURL(/&is=/)
-    })
+      await resultsPage.clearIndicatorSearchBox();
+      await resultsPage.clickIndicatorSearchButton();
+      await test.expect(resultsPage.page).not.toHaveURL(/&is=/);
+    });
   });
 });
 

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -198,6 +198,33 @@ test.describe(`Navigation, accessibility and validation tests`, () => {
       await test.expect(resultsPage.areaFilterCombobox()).toBeEnabled();
     });
   });
+
+  test('check indicators are removed from url when search changes', async ({
+    resultsPage,
+  }) => {
+    await test.step('Navigate directly to the results page', async () => {
+      await resultsPage.navigateToResults(subjectSearchTerm, [
+        allNHSRegionAreas[0].areaCode,
+        allNHSRegionAreas[1].areaCode,
+        allNHSRegionAreas[2].areaCode,
+      ]);
+    });
+
+    await test.step('Select single indicator, and verify url is updated to include indicator', async () => {
+      await resultsPage.selectIndicatorCheckboxes(
+        filteredIndicatorIds,
+        indicatorMode
+      );
+
+      await test.expect(resultsPage.page).toHaveURL(/&is=/);
+    });
+
+    await test.step('Clear search bar and search, verify url is updated to remove indicator', async () => {
+      await resultsPage.clearIndicatorSearchBox()
+      await resultsPage.clickIndicatorSearchButton()
+      await test.expect(resultsPage.page).not.toHaveURL(/&is=/)
+    })
+  });
 });
 
 // log out current url when a test fails


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-489](https://bjss-enterprise.atlassian.net/browse/DHSCFT-489)

Added new e2e test to cater for the changes made as part of DHSCFT-358

## Changes

- Added new test to ensure the URL is updated correctly to remove any selected indicators when the search changes.

## Validation

New test added and passing