### PR TITLE
DHSCFT-464: Update links in header and footer

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/Footer/__snapshots__/Footer.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`FTFooter should match snapshot 1`] = `
             >
               <a
                 class="c6 c7"
-                href="#"
+                href="mailto:profilefeedback@dhsc.gov.uk?subject=Profile%20Feedback%20[General enquiry]"
               >
                 Contact
               </a>
@@ -325,7 +325,7 @@ exports[`FTFooter should match snapshot 1`] = `
             >
               <a
                 class="c6 c7"
-                href="#"
+                href="https://www.gov.uk/government/organisations/government-digital-service"
               >
                 Government Digital Service
               </a>

--- a/frontend/fingertips-frontend/components/molecules/Footer/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Footer/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { contactEmailLink, GDSLink } from '@/lib/links';
 import { GovukColours } from '@/lib/styleHelpers/colours';
 import { Footer, Link } from 'govuk-react';
 import styled from 'styled-components';
@@ -43,7 +44,7 @@ export function FTFooter() {
             <FooterLink href="#">Accessibility statement</FooterLink>
           </FooterListItem>
           <FooterListItem>
-            <FooterLink href="#">Contact</FooterLink>
+            <FooterLink href={contactEmailLink}>Contact</FooterLink>
           </FooterListItem>
           <FooterListItem>
             <FooterLink href="#">Terms and conditions</FooterLink>
@@ -52,7 +53,7 @@ export function FTFooter() {
             <FooterLink href="#">Rhestr o Wasanaethau Cymraeg</FooterLink>
           </FooterListItem>
           <FooterListItem>
-            <FooterLink href="#">Government Digital Service</FooterLink>
+            <FooterLink href={GDSLink}>Government Digital Service</FooterLink>
           </FooterListItem>
         </FooterContainer>
       }

--- a/frontend/fingertips-frontend/components/molecules/Header/__snapshots__/Header.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/Header/__snapshots__/Header.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`Header should match snapshot 1`] = `
               This is a new service - your 
               <a
                 class="c19"
-                href="#"
+                href="mailto:profilefeedback@dhsc.gov.uk?subject=Profile%20Feedback%20[General enquiry]"
               >
                 feedback
               </a>

--- a/frontend/fingertips-frontend/components/molecules/Header/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Header/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { contactEmailLink } from '@/lib/links';
 import { Link, Main, PhaseBanner, TopNav } from 'govuk-react';
 import styled from 'styled-components';
 
@@ -19,8 +20,9 @@ export function FTHeader() {
       />
       <ZeroPaddingMain>
         <PhaseBanner level="alpha">
-          This is a new service - your <Link href="#">feedback</Link> will help
-          us to improve it.
+          This is a new service - your{' '}
+          <Link href={contactEmailLink}>feedback</Link> will help us to improve
+          it.
         </PhaseBanner>
       </ZeroPaddingMain>
     </header>

--- a/frontend/fingertips-frontend/lib/links.ts
+++ b/frontend/fingertips-frontend/lib/links.ts
@@ -1,0 +1,5 @@
+export const contactEmailLink =
+  'mailto:profilefeedback@dhsc.gov.uk?subject=Profile%20Feedback%20[General enquiry]';
+
+export const GDSLink =
+  'https://www.gov.uk/government/organisations/government-digital-service';


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-464](https://bjss-enterprise.atlassian.net/browse/DHSCFT-464)

This PR updates the `Contact` link in the header and footer to include the same mailto link as is used for the `Contact us` links on the current [Fingertips](https://fingertips.phe.org.uk/) site, and updates the `Government Digital Service` link in the footer to use the same URL as the link in the footer of https://www.gov.uk/.

As we do not have pages to show for the rest of the footer links, these have not been updated.

## Changes

- Updated the URL of the `feedback` link in the header's "phase banner" (the bit that says "Alpha")
- Updated the URL of the `Contact` link in the footer
- Updated the URL of the `Government Digital Service` link in the footer

## Validation
Hovering over `feedback` link in header:
![Screenshot 2025-03-19 at 11 52 32](https://github.com/user-attachments/assets/32a0636b-1324-42ac-be53-38ced700861e)

Hovering over `Contact` link in footer:
![Screenshot 2025-03-19 at 11 52 56](https://github.com/user-attachments/assets/c0058702-7e28-4bd1-8285-a73d96b95aac)

Hovering over `Government Digital Service` link in footer:
![Screenshot 2025-03-19 at 11 53 06](https://github.com/user-attachments/assets/6379d7ac-46f2-4779-b737-3c04e5c8e935)
