### PR TITLE
Feature/dhscft 569 get area data multiple

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
@@ -30,7 +30,7 @@ public class AreaRepository : IAreaRepository
     /// Retrieves a list of area models based on the requested area codes.
     /// </summary>
     /// <param name="areaCodes"></param>
-    /// <returns></returns>
+    /// <returns>List of areas requested</returns>
     public async Task<List<AreaModel>> GetMultipleAreaDetailsAsync(string[] areaCodes)
     {
         return await _dbContext.Area

--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
@@ -27,6 +27,32 @@ public class AreaRepository : IAreaRepository
             .ToListAsync();
 
     /// <summary>
+    /// Retrieves a list of area models based on the requested area codes.
+    /// </summary>
+    /// <param name="areaCodes"></param>
+    /// <returns></returns>
+    public async Task<List<AreaModel>> GetMultipleAreaDetailsAsync(string[] areaCodes)
+    {
+        return await _dbContext.Area
+            .Where(area => EF.Constant(areaCodes).Contains(area.AreaCode))
+            .Include(area => area.AreaType)
+            .Select(area => new AreaModel
+            {
+                AreaCode = area.AreaCode,
+                AreaName = area.AreaName,
+                AreaType = new AreaTypeModel
+                {
+                    AreaTypeKey = area.AreaType.AreaTypeKey,
+                    AreaTypeName = area.AreaType.AreaTypeName,
+                    HierarchyType = area.AreaType.HierarchyType,
+                    Level = area.AreaType.Level
+                }
+            })
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
+    /// <summary>
     ///
     /// </summary>
     /// <param name="hierarchyType"></param>

--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/AreaRepository.cs
@@ -121,6 +121,10 @@ public class AreaRepository : IAreaRepository
             .AsSplitQuery()
             .FirstOrDefaultAsync();
 
+        if (area == null) {
+            return null;
+        }
+
         var areasWithRelations = new AreaWithRelationsModel
         {
             Area = area,

--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/IAreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/IAreaRepository.cs
@@ -14,6 +14,13 @@ public interface IAreaRepository
     Task<List<string>> GetHierarchiesAsync();
 
     /// <summary>
+    /// Retrieves a list of area models based on the requested area codes.
+    /// </summary>
+    /// <param name="areaCodes"></param>
+    /// <returns></returns>
+    Task<List<AreaModel>> GetMultipleAreaDetailsAsync(string[] areaCodes);
+
+    /// <summary>
     ///
     /// </summary>
     /// <param name="hierarchyType"></param>

--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/IAreaRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/IAreaRepository.cs
@@ -17,7 +17,7 @@ public interface IAreaRepository
     /// Retrieves a list of area models based on the requested area codes.
     /// </summary>
     /// <param name="areaCodes"></param>
-    /// <returns></returns>
+    /// <returns>List of areas requested</returns>
     Task<List<AreaModel>> GetMultipleAreaDetailsAsync(string[] areaCodes);
 
     /// <summary>

--- a/api/DHSC.FingertipsNext.Modules.Area.Repository/Models/AreaModel.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Repository/Models/AreaModel.cs
@@ -15,7 +15,7 @@ public class AreaModel
     /// The unique area key of the area - this is a surrogate key
     /// </summary>
     [Key]
-    public required int AreaKey { get; set; }
+    public int AreaKey { get; set; }
 
     /// <summary>
     /// The area code of the area - may not be unique because
@@ -41,7 +41,7 @@ public class AreaModel
     /// 
     /// </summary>
     [MaxLength(50)]
-    public required string AreaTypeKey { get; set; }
+    public string AreaTypeKey { get; set; }
     
     public virtual ICollection<AreaModel> Children { get; set; }
     

--- a/api/DHSC.FingertipsNext.Modules.Area.Service/AreaService.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Service/AreaService.cs
@@ -32,6 +32,16 @@ public class AreaService : IAreaService
         _areaRepository.GetHierarchiesAsync();
 
     /// <summary>
+    /// Gets a list of areas for the list of requested area codes.
+    /// </summary>
+    /// <param name="areaCodes"></param>
+    /// <returns></returns>
+    public async Task<List<Schemas.Area>> GetMultipleAreaDetails(string[] areaCodes)
+    {
+        return _mapper.Map<List<Schemas.Area>>(await _areaRepository.GetMultipleAreaDetailsAsync(areaCodes));
+    }
+
+    /// <summary>
     ///
     /// </summary>
     /// <param name="hierarchyType"></param>

--- a/api/DHSC.FingertipsNext.Modules.Area.Service/AreaService.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Service/AreaService.cs
@@ -35,7 +35,7 @@ public class AreaService : IAreaService
     /// Gets a list of areas for the list of requested area codes.
     /// </summary>
     /// <param name="areaCodes"></param>
-    /// <returns></returns>
+    /// <returns>List of areas requested</returns>
     public async Task<List<Schemas.Area>> GetMultipleAreaDetails(string[] areaCodes)
     {
         return _mapper.Map<List<Schemas.Area>>(await _areaRepository.GetMultipleAreaDetailsAsync(areaCodes));

--- a/api/DHSC.FingertipsNext.Modules.Area.Service/IAreaService.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Service/IAreaService.cs
@@ -14,6 +14,13 @@ public interface IAreaService
     public Task<List<string>> GetHierarchies();
 
     /// <summary>
+    /// Gets a list of areas for the list of requested area codes.
+    /// </summary>
+    /// <param name="areaCodes"></param>
+    /// <returns></returns>
+    public Task<List<Schemas.Area>> GetMultipleAreaDetails(string[] areaCodes);
+
+    /// <summary>
     /// Get area types, optionally filtering by hierarchy type
     /// </summary>
     /// <param name="hierarchyType"></param>

--- a/api/DHSC.FingertipsNext.Modules.Area.Service/IAreaService.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.Service/IAreaService.cs
@@ -17,7 +17,7 @@ public interface IAreaService
     /// Gets a list of areas for the list of requested area codes.
     /// </summary>
     /// <param name="areaCodes"></param>
-    /// <returns></returns>
+    /// <returns>List of areas requested</returns>
     public Task<List<Schemas.Area>> GetMultipleAreaDetails(string[] areaCodes);
 
     /// <summary>

--- a/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Fakers/AreaRelationsModelFaker.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Fakers/AreaRelationsModelFaker.cs
@@ -1,0 +1,15 @@
+using Bogus;
+using DHSC.FingertipsNext.Modules.Area.Repository.Models;
+
+namespace DHSC.FingertipsNext.Modules.Area.UnitTests.Fakers;
+
+public class AreaNoRelationsModelFaker: Faker<AreaModel>
+{
+    public AreaNoRelationsModelFaker()
+    {
+        RuleFor(a => a.AreaKey, f => f.IndexFaker);
+        RuleFor(a => a.AreaName, f => f.Lorem.Sentence(4));
+        RuleFor(a => a.AreaCode, f => f.Random.Guid().ToString());
+        RuleFor(a => a.AreaType, f => Fake.AreaTypeModel);
+    }
+}

--- a/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Fakers/Fake.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Fakers/Fake.cs
@@ -10,4 +10,7 @@ public static class Fake
 
     public static AreaWithRelationsModel AreaWithRelationsModel =>
         new AreaWithRelationsModelFaker().Generate();
+
+    public static AreaModel AreaNoRelationsModel =>
+        new AreaNoRelationsModelFaker().Generate();
 }

--- a/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Service/AreaServiceTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area.UnitTests/Service/AreaServiceTests.cs
@@ -158,4 +158,49 @@ public class AreaServiceTests
     }
     
     #endregion
+
+    #region GetMultipleAreaDetails
+
+    [Fact]
+    public async Task GetMultipleAreaDetails_ShouldReturnedMappedResult_IfRepositoryReturnsAreas()
+    {
+        var fakeAreaWithNoRelationsModel = new List<AreaModel>
+        {
+            Fake.AreaNoRelationsModel,
+            Fake.AreaNoRelationsModel
+        };
+        _mockRepository
+            .GetMultipleAreaDetailsAsync(Arg.Any<string[]>())
+            .Returns(fakeAreaWithNoRelationsModel);
+
+        var result = await _service.GetMultipleAreaDetails(["areaOne", "districtNine"]);
+
+        await _mockRepository.Received(1).GetMultipleAreaDetailsAsync(
+            Arg.Is<string[]>(areaCodes => areaCodes[0] == "areaOne" && areaCodes[1] == "districtNine")
+        );
+        result.Count.ShouldBe(2);
+        result[0].ShouldBeEquivalentTo(
+            _mapper.Map<Schemas.Area>(fakeAreaWithNoRelationsModel[0])
+        );
+        result[1].ShouldBeEquivalentTo(
+            _mapper.Map<Schemas.Area>(fakeAreaWithNoRelationsModel[1])
+        );
+    }
+
+    [Fact]
+    public async Task GetMultipleAreaDetails_ShouldReturnedEmptyList_IfRepositoryReturnsEmpty()
+    {
+        _mockRepository
+            .GetMultipleAreaDetailsAsync(Arg.Any<string[]>())
+            .Returns(new List<AreaModel>{});
+
+        var result = await _service.GetMultipleAreaDetails(["areaOne"]);
+
+        await _mockRepository.Received(1).GetMultipleAreaDetailsAsync(
+            Arg.Is<string[]>(areaCodes => areaCodes[0] == "areaOne")
+        );
+        result.Count.ShouldBe(0);
+    }
+
+    #endregion
 }

--- a/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
@@ -18,6 +18,7 @@ namespace DHSC.FingertipsNext.Modules.Area.Controllers.V1;
 public class AreaController : ControllerBase
 {
     private readonly IAreaService _areaService;
+    private const int MaxNumberAreas = 100;
 
     /// <summary>
     ///
@@ -42,18 +43,22 @@ public class AreaController : ControllerBase
     )
     {
         // Could discuss in PR - .IsNullOrEmpty() is nicer but makes the linter sad - why?
-        if (areaCodes == null || areaCodes.Length == 0) {
+        if (areaCodes == null || areaCodes.Length == 0)
             return new BadRequestObjectResult(new SimpleError
             {
-                Message = "Please provide at least one area for the parameter area_codes"
+                Message = "Please provide at least one value for the parameter area_codes"
             });
-        }
+
+        if (areaCodes is {Length: > MaxNumberAreas})
+            return new BadRequestObjectResult(new SimpleError
+            {
+                Message =
+                    $"Too many values supplied for parameter area_codes. The maximum is {MaxNumberAreas} but {areaCodes.Length} supplied."
+            });
 
         var areasData = await _areaService.GetMultipleAreaDetails(areaCodes);
 
-        if (areasData.IsNullOrEmpty()) {
-            return NotFound();
-        }
+        if (areasData.IsNullOrEmpty()) return NotFound();
 
         return Ok(areasData);
     }

--- a/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
@@ -5,8 +5,6 @@ using DHSC.FingertipsNext.Modules.Area.Service;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
-using AutoMapper.Internal;
-using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace DHSC.FingertipsNext.Modules.Area.Controllers.V1;
 
@@ -27,12 +25,12 @@ public class AreaController : ControllerBase
     public AreaController(IAreaService areaService) => _areaService = areaService;
 
     /// <summary>
-    /// Gets the fulls details of each of the areas requested by the client.
+    /// Gets the details of each area requested by the client.
     /// </summary>
     /// <param name="areaCodes">A list of area codes provided in the query params</param>
     /// <returns>The corresponding area data for the list of area codes provided</returns>
     /// <remarks>
-    /// If not area codes are provided then a client error response is returned.
+    /// If no area codes are provided then a client error response is returned.
     /// </remarks>
     [HttpGet]
     [ProducesResponseType(typeof(List<Schemas.Area>), StatusCodes.Status200OK)]
@@ -42,7 +40,6 @@ public class AreaController : ControllerBase
         [FromQuery(Name = "area_codes")] string[]? areaCodes = null
     )
     {
-        // Could discuss in PR - .IsNullOrEmpty() is nicer but makes the linter sad - why?
         if (areaCodes == null || areaCodes.Length == 0)
             return new BadRequestObjectResult(new SimpleError
             {

--- a/api/DHSC.FingertipsNext.Modules.Area/DHSC.FingertipsNext.Modules.Area.csproj
+++ b/api/DHSC.FingertipsNext.Modules.Area/DHSC.FingertipsNext.Modules.Area.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.Area.Repository\DHSC.FingertipsNext.Modules.Area.Repository.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.Area.Service\DHSC.FingertipsNext.Modules.Area.Service.csproj" />
+      <ProjectReference Include="..\DHSC.FingertipsNext.Modules.Common.Schemas\DHSC.FingertipsNext.Modules.Common.Schemas.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Monolith\DHSC.FingertipsNext.Monolith.csproj" />
     </ItemGroup>
 

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-area-code_.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-area-code_.http
@@ -61,4 +61,13 @@ GET http://localhost:5144/areas/E92000001?include_children=true&child_area_type=
     });
 %}
 
