### PR TITLE
DHSCFT-505 Remove defensive filters from filterIndicatorsByName

### DIFF
--- a/frontend/fingertips-frontend/playwright/testHelpers.ts
+++ b/frontend/fingertips-frontend/playwright/testHelpers.ts
@@ -134,11 +134,7 @@ function filterIndicatorsByName(
   return indicators.filter(
     (indicator) =>
       indicator.usedInPoc === true &&
-      indicator.indicatorName.toLowerCase().includes(normalizedSearchTerm) &&
-      // the following filters are needed due to an API bug see DHSCFT-434
-      !indicator.indicatorName.includes('years') &&
-      !indicator.indicatorName.includes('females') &&
-      !indicator.indicatorName.includes('sex')
+      indicator.indicatorName.toLowerCase().includes(normalizedSearchTerm)
   );
 }
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-505](https://bjss-enterprise.atlassian.net/browse/DHSCFT-505)

in DHSCFT-434: Fix inequalities functionality with real data - @Gareth Allan fixed an api issue that means i can safely remove some defensive filters from filterIndicatorsByName

## Validation

E2E and UI tests continue to pass
