### PR TITLE
DHSCFT-450 - Sort AreaType in area type dropdown by Hierarchy and Level

### DIFF
--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
@@ -17,8 +17,8 @@ describe('areaTypeSorter', () => {
   it('should return area types sorted by hierarchy and level', () => {
     const expectedSortedAreaTypes: AreaType[] = [
       englandAreaType,
-      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),
-      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+      ...adminHierarchyAreaTypes.toSorted((a, b) => a.level - b.level),
+      ...nhsHierarchyAreaTypes.toSorted((a, b) => a.level - b.level),
     ];
 
     const sortedAreaTypes = areaTypeSorter(allAreaTypes);
@@ -34,7 +34,7 @@ describe('areaTypeSorter', () => {
 
     const expectedSortedWithoutAdmin: AreaType[] = [
       englandAreaType,
-      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+      ...nhsHierarchyAreaTypes.toSorted((a, b) => a.level - b.level),
     ];
 
     const sortedAreaTypes = areaTypeSorter(mockAreaTypesWithoutAdmin);

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
@@ -1,0 +1,75 @@
+import { AreaType } from '@/generated-sources/ft-api-client';
+import { areaTypeSorter } from './areaTypeSorter';
+import {
+  allAreaTypes,
+  adminHierarchyAreaTypes,
+  nhsHierarchyAreaTypes,
+  englandAreaType,
+  regionsAreaType,
+  nhsSubIntegratedCareBoardsAreaType,
+  nhsPrimaryCareNetworksAreaType,
+  nhsIntegratedCareBoardsAreaType,
+  gpsAreaType,
+  nhsRegionsAreaType,
+  districtAndUnitaryAuthoritiesAreaType,
+  combinedAuthoritiesAreaType,
+  countiesAndUnitaryAuthoritiesAreaType,
+} from '@/lib/areaFilterHelpers/areaType';
+
+describe('areaTypeSorter', () => {
+  it('should return area types sorted by hierarchy and level', () => {
+    const expectedSortedAreaTypes: AreaType[] = [
+      englandAreaType,
+      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+    ];
+
+    const sortedAreaTypes = areaTypeSorter(allAreaTypes);
+
+    expect(sortedAreaTypes).toEqual(expectedSortedAreaTypes);
+  });
+
+  it('should return correct order when Administrative AreaType data is missing', () => {
+    const mockAreaTypesWithoutAdmin: AreaType[] = [
+      englandAreaType,
+      ...nhsHierarchyAreaTypes,
+    ];
+
+    const expectedSortedWithoutAdmin: AreaType[] = [
+      englandAreaType,
+      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+    ];
+
+    const sortedAreaTypes = areaTypeSorter(mockAreaTypesWithoutAdmin);
+
+    expect(sortedAreaTypes).toEqual(expectedSortedWithoutAdmin);
+  });
+
+  
+  it('should return correct order when only a subset of AreaType data is given', () => {
+    const mockAreaTypes: AreaType[] = [
+      districtAndUnitaryAuthoritiesAreaType,
+      englandAreaType,
+      nhsSubIntegratedCareBoardsAreaType,
+      regionsAreaType,
+      nhsIntegratedCareBoardsAreaType,
+      gpsAreaType,
+      countiesAndUnitaryAuthoritiesAreaType,
+    ];
+
+    const mocksortedAreaTypes: AreaType[] = [
+        englandAreaType,
+        regionsAreaType,
+        countiesAndUnitaryAuthoritiesAreaType,
+        districtAndUnitaryAuthoritiesAreaType,
+        nhsIntegratedCareBoardsAreaType,
+        nhsSubIntegratedCareBoardsAreaType,
+        gpsAreaType,
+      ];
+
+
+    const sortedAreaTypes = areaTypeSorter(mockAreaTypes);
+
+    expect(sortedAreaTypes).toEqual(mocksortedAreaTypes);
+  });
+});

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.test.ts
@@ -7,12 +7,9 @@ import {
   englandAreaType,
   regionsAreaType,
   nhsSubIntegratedCareBoardsAreaType,
-  nhsPrimaryCareNetworksAreaType,
   nhsIntegratedCareBoardsAreaType,
   gpsAreaType,
-  nhsRegionsAreaType,
   districtAndUnitaryAuthoritiesAreaType,
-  combinedAuthoritiesAreaType,
   countiesAndUnitaryAuthoritiesAreaType,
 } from '@/lib/areaFilterHelpers/areaType';
 
@@ -45,7 +42,6 @@ describe('areaTypeSorter', () => {
     expect(sortedAreaTypes).toEqual(expectedSortedWithoutAdmin);
   });
 
-  
   it('should return correct order when only a subset of AreaType data is given', () => {
     const mockAreaTypes: AreaType[] = [
       districtAndUnitaryAuthoritiesAreaType,
@@ -58,15 +54,14 @@ describe('areaTypeSorter', () => {
     ];
 
     const mocksortedAreaTypes: AreaType[] = [
-        englandAreaType,
-        regionsAreaType,
-        countiesAndUnitaryAuthoritiesAreaType,
-        districtAndUnitaryAuthoritiesAreaType,
-        nhsIntegratedCareBoardsAreaType,
-        nhsSubIntegratedCareBoardsAreaType,
-        gpsAreaType,
-      ];
-
+      englandAreaType,
+      regionsAreaType,
+      countiesAndUnitaryAuthoritiesAreaType,
+      districtAndUnitaryAuthoritiesAreaType,
+      nhsIntegratedCareBoardsAreaType,
+      nhsSubIntegratedCareBoardsAreaType,
+      gpsAreaType,
+    ];
 
     const sortedAreaTypes = areaTypeSorter(mockAreaTypes);
 

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
@@ -1,28 +1,27 @@
 import { AreaType } from '@/generated-sources/ft-api-client';
 
 export const areaTypeSorter = (availableAreaTypes: AreaType[]): AreaType[] => {
-    const areaTypesGroupedByHierarchy = availableAreaTypes.reduce(
-        (result: Record<string, AreaType[]>, areaType: AreaType) => {
-          (result[areaType.hierarchyName] =
-            result[areaType.hierarchyName] || []).push(areaType);
-          return result;
-        },
-        {}
-    )
+  const areaTypesGroupedByHierarchy = availableAreaTypes.reduce(
+    (result: Record<string, AreaType[]>, areaType: AreaType) => {
+      (result[areaType.hierarchyName] =
+        result[areaType.hierarchyName] || []).push(areaType);
+      return result;
+    },
+    {}
+  );
 
-    const sortAreaTypesByLevel = (areaTypes: AreaType[] = []) =>
-      areaTypes.toSorted((a, b) => a.level - b.level);
+  const sortAreaTypesByLevel = (areaTypes: AreaType[] = []) =>
+    areaTypes.toSorted((a, b) => a.level - b.level);
 
-    const sortHierarchy = (name: string) => {
-      const areaTypes = areaTypesGroupedByHierarchy[name];
+  const sortHierarchy = (name: string) => {
+    const areaTypes = areaTypesGroupedByHierarchy[name];
 
-      return sortAreaTypesByLevel(areaTypes);
-    };
+    return sortAreaTypesByLevel(areaTypes);
+  };
 
-    return [
-      ...sortHierarchy('Both'),
-      ...sortHierarchy('Administrative'),
-      ...sortHierarchy('NHS'),
-    ];
-  }
-  
+  return [
+    ...sortHierarchy('Both'),
+    ...sortHierarchy('Administrative'),
+    ...sortHierarchy('NHS'),
+  ];
+};

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
@@ -1,0 +1,28 @@
+import { AreaType } from '@/generated-sources/ft-api-client';
+
+export const areaTypeSorter = (availableAreaTypes: AreaType[]): AreaType[] => {
+    const areaTypesGroupedByHierarchy = availableAreaTypes.reduce(
+        (result: Record<string, AreaType[]>, areaType: AreaType) => {
+          (result[areaType.hierarchyName] =
+            result[areaType.hierarchyName] || []).push(areaType);
+          return result;
+        },
+        {}
+    )
+
+    const sortAreaTypesByLevel = (areaTypes: AreaType[] = []) =>
+      areaTypes.toSorted((a, b) => a.level - b.level);
+
+    const sortHierarchy = (name: string) => {
+      const areaTypes = areaTypesGroupedByHierarchy[name];
+
+      return sortAreaTypesByLevel(areaTypes);
+    };
+
+    return [
+      ...sortHierarchy('Both'),
+      ...sortHierarchy('Administrative'),
+      ...sortHierarchy('NHS'),
+    ];
+  }
+  

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/areaTypeSorter.ts
@@ -3,8 +3,10 @@ import { AreaType } from '@/generated-sources/ft-api-client';
 export const areaTypeSorter = (availableAreaTypes: AreaType[]): AreaType[] => {
   const areaTypesGroupedByHierarchy = availableAreaTypes.reduce(
     (result: Record<string, AreaType[]>, areaType: AreaType) => {
-      (result[areaType.hierarchyName] =
-        result[areaType.hierarchyName] || []).push(areaType);
+      const hierarchyArrary = result[areaType.hierarchyName] || [];
+      result[areaType.hierarchyName] = hierarchyArrary;
+      hierarchyArrary.push(areaType);
+
       return result;
     },
     {}

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -34,8 +34,8 @@ describe('getAreaFilterData', () => {
 
     const expectedSortedAreaTypes: AreaType[] = [
       englandAreaType,
-      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),
-      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+      ...adminHierarchyAreaTypes.toSorted((a, b) => a.level - b.level),
+      ...nhsHierarchyAreaTypes.toSorted((a, b) => a.level - b.level),
     ];
 
     const { availableAreaTypes } = await getAreaFilterData({});

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -9,15 +9,10 @@ import {
   allAreaTypes,
   AreaTypeKeys,
   englandAreaType,
-  regionsAreaType,
-  nhsSubIntegratedCareBoardsAreaType,
-  nhsPrimaryCareNetworksAreaType,
   nhsIntegratedCareBoardsAreaType,
-  gpsAreaType,
   nhsRegionsAreaType,
-  districtAndUnitaryAuthoritiesAreaType,
-  combinedAuthoritiesAreaType,
-  countiesAndUnitaryAuthoritiesAreaType,
+  adminHierarchyAreaTypes,
+  nhsHierarchyAreaTypes,
 } from './areaType';
 import { eastEnglandNHSRegion } from '@/mock/data/areas/nhsRegionsAreas';
 import { SearchParams } from '../searchStateManager';
@@ -34,21 +29,14 @@ describe('getAreaFilterData', () => {
     jest.clearAllMocks();
   });
 
-  it('should call sortAreaTypesByHierarchyAndLevel and return the correctly sorted area types', async () => {
+  it('should return availableAreaTypes from the getAreaTypes call that have been sorted by hierarchy and level', async () => {
     mockAreasApi.getAreaTypes.mockResolvedValue(allAreaTypes);
 
-    const mockSortedAreaTypes: AreaType[] = [
-      englandAreaType,
-      combinedAuthoritiesAreaType,
-      regionsAreaType,
-      countiesAndUnitaryAuthoritiesAreaType,
-      districtAndUnitaryAuthoritiesAreaType,
-      nhsRegionsAreaType,
-      nhsIntegratedCareBoardsAreaType,
-      nhsSubIntegratedCareBoardsAreaType,
-      nhsPrimaryCareNetworksAreaType,
-      gpsAreaType,
-    ];
+    const expectedSortedAreaTypes: AreaType[] = [  
+      englandAreaType,  
+      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),  
+      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),  
+    ];  
 
     const { availableAreaTypes } = await getAreaFilterData({});
 
@@ -57,7 +45,7 @@ describe('getAreaFilterData', () => {
       API_CACHE_CONFIG
     );
 
-    expect(availableAreaTypes).toEqual(mockSortedAreaTypes);
+    expect(availableAreaTypes).toEqual(expectedSortedAreaTypes);
   });
 
   it('should return availableGroupTypes prop with a subset of areaTypes sorted by level that are applicable based upon the areaTypeSelected', async () => {

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -32,11 +32,11 @@ describe('getAreaFilterData', () => {
   it('should return availableAreaTypes from the getAreaTypes call that have been sorted by hierarchy and level', async () => {
     mockAreasApi.getAreaTypes.mockResolvedValue(allAreaTypes);
 
-    const expectedSortedAreaTypes: AreaType[] = [  
-      englandAreaType,  
-      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),  
-      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),  
-    ];  
+    const expectedSortedAreaTypes: AreaType[] = [
+      englandAreaType,
+      ...adminHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+      ...nhsHierarchyAreaTypes.sort((a, b) => a.level - b.level),
+    ];
 
     const { availableAreaTypes } = await getAreaFilterData({});
 

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -37,18 +37,18 @@ describe('getAreaFilterData', () => {
   it('should call sortAreaTypesByHierarchyAndLevel and return the correctly sorted area types', async () => {
     mockAreasApi.getAreaTypes.mockResolvedValue(allAreaTypes);
 
-  const mockSortedAreaTypes: AreaType[] = [
-    englandAreaType,
-    combinedAuthoritiesAreaType,
-    regionsAreaType,
-    countiesAndUnitaryAuthoritiesAreaType,
-    districtAndUnitaryAuthoritiesAreaType,
-    nhsRegionsAreaType,
-    nhsIntegratedCareBoardsAreaType,
-    nhsSubIntegratedCareBoardsAreaType,
-    nhsPrimaryCareNetworksAreaType,
-    gpsAreaType,
-  ];
+    const mockSortedAreaTypes: AreaType[] = [
+      englandAreaType,
+      combinedAuthoritiesAreaType,
+      regionsAreaType,
+      countiesAndUnitaryAuthoritiesAreaType,
+      districtAndUnitaryAuthoritiesAreaType,
+      nhsRegionsAreaType,
+      nhsIntegratedCareBoardsAreaType,
+      nhsSubIntegratedCareBoardsAreaType,
+      nhsPrimaryCareNetworksAreaType,
+      gpsAreaType,
+    ];
 
     const { availableAreaTypes } = await getAreaFilterData({});
 

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.test.ts
@@ -9,8 +9,15 @@ import {
   allAreaTypes,
   AreaTypeKeys,
   englandAreaType,
+  regionsAreaType,
+  nhsSubIntegratedCareBoardsAreaType,
+  nhsPrimaryCareNetworksAreaType,
   nhsIntegratedCareBoardsAreaType,
+  gpsAreaType,
   nhsRegionsAreaType,
+  districtAndUnitaryAuthoritiesAreaType,
+  combinedAuthoritiesAreaType,
+  countiesAndUnitaryAuthoritiesAreaType,
 } from './areaType';
 import { eastEnglandNHSRegion } from '@/mock/data/areas/nhsRegionsAreas';
 import { SearchParams } from '../searchStateManager';
@@ -27,12 +34,21 @@ describe('getAreaFilterData', () => {
     jest.clearAllMocks();
   });
 
-  it('should return availableAreaTypes with a sorted by level list of areaTypes from the getAreaTypes call', async () => {
+  it('should call sortAreaTypesByHierarchyAndLevel and return the correctly sorted area types', async () => {
     mockAreasApi.getAreaTypes.mockResolvedValue(allAreaTypes);
 
-    const mockSortedAreaTypes: AreaType[] = allAreaTypes.toSorted(
-      (a, b) => a.level - b.level
-    );
+  const mockSortedAreaTypes: AreaType[] = [
+    englandAreaType,
+    combinedAuthoritiesAreaType,
+    regionsAreaType,
+    countiesAndUnitaryAuthoritiesAreaType,
+    districtAndUnitaryAuthoritiesAreaType,
+    nhsRegionsAreaType,
+    nhsIntegratedCareBoardsAreaType,
+    nhsSubIntegratedCareBoardsAreaType,
+    nhsPrimaryCareNetworksAreaType,
+    gpsAreaType,
+  ];
 
     const { availableAreaTypes } = await getAreaFilterData({});
 
@@ -40,6 +56,7 @@ describe('getAreaFilterData', () => {
       {},
       API_CACHE_CONFIG
     );
+
     expect(availableAreaTypes).toEqual(mockSortedAreaTypes);
   });
 

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getAreaFilterData.ts
@@ -13,6 +13,7 @@ import {
   SearchStateParams,
 } from '../searchStateManager';
 import { AreaTypeKeys } from './areaType';
+import { areaTypeSorter } from '@/lib/areaFilterHelpers/areaTypeSorter';
 import { determineApplicableGroupTypes } from './determineApplicableGroupTypes';
 import { determineSelectedAreaType } from './determineSelectedAreaType';
 import { determineSelectedGroup } from './determineSelectedGroup';
@@ -42,9 +43,7 @@ export const getAreaFilterData = async (
   const areasApi = ApiClientFactory.getAreasApiClient();
 
   const availableAreaTypes = await areasApi.getAreaTypes({}, API_CACHE_CONFIG);
-  const sortedByLevelAreaTypes = availableAreaTypes?.toSorted(
-    (a, b) => a.level - b.level
-  );
+  const sortedByHierarchyAndLevelAreaTypes = areaTypeSorter(availableAreaTypes);
 
   const determinedSelectedAreaType = determineSelectedAreaType(
     selectedAreaType as AreaTypeKeys,
@@ -107,7 +106,7 @@ export const getAreaFilterData = async (
   );
 
   return {
-    availableAreaTypes: sortedByLevelAreaTypes,
+    availableAreaTypes: sortedByHierarchyAndLevelAreaTypes,
     availableGroupTypes: sortedByLevelGroupTypes,
     availableGroups,
     availableAreas: sortedAlphabeticallyAvailableAreas,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-450](https://bjss-enterprise.atlassian.net/browse/DHSCFT-450)

Changed the sorting of the AreaType dropdown so that it gets sorted by Hierarchy and by Level within the hierarchy.

## Changes

- Added new helper class areaTypeSorter 
- Updated getAreaFilterData to use new helper class function
- Updated getAreaFilterData 
- Added new unit test class for new helper

## Validation

Added a new set of unit tests as well as updated the existing one that checked the sorting of this dropdown. 