+### check endpoint returns a not found error for an area code which does not exist.
+GET http://localhost:5144/areas/narnia
+
+> {%
+    client.test("Expected not found error received", function (callbackfn, thisArg) {
+        client.assert(response.status === 404, "Response status is not 404");
+    });
+%}
+
 ###

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas-response.json
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas-response.json
@@ -1,0 +1,22 @@
+[
+  {
+    "code": "E12000001",
+    "name": "North East Region",
+    "areaType": {
+      "key": "regions",
+      "name": "Regions",
+      "hierarchyName": "Administrative",
+      "level": 2
+    }
+  },
+  {
+    "code": "E12000003",
+    "name": "Yorkshire And The Humber Region",
+    "areaType": {
+      "key": "regions",
+      "name": "Regions",
+      "hierarchyName": "Administrative",
+      "level": 2
+    }
+  }
+]

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
@@ -39,3 +39,5 @@ GET http://localhost:5144/areas?area_codes=narnia
         client.assert(response.status === 404, "Response status is not 404");
     });
 %}
+
+###

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
@@ -8,7 +8,12 @@ GET http://localhost:5144/areas?area_codes=E12000001&area_codes=E12000003
 
     client.test("Expected areas returned in response", function (callbackfn, thisArg) {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(JSON.stringify(response.body) === JSON.stringify(expected), "Response body does not match");
+        client.assert(response.body.length === expected.length, "Receieved unexpected number of areas");
+
+        // Cannot guarantee order in which areas are returned, hence the assertion approach
+        client.assert(JSON.stringify(response.body).length === JSON.stringify(expected).length, "Received unexpected response");
+        client.assert((response.body[0].name === "North East Region" || response.body[0].name === "Yorkshire and the Humber Region"), "Received unexpected area");
+        client.assert((response.body[1].name === "North East Region" || response.body[1].name === "Yorkshire and the Humber Region"), "Received unexpected area");
     });
 %}
 
