### PR TITLE
DHSCFT-556: Skip full population indicators for trend analysis

### DIFF
--- a/trend-analysis/TrendAnalysisApp/Constants.cs
+++ b/trend-analysis/TrendAnalysisApp/Constants.cs
@@ -14,6 +14,19 @@ public static class Constants {
         public const int CommandTimeout = 120;
     }
 
+    public static class Indicator {
+        public const int GpRegisteredPopulationId = 337;
+        public const int ResidentPopulationId = 92708;
+
+        // IDs to skip for trend analysis. The following are full population indicators and are not
+        // displayed in the Fingertips website.
+        public static readonly IList<int> IdsToSkip = new ReadOnlyCollection<int>(
+        [
+            GpRegisteredPopulationId,
+            ResidentPopulationId
+        ]);
+    }
+
     public static class Polarity {
         public const string LowIsGood = "Low is good";
         public const string HighIsGood = "High is good";

--- a/trend-analysis/TrendAnalysisApp/Repository/HealthMeasureRepository.cs
+++ b/trend-analysis/TrendAnalysisApp/Repository/HealthMeasureRepository.cs
@@ -43,8 +43,11 @@ public class HealthMeasureRepository(HealthMeasureDbContext dbCtx)
     }
 
     public void UpdateTrendKey(HealthMeasureModel healthMeasure, byte newTrendKey) {
-        healthMeasure.TrendKey = newTrendKey;
-        _dbContext.Entry(healthMeasure).State = EntityState.Modified;
+        // Avoids registering an update in unlikely scenario where trend analysis is being rerun
+        if (healthMeasure.TrendKey != newTrendKey) {
+            healthMeasure.TrendKey = newTrendKey;
+            _dbContext.Entry(healthMeasure).State = EntityState.Modified;
+        }
     }
 
     public async Task SaveChanges() {

--- a/trend-analysis/TrendAnalysisApp/TrendDataProcessor.cs
+++ b/trend-analysis/TrendAnalysisApp/TrendDataProcessor.cs
@@ -55,11 +55,8 @@ public class TrendDataProcessor(
             var mostRecentDataPoints = hmGroup
                 .OrderByDescending(hm => hm.Year)
                 .Take(TrendCalculator.RequiredNumberOfDataPoints);
-            
-            if (
-                !mostRecentDataPoints.Any() ||
-                mostRecentDataPoints.First().TrendDimension.Name != Constants.Trend.NotYetCalculated
-            ) { continue; }
+
+            if (!mostRecentDataPoints.Any()) { continue; }
 
             var trend = trendCalculator.CalculateTrend(indicator, mostRecentDataPoints);
             healthMeasureRepository.UpdateTrendKey(mostRecentDataPoints.First(), (byte) trend);
@@ -91,7 +88,9 @@ public class TrendDataProcessor(
     public async Task Process(ServiceProvider serviceProvider)
     {
         var indicators = await _indicatorRepo.GetAll();
-        var tasks = indicators.Select(indicator => 
+        var tasks = indicators
+        .Where(indicator => !Constants.Indicator.IdsToSkip.Contains(indicator.IndicatorId))
+        .Select(indicator => 
         {
             return Task.Run(async () =>
             {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-556](https://bjss-enterprise.atlassian.net/browse/DHSCFT-556)

Increases robustness and reliability of the trend analysis app.

## Changes

- Main change is to skip trend analysis calculation for the indicators as discussed here: https://bjss.slack.com/archives/C08335HN952/p1743409304149789 Specifically that is `337` and `92708`. I am using the Fingertips IndicatorIds rather than key as I find this varies sometimes between local and deployed DB. IndicatorId is reliably constant.

There is an additional change for a bug I noticed. Occasionally when the job fails we have to rerun it. A while back, I had the application skip calculating trends if it saw that the trend had already been calculated. This failed to take into account reruns. At the time it was not an issue, but since we have started loading trend data for search, this presents a potential issue.

Replication steps:
- Trend analysis step times out in the pipeline. Several indicators were processed successfully but one or two failed. Therefore the DB is in a state of partially calculated trends.
- The step is rerun, this time the remaining indicators are processed. However, because the already processed ones were skipped, they will not have trends written to the JSON file which is passed to the search-setup step.

This will most likely be mitigated by the fact that the change is going to make the step much more reliable and unlikely to need rerunning. However, that cannot be guaranteed so I added code to make the process repeatable.

Now, the trend-analysis tool will still calculate the trend each time (so the exact same and correct data will be written to JSON), only we shall skip updating the DB if we notice we've already calculated the value.

I did think maybe we could wrap with a transac i.e. fail one, fail all, but due to parallel use of DB Context I think that would be quite tricky, and the above approach should do.

## Validation

Ran locally and verified that the 2 population indicators were skipped - was very fast too.
Ran locally for a second time after the data had been processed and verified that the JSON file for search gets correctly updated again.

