### PR TITLE
DHSCFT-527 - Filter search results by area when selecting all areas in a group

### DIFF
--- a/frontend/fingertips-frontend/app/results/page.tsx
+++ b/frontend/fingertips-frontend/app/results/page.tsx
@@ -12,6 +12,7 @@ import { getAreaFilterData } from '@/lib/areaFilterHelpers/getAreaFilterData';
 import { getSelectedAreasDataByAreaType } from '@/lib/areaFilterHelpers/getSelectedAreasData';
 import { AreaTypeKeys } from '@/lib/areaFilterHelpers/areaType';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
+import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 
 export default async function Page(
   props: Readonly<{
@@ -28,6 +29,7 @@ export default async function Page(
     [SearchParams.IndicatorsSelected]: indicatorsSelected,
     [SearchParams.GroupSelected]: groupSelected,
     [SearchParams.AreaTypeSelected]: areaTypeSelected,
+    [SearchParams.GroupAreaSelected]: groupAreaSelected,
   } = stateManager.getSearchState();
   try {
     await connection();
@@ -53,11 +55,16 @@ export default async function Page(
       stateManager.setState(updatedSearchState);
     }
 
+    const searchFilterAreas =
+      groupAreaSelected === ALL_AREAS_SELECTED
+        ? availableAreas?.map((area) => area.code)
+        : areasSelected;
+
     const searchResults =
       await SearchServiceFactory.getIndicatorSearchService().searchWith(
         searchedIndicator ?? '',
         isEnglandSelectedAsGroup,
-        areasSelected
+        searchFilterAreas
       );
 
     const initialState: IndicatorSelectionState = {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-527](https://bjss-enterprise.atlassian.net/browse/DHSCFT-527)

Resolves the issue where we weren't filtering the search results by area when you had selected all areas in a group.

## Changes

- Made the results page use the available areas to filter search results (instead of the selected areas) when the `gas` query parameter is set to `ALL`

## Validation
Running locally in Docker, selecting all areas in a group no longer causes the indicator to appear (it did before these changes):
![Screenshot 2025-04-10 at 15 01 14](https://github.com/user-attachments/assets/dca71bc9-2a6a-43f0-aa7c-9b6d5978ed19)
![Screenshot 2025-04-10 at 15 01 32](https://github.com/user-attachments/assets/d976126e-3c7e-4ad8-b2b1-0443aefed0b3)