### PR TITLE
DHSCFT-TECH: Updated the hardcoded indexes in trend-analysis

### DIFF
--- a/trend-analysis/TrendAnalysisApp.UnitTests/TrendDataProcessorTests.cs
+++ b/trend-analysis/TrendAnalysisApp.UnitTests/TrendDataProcessorTests.cs
@@ -22,10 +22,10 @@ public class TrendDataProcessorTests
     }
 
     [Theory]
-    [InlineData(1, 29, 2)]
-    [InlineData(2, 1, 2)] // Indicator 2 uses the default dimensions
-    [InlineData(5, 33, 1)]
-    [InlineData(19, 1, 1)]
+    [InlineData(2, 30, 3)]
+    [InlineData(3, 2, 3)] // Indicator 3 uses the default dimensions
+    [InlineData(5, 24, 3)]
+    [InlineData(20, 2, 2)] // Indicator 20 is female-only
     public void TestGetDefaultSearchDimsForIndicatorReturnsCorrectDimensions(
         short indicatorId,
         short expectedAgeDim,

--- a/trend-analysis/TrendAnalysisApp/Constants.cs
+++ b/trend-analysis/TrendAnalysisApp/Constants.cs
@@ -33,38 +33,38 @@ public static class Constants {
     }
 
     public static class Indicator {
-        // Default to using 1 = All ages
-        public const short DefaultAgeDimensionKey = 1;
-        // Default to using 0 = All
-        public const short DefaultDeprivationDimensionKey = 0;
-        // Default to using 2 = Persons
-        public const byte DefaultSexDimensionKey = 2;
+        // Default to using 2 = All ages
+        public const short DefaultAgeDimensionKey = 2;
+        // Default to using 1 = All
+        public const short DefaultDeprivationDimensionKey = 1;
+        // Default to using 3 = Persons
+        public const byte DefaultSexDimensionKey = 3;
 
         // A map containing any PoC indicators that do not use the standard dimensions
         public static readonly ReadOnlyDictionary<short, IndicatorSearchDimensions> NonStandardDimensionMap = new(
             new Dictionary<short, IndicatorSearchDimensions> {
-                {1, new IndicatorSearchDimensions(29, DefaultSexDimensionKey)},
-                {3, new IndicatorSearchDimensions(29, DefaultSexDimensionKey)},
-                {4, new IndicatorSearchDimensions(23, DefaultSexDimensionKey)},
-                {5, new IndicatorSearchDimensions(33, 1)},
-                {6, new IndicatorSearchDimensions(41, DefaultSexDimensionKey)},
-                {7, new IndicatorSearchDimensions(35, DefaultSexDimensionKey)},
-                {9, new IndicatorSearchDimensions(21, DefaultSexDimensionKey)},
-                {10, new IndicatorSearchDimensions(29, DefaultSexDimensionKey)},
-                {11, new IndicatorSearchDimensions(39, DefaultSexDimensionKey)},
-                {13, new IndicatorSearchDimensions(21, DefaultSexDimensionKey)},
-                {14, new IndicatorSearchDimensions(37, DefaultSexDimensionKey)},
-                {15, new IndicatorSearchDimensions(34, 1)},
-                {17, new IndicatorSearchDimensions(33, DefaultSexDimensionKey)},
-                {18, new IndicatorSearchDimensions(48, DefaultSexDimensionKey)},
-                {19, new IndicatorSearchDimensions(DefaultAgeDimensionKey, 1)},
-                {20, new IndicatorSearchDimensions(31, DefaultSexDimensionKey)},
-                {24, new IndicatorSearchDimensions(32, DefaultSexDimensionKey)},
-                {25, new IndicatorSearchDimensions(38, DefaultSexDimensionKey)},
-                {27, new IndicatorSearchDimensions(42, DefaultSexDimensionKey)},
-                {28, new IndicatorSearchDimensions(21, DefaultSexDimensionKey)},
-                {29, new IndicatorSearchDimensions(40, 1)},
-                {30, new IndicatorSearchDimensions(49, 1)}
+                {2, new IndicatorSearchDimensions(30, DefaultSexDimensionKey)},
+                {4, new IndicatorSearchDimensions(30, DefaultSexDimensionKey)},
+                {5, new IndicatorSearchDimensions(24, DefaultSexDimensionKey)},
+                {6, new IndicatorSearchDimensions(34, 2)},
+                {7, new IndicatorSearchDimensions(42, DefaultSexDimensionKey)},
+                {8, new IndicatorSearchDimensions(36, DefaultSexDimensionKey)},
+                {10, new IndicatorSearchDimensions(22, DefaultSexDimensionKey)},
+                {11, new IndicatorSearchDimensions(30, DefaultSexDimensionKey)},
+                {12, new IndicatorSearchDimensions(40, DefaultSexDimensionKey)},
+                {14, new IndicatorSearchDimensions(22, DefaultSexDimensionKey)},
+                {15, new IndicatorSearchDimensions(38, DefaultSexDimensionKey)},
+                {16, new IndicatorSearchDimensions(35, 2)},
+                {18, new IndicatorSearchDimensions(34, DefaultSexDimensionKey)},
+                {19, new IndicatorSearchDimensions(49, DefaultSexDimensionKey)},
+                {20, new IndicatorSearchDimensions(DefaultAgeDimensionKey, 2)},
+                {21, new IndicatorSearchDimensions(32, DefaultSexDimensionKey)},
+                {25, new IndicatorSearchDimensions(33, DefaultSexDimensionKey)},
+                {26, new IndicatorSearchDimensions(39, DefaultSexDimensionKey)},
+                {28, new IndicatorSearchDimensions(43, DefaultSexDimensionKey)},
+                {29, new IndicatorSearchDimensions(21, DefaultSexDimensionKey)},
+                {30, new IndicatorSearchDimensions(41, 2)},
+                {31, new IndicatorSearchDimensions(50, 2)}
             }
         );
     }


### PR DESCRIPTION
# Description

Jira ticket: NA Tech ticket

Since a recent change went into the DB, some of the indexes for the dimensions have changed.

This resulted in the Azure AI Search returning trendsForAreas as always an empty list (you can test this against the dev AI Search index). It demonstrates some of the limitations of my PoC approach for this, hopefully the indicator, age and sex dimension keys won't change again. But it does show that a more sustainable approach may need to be taken in future e.g. retrieving based on string value. However, unless the trend calculation is moved elsewhere we will always require some config data.

My change fixes the constants up to match the updated keys.

## Validation

Ran it locally and verified you now get trend data generated.