@@ -16,11 +21,13 @@ GET http://localhost:5144/areas?area_codes=E12000001&area_codes=E12000003
 GET http://localhost:5144/areas
 
 > {%
-    const validationErrorMessage = "Please provide at least one area for the parameter area_codes";
+    const expected = {
+        "message": "Please provide at least one value for the parameter area_codes"
+    }
 
     client.test("Expected validation error received", function (callbackfn, thisArg) {
         client.assert(response.status === 400, "Response status is not 400");
-        client.assert(response.body.message === validationErrorMessage, "Received unexpected validation error message");
+        client.assert(JSON.stringify(response.body) === JSON.stringify(expected), "Received unexpected validation error message");
     });
 %}
 

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
@@ -1,0 +1,34 @@
+### check get multiple areas returns the list of area details for the requested area codes.
+
+# North East Region and Yorkshire and the Humber Region
+GET http://localhost:5144/areas?area_codes=E12000001&area_codes=E12000003
+
+> {%
+    const expected = require ('./test-areas-multiple-areas-response.json');
+
+    client.test("Expected areas returned in response", function (callbackfn, thisArg) {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(JSON.stringify(response.body) === JSON.stringify(expected), "Response body does not match");
+    });
+%}
+
+### check endpoint returns validation error if no area codes provided.
+GET http://localhost:5144/areas
+
+> {%
+    const validationErrorMessage = "Please provide at least one area for the parameter area_codes";
+
+    client.test("Expected validation error received", function (callbackfn, thisArg) {
+        client.assert(response.status === 400, "Response status is not 400");
+        client.assert(response.body.message === validationErrorMessage, "Received unexpected validation error message");
+    });
+%}
+
+### check endpoint returns a not found error for an area code which does not exist.
+GET http://localhost:5144/areas?area_codes=narnia
+
+> {%
+    client.test("Expected not found error received", function (callbackfn, thisArg) {
+        client.assert(response.status === 404, "Response status is not 404");
+    });
+%}

