### PR TITLE
use build and start for playwright tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: ${{ env.frontend-directory }}/package-lock.json
 
       - name: Install dependencies
@@ -39,6 +39,9 @@ jobs:
 
       - name: Run Playwright ui tests
         run: npm run test-ui-local-mocks
+        env:
+          FINGERTIPS_API_URL: http://localhost:5144
+          DHSC_AI_SEARCH_USE_MOCK_SERVICE: true
 
       - name: Upload playwright report and screenshot if ui tests fail - always on failure
         uses: actions/upload-artifact@v4

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -10,6 +10,7 @@
     "generate:ft-mocks": "npx msw-auto-mock ./../../api/definition/swagger.yaml -o ./mock/server",
     "build": "next build",
     "start": "next start",
+    "start-local-mocks": "cross-env MOCK_SERVER=true next start",
     "api:start": "COMPOSE_BAKE=true docker compose --profile api up --build",
     "api:stop": "docker compose --profile api down",
     "start:all": "COMPOSE_BAKE=true docker compose --profile all up --build --remove-orphans --wait -d",

--- a/frontend/fingertips-frontend/playwright.config.ts
+++ b/frontend/fingertips-frontend/playwright.config.ts
@@ -5,7 +5,9 @@ const url = process.env.FINGERTIPS_FRONTEND_URL || 'http://localhost:3000';
 console.log(`The target URL for this test execution is ${url}`); // allows to see where tests are executed
 const jobUrl = process.env.JOB_URL;
 const runCommand =
-  process.env.MOCK_SERVER === 'false' ? 'npm run dev-no-mocks' : 'npm run dev';
+  process.env.MOCK_SERVER === 'false'
+    ? 'npm run build && npm run start'
+    : 'npm run build && npm run start-local-mocks';
 
 // Create the base config
 const config: PlaywrightTestConfig = {
@@ -69,6 +71,7 @@ if (!process.env.FINGERTIPS_FRONTEND_URL) {
     command: runCommand,
     url: url,
     reuseExistingServer: true,
+    timeout: 120000,
   };
 }
 


### PR DESCRIPTION
# Description
Jira ticket: [DHSCFT-495](https://bjss-enterprise.atlassian.net/browse/DHSCFT-495)

Change playwright tests to use Next build and start rather than dev.

## Changes
add new script to package.json to start with local mocks
change playwright config to build and start. Also, increase timeout for webserver to allow for build time
pass configuration variables in github action

## Validation
npm run test-ui-local-mocks and npm run test-e2e-ci-azure (with local api) pass all tests.









