### PR TITLE
Add indicator ID to health data endpoint

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/IndicatorWithHealthDataForAreas.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Schemas/IndicatorWithHealthDataForAreas.cs
@@ -4,6 +4,9 @@ namespace DHSC.FingertipsNext.Modules.HealthData.Schemas;
 
 public class IndicatorWithHealthDataForAreas
 {
+    [JsonPropertyName("indicatorId")]
+    public int IndicatorId { get; init; }
+    
     [JsonPropertyName("name")]
     public string Name { get; init; } = string.Empty;
     

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
@@ -40,6 +40,7 @@ public class IndicatorService(IHealthDataRepository healthDataRepository, IMappe
         
         return new IndicatorWithHealthDataForAreas()
         {
+            IndicatorId = indicatorData.IndicatorId,
             Name = indicatorData.Name,
             StartDate = indicatorData.StartDate,
             EndDate = indicatorData.EndDate,

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -506,6 +506,10 @@ components:
       type: object
       description: Indicator information with area health data
       properties:
+        indicatorId:
+          type: integer
+          example: 21404
+          description: Unique ID of the indicator
         name:
           type: string
           example: Emergency readmissions within 30 days of discharge from hospital

--- a/frontend/fingertips-frontend/generated-sources/ft-api-client/models/IndicatorWithHealthDataForArea.ts
+++ b/frontend/fingertips-frontend/generated-sources/ft-api-client/models/IndicatorWithHealthDataForArea.ts
@@ -42,6 +42,12 @@ import {
  */
 export interface IndicatorWithHealthDataForArea {
     /**
+     * Unique ID of the indicator
+     * @type {number}
+     * @memberof IndicatorWithHealthDataForArea
+     */
+    indicatorId?: number;
+    /**
      * Name of the indicator
      * @type {string}
      * @memberof IndicatorWithHealthDataForArea
@@ -98,6 +104,7 @@ export function IndicatorWithHealthDataForAreaFromJSONTyped(json: any, ignoreDis
     }
     return {
         
+        'indicatorId': json['indicatorId'] == null ? undefined : json['indicatorId'],
         'name': json['name'] == null ? undefined : json['name'],
         'startDate': json['startDate'] == null ? undefined : json['startDate'],
         'endDate': json['endDate'] == null ? undefined : json['endDate'],
@@ -118,6 +125,7 @@ export function IndicatorWithHealthDataForAreaToJSONTyped(value?: IndicatorWithH
 
     return {
         
+        'indicatorId': value['indicatorId'],
         'name': value['name'],
         'startDate': value['startDate'],
         'endDate': value['endDate'],

--- a/frontend/fingertips-frontend/mock/server/handlers.ts
+++ b/frontend/fingertips-frontend/mock/server/handlers.ts
@@ -230,6 +230,7 @@ export function getGetHealthDataForAnIndicator200Response(
     areaCodes.includes(healthData.areaCode)
   );
   return {
+    indicatorId: Number(indicatorId),
     name: 'Indicator Name',
     benchmarkMethod: BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
     areaHealthData: !isAreaCodesEmpty(areaCodes)


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-542](https://bjss-enterprise.atlassian.net/jira/software/projects/DHSCFT/boards/823?assignee=557058%3A5e651a12-82ba-4f1e-b0d5-debb80721a37)

Adds indicator ID into the response from the health data endpoint

## Validation

All tests pass and manually validated by calling the API.