--- a/api/DHSC.FingertipsNext.Modules.Common.Schemas/DHSC.FingertipsNext.Modules.Common.Schemas.csproj
+++ b/api/DHSC.FingertipsNext.Modules.Common.Schemas/DHSC.FingertipsNext.Modules.Common.Schemas.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/api/DHSC.FingertipsNext.Modules.Common.Schemas/SimpleError.cs
+++ b/api/DHSC.FingertipsNext.Modules.Common.Schemas/SimpleError.cs
@@ -1,6 +1,6 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
-namespace DHSC.FingertipsNext.Modules.HealthData.Schemas;
+namespace DHSC.FingertipsNext.Modules.Common.Schemas;
 
 public class SimpleError
 {

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Controllers/V1/IndicatorsControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using DHSC.FingertipsNext.Modules.HealthData.Controllers.V1;
+﻿using DHSC.FingertipsNext.Modules.Common.Schemas;
+using DHSC.FingertipsNext.Modules.HealthData.Controllers.V1;
 using DHSC.FingertipsNext.Modules.HealthData.Schemas;
 using DHSC.FingertipsNext.Modules.HealthData.Service;
 using Microsoft.AspNetCore.Mvc;

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/DHSC.FingertipsNext.Modules.HealthData.UnitTests.csproj
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/DHSC.FingertipsNext.Modules.HealthData.UnitTests.csproj
@@ -32,6 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\DHSC.FingertipsNext.Modules.Common.Schemas\DHSC.FingertipsNext.Modules.Common.Schemas.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.HealthData.Schemas\DHSC.FingertipsNext.Modules.HealthData.Schemas.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.HealthData\DHSC.FingertipsNext.Modules.HealthData.csproj" />
     </ItemGroup>

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Services/IndicatorServiceTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Services/IndicatorServiceTests.cs
@@ -559,7 +559,6 @@ public class IndicatorServiceTests
         new object[] { "Bar", "Low is good", IndicatorPolarity.LowIsGood, "Confidence intervals overlapping reference value (99.8)", BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8  },
         new object[] { "Bar", "No judgement", IndicatorPolarity.NoJudgement, "Confidence intervals overlapping reference value (99.8)", BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8  },
         new object[] { "Bar", "", IndicatorPolarity.Unknown, "", BenchmarkComparisonMethod.Unknown },
-        new object[] { "Foo", "High is good", IndicatorPolarity.HighIsGood, "Confidence intervals overlapping reference value (95.0)", BenchmarkComparisonMethod.CIOverlappingReferenceValue95  },
         new object[] { "Foo", "", IndicatorPolarity.Unknown, "Quintiles", BenchmarkComparisonMethod.Quintiles  },
     };
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+﻿using DHSC.FingertipsNext.Modules.Common.Schemas;
 using DHSC.FingertipsNext.Modules.HealthData.Schemas;
 using DHSC.FingertipsNext.Modules.HealthData.Service;
 using Microsoft.AspNetCore.Http;

