### PR TITLE
DHSCFT-624: Bug: Health data x-ref by year not index

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -452,4 +452,44 @@ describe('Line chart table suite', () => {
       expect(screen.queryByTestId('england-header')).not.toBeInTheDocument();
     });
   });
+
+  describe('LineChartTable when mismatched years are supplied', () => {
+    it('should not render Xs but keep the correct years aligned', () => {
+      const mockHealthArea1 = JSON.parse(JSON.stringify(MOCK_ENGLAND_DATA));
+      mockHealthArea1.areaName = 'year-2005-in-between-england-values';
+      mockHealthArea1.areaCode = '2005';
+      mockHealthArea1.healthData[1] = {
+        ...mockHealthArea1.healthData[1],
+        year: 2005,
+      };
+
+      const mockHealthArea2 = JSON.parse(JSON.stringify(MOCK_ENGLAND_DATA));
+      mockHealthArea2.areaName = 'year-1999-not-in-england';
+      mockHealthArea2.areaCode = '1999';
+      mockHealthArea2.healthData[0] = {
+        ...mockHealthArea2.healthData[0],
+        year: 1999,
+      };
+
+      render(
+        <LineChartTable
+          healthIndicatorData={[mockHealthArea1, mockHealthArea2]}
+          englandBenchmarkData={MOCK_ENGLAND_DATA}
+          measurementUnit="%"
+          benchmarkComparisonMethod={
+            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+          }
+        />
+      );
+
+      const rows = screen.getAllByRole('row');
+      expect(rows).toHaveLength(6);
+      expect(rows[4]).toHaveTextContent(
+        /^2004Not compared200904.90.00.0Not comparedXXXX904.9$/
+      );
+      expect(rows[5]).toHaveTextContent(
+        /^2008Not comparedXXXXNot compared500966.00.00.0966.0$/
+      );
+    });
+  });
 });


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-624](https://bjss-enterprise.atlassian.net/browse/DHSCFT-624)

When areas are missing data the line chart table was matching them by index rather than year - change to base row data on the england benchmark data and find area and group values by their matching year.

## Changes

- Match by year not index

## Validation

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/435f0a5b-23a3-495b-8cf6-f288ff614d37" />
