### PR TITLE
DHSCFT-557 - Part 2 - pin the sub dependency to latest

### DIFF
--- a/frontend/fingertips-frontend/package-lock.json
+++ b/frontend/fingertips-frontend/package-lock.json
@@ -35,7 +35,7 @@
         "@eslint/js": "^9.17.0",
         "@estruyf/github-actions-reporter": "^1.10.0",
         "@faker-js/faker": "^9.3.0",
-        "@openapitools/openapi-generator-cli": "2.18.3",
+        "@openapitools/openapi-generator-cli": "^2.18.4",
         "@playwright/test": "^1.51.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3178,9 +3178,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.15",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.15.tgz",
-      "integrity": "sha512-vaLg1ZgwhG29BuLDxPA9OAcIlgqzp9/N8iG0wGapyUNTf4IY4O6zAHgN6QalwLhFxq7nOI021vdRojR1oF3bqg==",
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.12.tgz",
+      "integrity": "sha512-6PXxmDe2iYmb57xacnxzpW1NAxRZ7Gf+acMT7/hmRB/4KpZiFU/cNvLWwgbM2BL5QSzQulOwY6ny5bbKnPpB+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3483,9 +3483,9 @@
       "license": "MIT"
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.18.3.tgz",
-      "integrity": "sha512-dqK+Q+PXyok9EtyLXKKEmT5HZt67uPuJjx/DTQVyurhgIBbVrJN4p9j1lVC6bIH7fnYIux4QCZCaYFovTaJfng==",
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.18.4.tgz",
+      "integrity": "sha512-wer7rWp92fLcHqRG/2XS2bGqGUo2qVO0MseUgcpbxyVzBrKZZJh5c0dxQWTD3V178laj1ndC6w1Parn3fjKolg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3500,7 +3500,7 @@
         "compare-versions": "4.1.4",
         "concurrently": "6.5.1",
         "console.table": "0.10.0",
-        "fs-extra": "10.1.0",
+        "fs-extra": "11.3.0",
         "glob": "9.3.5",
         "inquirer": "8.2.6",
         "lodash": "4.17.21",
@@ -8473,9 +8473,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8484,7 +8484,7 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {

--- a/frontend/fingertips-frontend/package.json
+++ b/frontend/fingertips-frontend/package.json
@@ -55,7 +55,7 @@
     "@eslint/js": "^9.17.0",
     "@estruyf/github-actions-reporter": "^1.10.0",
     "@faker-js/faker": "^9.3.0",
-    "@openapitools/openapi-generator-cli": "2.18.3",
+    "@openapitools/openapi-generator-cli": "^2.18.4",
     "@playwright/test": "^1.51.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -96,6 +96,6 @@
       "styled-components": "^5.3.0"
     },
     "whatwg-url": "^14.0.0",
-    "@openapitools/openapi-generator-cli": "2.18.3"
+    "@nestjs/common": "^11.0.12"
   }
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-557](https://bjss-enterprise.atlassian.net/browse/DHSCFT-557)

Tried downgrading the top level dependency that we use in previous PR but that didnt work as the lower version also used the same dub dependency - https://www.npmjs.com/package/@nestjs/common

## Changes

- pinned sub dependency to latest

## Validation

pipeline green