### PR TITLE
DHSCFT-176: Result sort order

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
@@ -10,14 +10,16 @@ import {
 } from '@/lib/searchStateManager';
 import {
   Button,
+  Checkbox,
   ListItem,
   Paragraph,
   SectionBreak,
   UnorderedList,
-  Checkbox,
 } from 'govuk-react';
 import { usePathname, useRouter } from 'next/navigation';
 import styled from 'styled-components';
+import { IndicatorSort } from '@/components/forms/IndicatorSort/IndicatorSort';
+import { useIndicatorSort } from '@/components/forms/IndicatorSort/useIndicatorSort';
 
 const ResultLabelsContainer = styled.span({
   alignItems: 'center',
@@ -135,6 +137,9 @@ export function IndicatorSelectionForm({
     replace(stateManager.generatePath(pathname), { scroll: false });
   };
 
+  const { sortedResults, selectedSortOrder, handleSortOrder } =
+    useIndicatorSort(searchResults);
+
   return (
     <form
       action={formAction}
@@ -149,7 +154,11 @@ export function IndicatorSelectionForm({
         defaultValue={JSON.stringify(searchState)}
         hidden
       />
-      {searchResults.length ? (
+      <IndicatorSort
+        selectedSortOrder={selectedSortOrder}
+        onChange={handleSortOrder}
+      />
+      {sortedResults.length ? (
         <>
           <ResultLabelsContainer>
             <Checkbox
@@ -170,7 +179,7 @@ export function IndicatorSelectionForm({
             <ListItem>
               <SectionBreak visible={true} />
             </ListItem>
-            {searchResults.map((result) => (
+            {sortedResults.map((result) => (
               <SearchResult
                 key={generateKey(result.indicatorID.toString(), searchState)}
                 result={result}

--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
@@ -6,6 +6,7 @@ import { UserEvent, userEvent } from '@testing-library/user-event';
 import { formatDate } from '@/lib/dateHelpers/dateHelpers';
 import { LoaderContext } from '@/context/LoaderContext';
 import { SearchStateContext } from '@/context/SearchStateContext';
+import { SortOrderKeys } from '@/components/forms/IndicatorSort/indicatorSort.types';
 
 const mockPath = 'some-mock-path';
 const mockReplace = jest.fn();
@@ -387,5 +388,19 @@ describe('IndicatorSelectionForm', () => {
     );
 
     expect(screen.getByRole('checkbox', { name: /Select all/i })).toBeChecked();
+  });
+
+  it('should show sort order', () => {
+    render(
+      <IndicatorSelectionForm
+        searchResults={MOCK_DATA}
+        showTrends={false}
+        formAction={mockFormAction}
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: /Sort by/i })).toHaveValue(
+      SortOrderKeys.relevance
+    );
   });
 });

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/IndicatorSort.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/IndicatorSort.tsx
@@ -1,0 +1,33 @@
+import { Select } from 'govuk-react';
+import {
+  SortOrderKeys,
+  sortOrderLabels,
+} from '@/components/forms/IndicatorSort/indicatorSort.types';
+import { ChangeEventHandler, FC } from 'react';
+import styled from 'styled-components';
+
+interface IndicatorSortProps {
+  selectedSortOrder: SortOrderKeys;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+}
+
+const StyledDiv = styled.div({
+  marginBottom: '1.5rem',
+});
+
+export const IndicatorSort: FC<IndicatorSortProps> = ({
+  selectedSortOrder,
+  onChange,
+}) => {
+  return (
+    <StyledDiv>
+      <Select label="Sort by" input={{ onChange, value: selectedSortOrder }}>
+        {Object.keys(SortOrderKeys).map((key) => (
+          <option key={key} value={key}>
+            {sortOrderLabels[key as keyof typeof SortOrderKeys]}
+          </option>
+        ))}
+      </Select>
+    </StyledDiv>
+  );
+};

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/IndicatorSort.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/IndicatorSort.tsx
@@ -24,7 +24,7 @@ export const IndicatorSort: FC<IndicatorSortProps> = ({
       <Select label="Sort by" input={{ onChange, value: selectedSortOrder }}>
         {Object.keys(SortOrderKeys).map((key) => (
           <option key={key} value={key}>
-            {sortOrderLabels[key as keyof typeof SortOrderKeys]}
+            {sortOrderLabels[key as SortOrderKeys]}
           </option>
         ))}
       </Select>

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/indicatorSort.types.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/indicatorSort.types.ts
@@ -5,7 +5,7 @@ export enum SortOrderKeys {
 }
 
 export const sortOrderLabels: Record<SortOrderKeys, string> = {
-  relevance: 'Most relevant',
-  updated: 'Last updated',
-  alphabetical: 'Alphabetical',
+  [SortOrderKeys.relevance]: 'Most relevant',
+  [SortOrderKeys.updated]: 'Last updated',
+  [SortOrderKeys.alphabetical]: 'Alphabetical',
 };

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/indicatorSort.types.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/indicatorSort.types.ts
@@ -1,0 +1,11 @@
+export enum SortOrderKeys {
+  relevance = 'relevance',
+  updated = 'updated',
+  alphabetical = 'alphabetical',
+}
+
+export const sortOrderLabels: Record<SortOrderKeys, string> = {
+  relevance: 'Most relevant',
+  updated: 'Last updated',
+  alphabetical: 'Alphabetical',
+};

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.test.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.test.ts
@@ -1,0 +1,151 @@
+import { LoaderContext } from '@/context/LoaderContext';
+import { SearchStateContext } from '@/context/SearchStateContext';
+import { useIndicatorSort } from '@/components/forms/IndicatorSort/useIndicatorSort';
+import { IndicatorDocument } from '@/lib/search/searchTypes';
+import { renderHook } from '@testing-library/react';
+import { SearchParams } from '@/lib/searchStateManager';
+import { SortOrderKeys } from '@/components/forms/IndicatorSort/indicatorSort.types';
+import { ChangeEvent } from 'react';
+
+const mockPath = 'some-mock-path';
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => {
+  const originalModule = jest.requireActual('next/navigation');
+
+  return {
+    ...originalModule,
+    usePathname: () => mockPath,
+    useSearchParams: () => {},
+    useRouter: jest.fn().mockImplementation(() => ({
+      replace: mockReplace,
+    })),
+  };
+});
+
+const mockSetIsLoading = jest.fn();
+const mockLoaderContext: LoaderContext = {
+  getIsLoading: jest.fn(),
+  setIsLoading: mockSetIsLoading,
+};
+jest.mock('@/context/LoaderContext', () => {
+  return {
+    useLoadingState: () => mockLoaderContext,
+  };
+});
+
+const mockGetSearchState = jest.fn();
+const mockSearchStateContext: SearchStateContext = {
+  getSearchState: mockGetSearchState,
+  setSearchState: jest.fn(),
+};
+jest.mock('@/context/SearchStateContext', () => {
+  return {
+    useSearchState: () => mockSearchStateContext,
+  };
+});
+
+const mockApple = {
+  indicatorName: 'Apple',
+  lastUpdatedDate: new Date('2000/12/25'),
+} as IndicatorDocument;
+const mockBanana = {
+  indicatorName: 'Banana',
+  lastUpdatedDate: new Date('2005/12/25'),
+} as IndicatorDocument;
+const mockCherry = {
+  indicatorName: 'Cherry',
+  lastUpdatedDate: new Date('2010/12/25'),
+} as IndicatorDocument;
+const mockDamson = {
+  indicatorName: 'Damson',
+  lastUpdatedDate: new Date('2015/12/25'),
+} as IndicatorDocument;
+
+describe('useIndicatorSort', () => {
+  const mockResults = [mockBanana, mockApple, mockDamson, mockCherry];
+  it('should not change the sort order when relevance is selected', () => {
+    const { result } = renderHook(() => useIndicatorSort(mockResults));
+
+    expect(result.current.sortedResults).toEqual([
+      mockBanana,
+      mockApple,
+      mockDamson,
+      mockCherry,
+    ]);
+  });
+
+  it('should change the sort order to alphabetical', () => {
+    mockGetSearchState.mockImplementation(() => ({
+      [SearchParams.SearchedOrder]: SortOrderKeys.alphabetical,
+    }));
+    const { result } = renderHook(() => useIndicatorSort(mockResults));
+    expect(result.current.selectedSortOrder).toEqual(
+      SortOrderKeys.alphabetical
+    );
+    expect(result.current.sortedResults).toEqual([
+      mockApple,
+      mockBanana,
+      mockCherry,
+      mockDamson,
+    ]);
+  });
+
+  it('should change the sort order to most recently updated', () => {
+    mockGetSearchState.mockImplementation(() => ({
+      [SearchParams.SearchedOrder]: SortOrderKeys.updated,
+    }));
+    const { result } = renderHook(() => useIndicatorSort(mockResults));
+    expect(result.current.selectedSortOrder).toEqual(SortOrderKeys.updated);
+    expect(result.current.sortedResults).toEqual([
+      mockDamson,
+      mockCherry,
+      mockBanana,
+      mockApple,
+    ]);
+  });
+
+  it('should not change the sort order when nonsense is given as an order term', () => {
+    mockGetSearchState.mockImplementation(() => ({
+      [SearchParams.SearchedOrder]: 'foobar',
+    }));
+    const { result } = renderHook(() => useIndicatorSort(mockResults));
+    expect(result.current.selectedSortOrder).toEqual(SortOrderKeys.relevance);
+    expect(result.current.sortedResults).toEqual([
+      mockBanana,
+      mockApple,
+      mockDamson,
+      mockCherry,
+    ]);
+  });
+
+  it('should limit the results to 20', () => {
+    mockGetSearchState.mockImplementation(() => ({
+      [SearchParams.SearchedOrder]: SortOrderKeys.updated,
+    }));
+    const lotsOfResults = new Array(30).map(() => mockApple);
+    const { result } = renderHook(() => useIndicatorSort(lotsOfResults));
+    expect(result.current.sortedResults).toHaveLength(20);
+  });
+
+  it('should return a callback function to use on the select element', () => {
+    mockGetSearchState.mockImplementation(() => ({
+      [SearchParams.SearchedOrder]: SortOrderKeys.updated,
+      [SearchParams.IndicatorsSelected]: [1, 2, 3],
+    }));
+
+    const { result } = renderHook(() => useIndicatorSort(mockResults));
+    expect(result.current).toHaveProperty('handleSortOrder');
+    const { handleSortOrder } = result.current;
+    expect(typeof handleSortOrder).toBe('function');
+
+    handleSortOrder({
+      target: { value: SortOrderKeys.alphabetical },
+    } as ChangeEvent<HTMLSelectElement>);
+    expect(mockSetIsLoading).toHaveBeenCalledWith(true);
+    expect(mockReplace).toHaveBeenCalledWith(
+      `${mockPath}?${SearchParams.SearchedOrder}=alphabetical`,
+      { scroll: false }
+    );
+  });
+});

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
@@ -1,0 +1,58 @@
+import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
+import { ChangeEvent, useCallback } from 'react';
+import { IndicatorDocument } from '@/lib/search/searchTypes';
+import { SortOrderKeys } from '@/components/forms/IndicatorSort/indicatorSort.types';
+import { usePathname, useRouter } from 'next/navigation';
+import { useLoadingState } from '@/context/LoaderContext';
+import { useSearchState } from '@/context/SearchStateContext';
+
+export const maxResults = 20;
+
+export const useIndicatorSort = (results: IndicatorDocument[]) => {
+  const pathname = usePathname();
+  const { replace } = useRouter();
+  const { setIsLoading } = useLoadingState();
+  const { getSearchState } = useSearchState();
+  const searchState = getSearchState();
+  const stateManager = SearchStateManager.initialise(searchState);
+
+  const sortOrderFromState = searchState
+    ? searchState[SearchParams.SearchedOrder]
+    : undefined;
+  const selectedSortOrder = (
+    Object.keys(SortOrderKeys).includes(sortOrderFromState ?? '')
+      ? sortOrderFromState
+      : SortOrderKeys.relevance
+  ) as SortOrderKeys;
+
+  const handleSortOrder = (e: ChangeEvent<HTMLSelectElement>) => {
+    setIsLoading(true);
+    const newSortOrder = e.target.value;
+    stateManager.addParamValueToState(SearchParams.SearchedOrder, newSortOrder);
+    stateManager.removeAllParamFromState(SearchParams.IndicatorsSelected);
+    replace(stateManager.generatePath(pathname), { scroll: false });
+  };
+
+  const sortFunction = useCallback(
+    (a: IndicatorDocument, b: IndicatorDocument) => {
+      if (selectedSortOrder === SortOrderKeys.updated) {
+        return b.lastUpdatedDate.getTime() - a.lastUpdatedDate.getTime();
+      }
+
+      // alphabetical
+      return a.indicatorName.localeCompare(b.indicatorName, 'en', {
+        sensitivity: 'base',
+      });
+    },
+    [selectedSortOrder]
+  );
+
+  const sorted =
+    selectedSortOrder === SortOrderKeys.relevance
+      ? results
+      : results.toSorted(sortFunction);
+
+  const sortedResults = sorted.slice(0, maxResults);
+
+  return { sortedResults, handleSortOrder, selectedSortOrder };
+};

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
@@ -16,9 +16,8 @@ export const useIndicatorSort = (results: IndicatorDocument[]) => {
   const searchState = getSearchState();
   const stateManager = SearchStateManager.initialise(searchState);
 
-  const sortOrderFromState = searchState
-    ? searchState[SearchParams.SearchedOrder]
-    : undefined;
+  const sortOrderFromState = searchState?.[SearchParams.SearchedOrder];
+
   const selectedSortOrder = (
     Object.keys(SortOrderKeys).includes(sortOrderFromState ?? '')
       ? sortOrderFromState

--- a/frontend/fingertips-frontend/lib/search/indicatorSearchService.test.ts
+++ b/frontend/fingertips-frontend/lib/search/indicatorSearchService.test.ts
@@ -1,5 +1,5 @@
 import { IndicatorSearchService } from './indicatorSearchService';
-import { SearchClient, AzureKeyCredential } from '@azure/search-documents';
+import { AzureKeyCredential, SearchClient } from '@azure/search-documents';
 import { SearchServiceFactory } from './searchServiceFactory';
 import { INDICATOR_SEARCH_INDEX_NAME } from './searchTypes';
 import { HealthDataPointTrendEnum } from '@/generated-sources/ft-api-client/models/HealthDataPoint';
@@ -204,7 +204,7 @@ describe('IndicatorSearchService', () => {
       ]);
     });
 
-    it('should only return the first 20 results', async () => {
+    it('should only return all results', async () => {
       const fiftyResults = Array(50).fill({
         document: {
           indicatorID: '123',
@@ -241,7 +241,7 @@ describe('IndicatorSearchService', () => {
       const searchService = SearchServiceFactory.getIndicatorSearchService();
       const results = await searchService.searchWith('Test Indicator', false);
 
-      expect(results).toHaveLength(20);
+      expect(results).toHaveLength(50);
     });
   });
 

--- a/frontend/fingertips-frontend/lib/search/indicatorSearchService.ts
+++ b/frontend/fingertips-frontend/lib/search/indicatorSearchService.ts
@@ -61,7 +61,7 @@ export class IndicatorSearchService implements IIndicatorSearchService {
     }
 
     return this.mapper.toEntities(
-      results.slice(0, 20),
+      results,
       areaCodes ?? [],
       isEnglandSelectedAsGroup
     );

--- a/frontend/fingertips-frontend/lib/search/indicatorSearchServiceMock.ts
+++ b/frontend/fingertips-frontend/lib/search/indicatorSearchServiceMock.ts
@@ -44,8 +44,7 @@ export class IndicatorSearchServiceMock implements IIndicatorSearchService {
               .includes(area.toLowerCase())
           )
         );
-      })
-      .slice(0, 20);
+      });
 
     return this.mapper.toEntities(
       searchResults,

--- a/frontend/fingertips-frontend/lib/searchStateManager.ts
+++ b/frontend/fingertips-frontend/lib/searchStateManager.ts
@@ -11,6 +11,7 @@ export enum SearchParams {
   InequalityTypeSelected = 'its',
   PopulationAreaSelected = 'pas',
   InequalityYearSelected = 'iys',
+  SearchedOrder = 'so',
 }
 
 export type SearchParamKeys = `${SearchParams}`;
@@ -31,6 +32,7 @@ export type SearchStateParams = {
   [SearchParams.InequalityTypeSelected]?: string;
   [SearchParams.PopulationAreaSelected]?: string;
   [SearchParams.InequalityYearSelected]?: string;
+  [SearchParams.SearchedOrder]?: string;
 };
 
 const isMultiValueTypeParam = (searchParamKey: SearchParamKeys) =>


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-176](https://bjss-enterprise.atlassian.net/browse/DHSCFT-176)

Add sort order dropdown to the indicator results page

## Changes

- Added hook for sorting
- Added component to show the dropdown/select

## Validation

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/584e1f4d-fa76-42d0-9ed4-1be7adfd26d0" />
