### PR TITLE
DHSCFT-555: Fix deprivation bar chart display

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
@@ -109,6 +109,7 @@ export function InequalitiesForSingleTimePeriod({
               <InequalitiesBarChart
                 barChartData={barChartData}
                 measurementUnit={measurementUnit}
+                type={type}
                 yAxisLabel="Value"
                 benchmarkComparisonMethod={benchmarkComparisonMethod}
                 polarity={polarity}


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-555](https://bjss-enterprise.atlassian.net/browse/DHSCFT-555)

When merging #346 the `type` property was inadvertently removed from the properties passed to the `InequalitiesBarChart` component. This means that the deprivation chart is shown at a very small size.

## Changes

- Pass type property to InequalitiesBarChart component again

## Validation

Chart on `main` ([link](http://20.26.160.30/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL&its=deprivation)):
![Screenshot 2025-04-03 at 16 04 04](https://github.com/user-attachments/assets/694b2415-7462-4db2-a55e-271a84d86949)

Chart with these changes:
![Screenshot 2025-04-03 at 16 04 15](https://github.com/user-attachments/assets/feb2663e-cc5a-4d39-b24d-36501c4ee10c)