--- a/api/DHSC.FingertipsNext.Modules.HealthData/DHSC.FingertipsNext.Modules.HealthData.csproj
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/DHSC.FingertipsNext.Modules.HealthData.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\DHSC.FingertipsNext.Modules.Common.Schemas\DHSC.FingertipsNext.Modules.Common.Schemas.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.HealthData.Repository\DHSC.FingertipsNext.Modules.HealthData.Repository.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.HealthData.Schemas\DHSC.FingertipsNext.Modules.HealthData.Schemas.csproj" />
       <ProjectReference Include="..\DHSC.FingertipsNext.Modules.HealthData.Service\DHSC.FingertipsNext.Modules.HealthData.Service.csproj" />

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -81,7 +81,7 @@ paths:
     get:
       tags:
         - areas
-      summary: Get area
+      summary: Get single area
       description: Get the full details of a given area, including it's parents, optionally including it's children, siblings and cousins
       operationId: getArea
       parameters:
@@ -114,6 +114,43 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RootArea"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /areas:
+    get:
+      tags:
+        - areas
+      summary: Get multiple areas
+      description: Get the basic details without children, parent relationships etc.
+        for 1 or more areas
+      operationId: getAreas
+      parameters:
+        - $ref: "#/components/parameters/area_codes"
+      responses:
+        "200":
+          description: A list of the basic area details for each of the requested area codes.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 100
+                items:
+                  $ref: "#/components/schemas/Area"
+        "400":
+          description: A validation error due to improper usage of the area_codes parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequest"
+              examples:
+                No area_codes provided:
+                  value:
+                    message: Please provide at least value for the parameter area_codes.
+                Too many area_codes:
+                  value:
+                    message: Too many values supplied for parameter area_codes. The maximum is 100 but 101 supplied.
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /healthcheck:

