### PR TITLE
DHSCFT-536: proposed fix for failing e2e tests

### DIFF
--- a/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
@@ -26,11 +26,14 @@ const testBase = baseTest.extend<{
       }
     });
 
-    const knownHighchartsExc = 'Cannot read properties of undefined (reading \'stacks\')';
+    const knownHighchartsExc =
+      "Cannot read properties of undefined (reading 'stacks')";
     // Uncaught exceptions
     page.on('pageerror', (error) => {
       if (failOnUnhandledError && error.message != knownHighchartsExc) {
-        throw new Error(`Page error: ${error.message}. Stack trace: ${error.stack}`);
+        throw new Error(
+          `Page error: ${error.message}. Stack trace: ${error.stack}`
+        );
       }
     });
 

--- a/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
@@ -26,10 +26,11 @@ const testBase = baseTest.extend<{
       }
     });
 
+    const knownHighchartsExc = 'Cannot read properties of undefined (reading \'stacks\')';
     // Uncaught exceptions
     page.on('pageerror', (error) => {
-      if (failOnUnhandledError) {
-        throw new Error(`Page error: ${error.message}`);
+      if (failOnUnhandledError && error.message != knownHighchartsExc) {
+        throw new Error(`Page error: ${error.message}. Stack trace: ${error.stack}`);
       }
     });
 

--- a/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
@@ -26,6 +26,7 @@ const testBase = baseTest.extend<{
       }
     });
 
+    // See DHSCFT-536 - for more details on exception
     const knownHighchartsExc =
       "Cannot read properties of undefined (reading 'stacks')";
     // Uncaught exceptions


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-536](https://bjss-enterprise.atlassian.net/browse/DHSCFT-536)

Since this morning, e2e tests (CD against deployed site) have been failing consistently.

To get to this change, I was running the `npm run test-e2e-ci-azure` against my locally running Docker setup. However, once DB deployments are complete I'll also try pointing it at the deployed environment.

**Cause:**
- When navigating to the 1 Indicator All areas in group page (which has the map and per area bar chart) an exception to do with Highcharts seems to be registered on the page.
- It is weird because I cannot see this when checking the console in the browser - all looks fine. Anyway, by surfacing the stack trace I was able to identify the full message and that it's something to do with Highcharts: https://github.com/highcharts/highcharts/issues/21276
- Ultimately it seems benign; the charts render correctly and when I put in handling for this error case all scenarios pass happily and reliably.
