### PR TITLE
Feature/dhscft 565 increase healthdata max area batch

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
@@ -20,16 +20,14 @@ public class IndicatorService(IHealthDataRepository healthDataRepository, IMappe
     /// </summary>
     /// <param name="indicatorId"></param>
     /// <param name="areaCodes">
-    ///     An array of upto 10 area codes. If more than 10 elements exist,
-    ///     only the first 10 are used. If the array is empty all area codes are retrieved.
+    ///     An array of area codes. If the array is empty all area codes are retrieved.
     /// </param>
     /// <param name="areaType">
     ///     The areaType which these codes should be compared against. This is important to specify to discriminate between
     ///     counties and districts which introduce amiguity to the areaType by duplicating areas.
     /// </param>
     /// <param name="years">
-    ///     An array of upto 10 years. If more than 10 elements exist,
-    ///     only the first 10 are used. If the array is empty all years are retrieved.
+    ///     An array of years. If the array is empty all years are retrieved.
     /// </param>
     /// <param name="inequalities">
     ///     An array of inequality dimensions to return. If the array is empty only data with no

--- a/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
@@ -10,11 +10,8 @@ namespace DHSC.FingertipsNext.Modules.HealthData.Controllers.V1;
 [Route("indicators")]
 public class IndicatorsController(IIndicatorsService indicatorsService) : ControllerBase
 {
-    private const int MaxNumberAreas = 10;
-    private const int MaxNumberYears = 10;
-
-    private const string TooManyParametersMessage =
-        "Too many values supplied for parameter {0}. The maximum is 10 but {1} supplied.";
+    private const int MaxNumberAreas = 100;
+    private const int MaxNumberYears = 20;
 
     private readonly IIndicatorsService _indicatorsService = indicatorsService;
 
@@ -24,9 +21,9 @@ public class IndicatorsController(IIndicatorsService indicatorsService) : Contro
     /// supplying one or more area codes and one or more years in the query string.
     /// </summary>
     /// <param name="indicatorId">The unique identifier of the indicator.</param>
-    /// <param name="areaCodes">A list of area codes. Up to 10 distinct area codes can be requested.</param>
+    /// <param name="areaCodes">A list of area codes. Up to 100 distinct area codes can be requested.</param>
     /// <param name="areaType">The area type the area codes belong to.</param>
-    /// <param name="years">A list of years. Up to 10 distinct years can be requested.</param>
+    /// <param name="years">A list of years. Up to 20 distinct years can be requested.</param>
     /// <param name="inequalities">A list of desired inequalities.</param>
     /// <returns></returns>
     /// <remarks>

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -226,10 +226,10 @@ paths:
               examples:
                 Too many area_codes:
                   value:
-                    message: Too many values supplied for parameter area_codes. The maximum is 10 but 11 supplied.
+                    message: Too many values supplied for parameter area_codes. The maximum is 100 but 101 supplied.
                 Too many years:
                   value:
-                    message: Too many values supplied for parameter years. The maximum is 10 but 11 supplied.
+                    message: Too many values supplied for parameter years. The maximum is 20 but 21 supplied.
         "500":
           $ref: "#/components/responses/InternalServerError"
       parameters:
@@ -568,14 +568,14 @@ components:
     years:
       in: query
       name: years
-      description: A list of years, up to 10 years can be requested
+      description: A list of years, up to 20 years can be requested
       style: form
       schema:
         type: array
         items:
           type: integer
           example: 2023
-        maxItems: 10
+        maxItems: 20
     area_code:
       in: path
       name: area_code
@@ -630,14 +630,14 @@ components:
     area_codes:
       in: query
       name: area_codes
-      description: A list of area codes, up to 10 area codes can be requested
+      description: A list of area codes, up to 100 area codes can be requested
       style: form
       schema:
         type: array
         items:
           type: string
           example: G82109
-        maxItems: 10
+        maxItems: 100
     area_type:
       in: query
       name: area_type

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -98,7 +98,7 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
 
   it('should make appropriate number of calls to the healthIndicatorApi with the expected parameters with a long list of areas', async () => {
     const testIndicators = '1';
-    const testAreas = new Array(15).fill('a', 0, 15);
+    const testAreas = new Array(101).fill('a', 0, 101);
     const testGroup = 'G001';
 
     const searchState: SearchStateParams = {
@@ -124,13 +124,10 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
     };
 
     const expected2 = {
-      areaCodes: ['a', 'a', 'a', 'a', 'a', 'E92000001', 'G001'],
+      areaCodes: ['a', 'E92000001', 'G001'],
       indicatorId: Number(testIndicators),
     };
 
-    expect(
-      mockIndicatorsApi.getHealthDataForAnIndicator
-    ).toHaveBeenNthCalledWith(1, expected1, API_CACHE_CONFIG);
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator
     ).toHaveBeenNthCalledWith(2, expected2, API_CACHE_CONFIG);

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -118,10 +118,19 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
       2
     );
 
+    const expected1 = {
+      areaCodes: new Array(100).fill('a', 0, 100),
+      indicatorId: Number(testIndicators),
+    };
+
     const expected2 = {
       areaCodes: ['a', 'E92000001', 'G001'],
       indicatorId: Number(testIndicators),
     };
+
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(1, expected1, API_CACHE_CONFIG);
 
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -118,11 +118,6 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
       2
     );
 
-    const expected1 = {
-      areaCodes: ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'],
-      indicatorId: Number(testIndicators),
-    };
-
     const expected2 = {
       areaCodes: ['a', 'E92000001', 'G001'],
       indicatorId: Number(testIndicators),

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
@@ -12,7 +12,10 @@ import {
   AreaTypeKeysForMapMeta,
   getMapGeographyData,
 } from '@/components/organisms/ThematicMap/thematicMapHelpers';
-import { chunkArray, maxNumAreasThatCanBeRequestedAPI } from '@/lib/ViewsHelpers';
+import {
+  chunkArray,
+  maxNumAreasThatCanBeRequestedAPI,
+} from '@/lib/ViewsHelpers';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 
 export default async function OneIndicatorTwoOrMoreAreasView({

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
@@ -12,7 +12,7 @@ import {
   AreaTypeKeysForMapMeta,
   getMapGeographyData,
 } from '@/components/organisms/ThematicMap/thematicMapHelpers';
-import { chunkArray, maxIndicatorAPIRequestSize } from '@/lib/ViewsHelpers';
+import { chunkArray, maxNumAreasThatCanBeRequestedAPI } from '@/lib/ViewsHelpers';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 
 export default async function OneIndicatorTwoOrMoreAreasView({
@@ -50,7 +50,7 @@ export default async function OneIndicatorTwoOrMoreAreasView({
   let indicatorData: IndicatorWithHealthDataForArea | undefined;
   try {
     const healthIndicatorDataChunks = await Promise.all(
-      chunkArray(areaCodesToRequest, maxIndicatorAPIRequestSize).map(
+      chunkArray(areaCodesToRequest, maxNumAreasThatCanBeRequestedAPI).map(
         (requestAreas) =>
           indicatorApi.getHealthDataForAnIndicator(
             {

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.ts
@@ -1,4 +1,4 @@
-export const maxIndicatorAPIRequestSize = 10;
+export const maxNumAreasThatCanBeRequestedAPI = 100;
 export function chunkArray(arrayToChunk: string[], chunkSize: number) {
   const chunkedArray = [];
   for (let i = 0; i < arrayToChunk.length; i += chunkSize) {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-565](https://bjss-enterprise.atlassian.net/browse/DHSCFT-565)

Increase the limit of areas that can be requested in the health data endpoint from 10 to 100 to improve performance for large groups.

## Changes

- Increase the limit to 100 in the API, updating swagger to match
- Increase the limit in the front-end
- Fix front end tests

## Validation

All tests run