### PR TITLE
DHSCFT-587 - ensure units are displayed with commas in the numbers

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/heatmap.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/heatmap.test.tsx.snap
@@ -1034,7 +1034,7 @@ exports[`snapshot test 1`] = `
             <div
               class="c17"
             >
-              per 1000
+              per 1,000
             </div>
           </td>
           <td

--- a/frontend/fingertips-frontend/components/organisms/Heatmap/heatmapUtil.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/Heatmap/heatmapUtil.test.ts
@@ -33,7 +33,7 @@ describe('generate headers and rows', () => {
     {
       id: '2',
       name: 'Indicator 2',
-      unitLabel: 'per 1000',
+      unitLabel: 'per 1,000',
       latestDataPeriod: 5678,
       benchmarkMethod:
         BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8,
@@ -159,7 +159,7 @@ const newHealthDataPoint = ({
 const indicator1 = {
   id: 'indicator1',
   name: 'Very Verbose Indicator Name With an Extreeeeeeeme Number of Words to Try And Trip Up The View. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus varius magna massa, commodo consectetur erat hendrerit id. In semper, nibh eu efficitur sagittis, quam lectus semper augue, quis vestibulum ipsum urna ut orci.',
-  unitLabel: 'per 1000',
+  unitLabel: 'per 1,000',
   latestDataPeriod: 2004,
   benchmarkMethod: BenchmarkComparisonMethod.Quintiles,
   polarity: IndicatorPolarity.NoJudgement,

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
@@ -23,7 +23,7 @@ describe('Spine chart table suite', () => {
     },
   ];
 
-  const mockUnits = ['kg', 'per 1000'];
+  const mockUnits = ['kg', 'per 1,000'];
 
   const mockHealthData: HealthDataForArea[] = [
     {
@@ -189,7 +189,7 @@ describe('Spine chart table suite', () => {
           indicatorId: 1,
           period: 2024,
           trend: 'Cannot be calculated',
-          unit: 'per 1000',
+          unit: 'per 1,000',
           value: 690.305692,
         },
       ];

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/__snapshots__/SpineChartTable.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/__snapshots__/SpineChartTable.test.tsx.snap
@@ -464,7 +464,7 @@ exports[`Spine chart table suite Spine chart table snapshot test - should match 
             class="c13 c14 c15"
             data-testid="unit-cell"
           >
-            per 1000
+            per 1,000
           </td>
           <td
             class="c13 c14 c15 c16"


### PR DESCRIPTION
in test data and test results

# Description

Jira ticket: [DHSCFT-587](https://bjss-enterprise.atlassian.net/browse/DHSCFT-587)

Ensure units are displayed with commas in the numbers e.g. `per 1,000`.

## Changes

- Manual check of the data stored in AI Search Index
- Search codebase to ensure we are not generating unit labels
- Search codebase for test data that does not use commas in unit labels.

## Validation

Validation by looking at documents and files.
No changes made to any application code.
AI Search index checked by searching entire index for `unitLabel` and manually inspecting the value.