### PR TITLE
DHSCFT-555: Make bar chart tooltip display for the deprivation chart

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
@@ -158,7 +158,10 @@ export function InequalitiesBarChart({
                 y: plotlineOptions.value,
                 plotX: normalizedEvent.chartX - chart.plotLeft,
                 plotY: normalizedEvent.chartY - chart.plotTop,
-                tooltipPos: [normalizedEvent.chartX, normalizedEvent.chartY],
+                tooltipPos: [
+                  normalizedEvent.chartX - chart.plotLeft,
+                  normalizedEvent.chartY - chart.plotTop,
+                ],
               } as unknown as Highcharts.Point;
 
               tooltip.update({ shape: 'rect' });


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-555](https://bjss-enterprise.atlassian.net/browse/DHSCFT-555)

Adjust the inequalities bar chart tooltip positioning so that it displays correctly for both the sex and deprivation charts.

## Changes

- Updated the `tooltipPos` value of the benchmark plotline's custom tooltip to use the same calculation as the `plotX` value. I found when debugging that the tooltip was showing for the deprivation chart, but the `tooltipPos` value was much too high and resulted in it display quite a way to the right of the benchmark line. This change results in the tooltip displaying to the left of the line, which seems to work well.

## Validation

I can't get screenshots to capture the tooltip, but you can try it out yourself.

Sex chart on main: http://20.26.160.30/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL
Deprivation chart on main: http://20.26.160.30/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL&its=deprivation

Sex chart running locally: http://localhost:3000/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL
Deprivation chart running locally: http://localhost:3000/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL&its=deprivation