--- a/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
+++ b/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
@@ -87,9 +87,9 @@ export interface IndicatorsApiInterface {
      * Get data for a public health indicator. This will return all data for all areas and all years for the indicators. Optionally filter the results by supplying one or more area codes and one or more years in the query string.
      * @summary Get health data for an indicator
      * @param {number} indicatorId The unique identifier of the indicator
-     * @param {Array<string>} [areaCodes] A list of area codes, up to 10 area codes can be requested
+     * @param {Array<string>} [areaCodes] A list of area codes, up to 100 area codes can be requested
      * @param {string} [areaType] The area type which the areas belong to
-     * @param {Array<number>} [years] A list of years, up to 10 years can be requested
+     * @param {Array<number>} [years] A list of years, up to 20 years can be requested
      * @param {Array<'age' | 'sex' | 'deprivation'>} [inequalities] Determines the kind of inequality data that should be returned if an option is specified
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-569](https://bjss-enterprise.atlassian.net/browse/DHSCFT-569)

Tech enabler for frontend ticket. Aim is to make it more efficient when calling for multiple area details. FE client can now simply pass a list of areas rather than parallelising tonnes of calls to the backend, area by area.

## Changes

- New interaction added to the `/areas` endpoint. You can now request multiple areas using the `area_codes` query parameter e.g. `/areas?area_codes=123&area_codes=456`. This follows the standard pattern in .Net WebAPI and other endpoints we've implemented.
- Existing endpoint for `/area/{area_code}` is unaffected. You can still request a single area.
- Unit tests, .http integration tests, swagger and updated UI client.
- Fixed minor existing bug and added a test for when requesting an area code which doesn't exist e.g. `area/narnia`.

## Validation

Local manual testing with deployed API and ran the new .http scripts.
