### PR TITLE
Feature/dhscft 507 data source single indicator views

### DIFF
--- a/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
@@ -2,6 +2,9 @@ import { PopulationPyramidWithTableDataProvider } from './index';
 import { render } from '@testing-library/react';
 import { SearchParams } from '@/lib/searchStateManager';
 import { HierarchyNameTypes } from '@/lib/areaFilterHelpers/areaType';
+import { mockDeep } from 'jest-mock-extended';
+import { IIndicatorSearchService } from '@/lib/search/searchTypes';
+import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 
 const mockGetHealthDataForAnIndicator = jest.fn();
 
@@ -23,6 +26,10 @@ jest.mock('@/lib/apiClient/apiClientFactory', () => ({
     }),
   },
 }));
+
+const mockIndicatorSearchService = mockDeep<IIndicatorSearchService>();
+SearchServiceFactory.getIndicatorSearchService = () =>
+  mockIndicatorSearchService;
 
 jest.mock('@/components/organisms/PopulationPyramidWithTable', () => ({
   PopulationPyramidWithTable: () => <div>PopulationPyramidWithTable</div>,
@@ -46,6 +53,19 @@ describe('PopulationPyramidWithTableDataProvider', () => {
     mockGetHealthDataForAnIndicator.mockResolvedValue({
       areaHealthData: [{ areaCode: 'E09000001', value: 100 }],
     });
+
+    mockIndicatorSearchService.getIndicator.mockClear();
+    mockIndicatorSearchService.getIndicator.mockResolvedValue({
+      indicatorID: '',
+      indicatorName: '',
+      indicatorDefinition: '',
+      dataSource: 'data source',
+      earliestDataPeriod: '',
+      latestDataPeriod: '',
+      lastUpdatedDate: new Date(),
+      hasInequalities: false,
+      unitLabel: '',
+    });
   });
 
   const searchParams = {
@@ -65,6 +85,7 @@ describe('PopulationPyramidWithTableDataProvider', () => {
     expect(view.getByText('PopulationPyramidWithTable')).toBeInTheDocument();
     expect(mockGetArea).toHaveBeenCalledTimes(1);
     expect(mockGetHealthDataForAnIndicator).toHaveBeenCalledTimes(1);
+    expect(mockIndicatorSearchService.getIndicator).toHaveBeenCalledTimes(1);
   });
 
   it('renders PopulationPyramidWithTable with more than 100 areas data to be fetched', async () => {
@@ -89,6 +110,7 @@ describe('PopulationPyramidWithTableDataProvider', () => {
     expect(view.getByText('PopulationPyramidWithTable')).toBeInTheDocument();
     expect(mockGetArea).toHaveBeenCalledTimes(1);
     expect(mockGetHealthDataForAnIndicator).toHaveBeenCalledTimes(2);
+    expect(mockIndicatorSearchService.getIndicator).toHaveBeenCalledTimes(1);
   });
 
   it('handles empty area codes', async () => {
@@ -101,5 +123,6 @@ describe('PopulationPyramidWithTableDataProvider', () => {
     expect(view.getByText('PopulationPyramidWithTable')).toBeInTheDocument();
     expect(mockGetArea).not.toHaveBeenCalled();
     expect(mockGetHealthDataForAnIndicator).not.toHaveBeenCalled();
+    expect(mockIndicatorSearchService.getIndicator).not.toHaveBeenCalled();
   });
 });

--- a/frontend/fingertips-frontend/components/atoms/DataSource/DataSource.test.tsx
+++ b/frontend/fingertips-frontend/components/atoms/DataSource/DataSource.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { DataSource } from './DataSource';
+
+describe('data source', () => {
+  it('should display nothing if no data source provided', () => {
+    const screen = render(<DataSource dataSource={undefined} />);
+
+    expect(screen.queryByTestId('data-source')).not.toBeInTheDocument();
+  });
+
+  it('should render the data source if provided', () => {
+    const dataSource = 'Black Mesa Research Facility';
+    const screen = render(<DataSource dataSource={dataSource} />);
+
+    expect(screen.getByTestId('data-source')).toBeInTheDocument();
+    expect(screen.getByText(`Data source: ${dataSource}`)).toBeInTheDocument();
+  });
+});

--- a/frontend/fingertips-frontend/components/atoms/DataSource/DataSource.tsx
+++ b/frontend/fingertips-frontend/components/atoms/DataSource/DataSource.tsx
@@ -1,0 +1,21 @@
+import { Paragraph } from 'govuk-react';
+import styled from 'styled-components';
+import { typography } from '@govuk-react/lib';
+
+const StyledParagraphDataSource = styled(Paragraph)(
+  typography.font({ size: 16 })
+);
+
+interface DataSourceProps {
+  dataSource?: string;
+}
+
+export function DataSource({ dataSource }: Readonly<DataSourceProps>) {
+  return dataSource ? (
+    <div data-testid={'data-source'}>
+      <StyledParagraphDataSource>
+        {`Data source: ${dataSource}`}
+      </StyledParagraphDataSource>
+    </div>
+  ) : null;
+}

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
@@ -27,6 +27,7 @@ import {
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
 import { InequalitiesTypesDropDown } from '../InequalitiesTypesDropDown';
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 interface InequalitiesForSingleTimePeriodProps {
   healthIndicatorData: HealthDataForArea;
@@ -34,6 +35,7 @@ interface InequalitiesForSingleTimePeriodProps {
   measurementUnit?: string;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   polarity?: IndicatorPolarity;
+  dataSource?: string;
 }
 
 export function InequalitiesForSingleTimePeriod({
@@ -42,6 +44,7 @@ export function InequalitiesForSingleTimePeriod({
   benchmarkComparisonMethod,
   polarity,
   searchState,
+  dataSource,
 }: Readonly<InequalitiesForSingleTimePeriodProps>) {
   const stateManager = SearchStateManager.initialise(searchState);
   const {
@@ -143,6 +146,7 @@ export function InequalitiesForSingleTimePeriod({
             ),
           },
         ]}
+        footer={<DataSource dataSource={dataSource} />}
       />
     </div>
   );

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/inequalitiesForSingleTimePeriod.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/inequalitiesForSingleTimePeriod.test.tsx
@@ -88,6 +88,7 @@ describe('InequalitiesForSingleTimePeriod suite', () => {
       <InequalitiesForSingleTimePeriod
         healthIndicatorData={mockHealthData}
         searchState={mockSearchState}
+        dataSource={'inequalities data source'}
       />
     );
 
@@ -124,6 +125,10 @@ describe('InequalitiesForSingleTimePeriod suite', () => {
     inequalitiesDropDownOptions.forEach((option, index) => {
       expect(option.textContent).toBe(inequalitiesOptions[index]);
     });
+
+    expect(
+      screen.getAllByText('Data source: inequalities data source')
+    ).toHaveLength(2);
   });
 
   it('should not render component if inequalities data is absent', () => {

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/index.tsx
@@ -27,11 +27,13 @@ import {
 } from '@/components/organisms/Inequalities/inequalitiesHelpers';
 import { formatNumber } from '@/lib/numberFormatter';
 import { InequalitiesTypesDropDown } from '../InequalitiesTypesDropDown';
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 interface InequalitiesTrendProps {
   healthIndicatorData: HealthDataForArea;
   searchState: SearchStateParams;
   measurementUnit?: string;
+  dataSource?: string;
 }
 
 const generateInequalitiesLineChartTooltipForPoint = (
@@ -47,6 +49,7 @@ export function InequalitiesTrend({
   healthIndicatorData,
   searchState,
   measurementUnit,
+  dataSource,
 }: Readonly<InequalitiesTrendProps>) {
   const [
     showInequalitiesLineChartConfidenceIntervals,
@@ -163,6 +166,7 @@ export function InequalitiesTrend({
             ),
           },
         ]}
+        footer={<DataSource dataSource={dataSource} />}
       />
     </div>
   );

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/inequalitiesTrend.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/inequalitiesTrend.test.tsx
@@ -74,6 +74,7 @@ describe('InequalitiesTrend suite', () => {
       <InequalitiesTrend
         healthIndicatorData={mockHealthData}
         searchState={state}
+        dataSource="inequalities data source"
       />
     );
 
@@ -99,6 +100,10 @@ describe('InequalitiesTrend suite', () => {
     inequalitiesDropDownOptions.forEach((option, index) => {
       expect(option.textContent).toBe(inequalitiesOptions[index]);
     });
+
+    expect(
+      screen.getAllByText('Data source: inequalities data source')
+    ).toHaveLength(2);
   });
 
   it('should not render component if inequalities data is absent', () => {

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/barChartEmbeddedTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/barChartEmbeddedTable.test.tsx
@@ -310,4 +310,18 @@ describe('BarChartEmbeddedTable', () => {
     expect(trendTags[2].textContent).toEqual('Decreasing and getting better'); // A1426 trend
     expect(trendTags[3].textContent).toEqual('No trend data available'); // A1425 trend
   });
+
+  it('should render the data source if provided', () => {
+    render(
+      <BarChartEmbeddedTable
+        healthIndicatorData={mockHealthIndicatorData}
+        benchmarkData={mockBenchmarkData}
+        dataSource={'bar chart data source'}
+      />
+    );
+
+    expect(
+      screen.getAllByText('Data source: bar chart data source')
+    ).toHaveLength(2);
+  });
 });

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -24,6 +24,7 @@ import { TrendTag } from '@/components/molecules/TrendTag';
 import { BenchmarkLegend } from '@/components/organisms/BenchmarkLegend';
 import { BarChartEmbeddedTableRow } from '@/components/organisms/BarChartEmbeddedTable/BarChartEmbeddedTable.types';
 import { BarChartEmbeddedRows } from '@/components/organisms/BarChartEmbeddedTable/BarChartEmbeddedRows';
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 export enum BarChartEmbeddedTableHeadingEnum {
   AreaName = 'Area',
@@ -48,6 +49,7 @@ interface BarChartEmbeddedTableProps {
   measurementUnit?: string;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   polarity?: IndicatorPolarity;
+  dataSource?: string;
 }
 
 const formatHeader = (title: string) => {
@@ -68,6 +70,7 @@ export function BarChartEmbeddedTable({
   measurementUnit,
   benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown,
   polarity = IndicatorPolarity.Unknown,
+  dataSource,
 }: Readonly<BarChartEmbeddedTableProps>) {
   const mostRecentYearData =
     sortHealthDataByYearDescending(healthIndicatorData);
@@ -297,6 +300,7 @@ export function BarChartEmbeddedTable({
           polarity={polarity}
         />
       </Table>
+      <DataSource dataSource={dataSource} />
     </div>
   );
 }

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/index.tsx
@@ -13,6 +13,7 @@ interface InequalitiesProps {
   measurementUnit?: string;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   polarity?: IndicatorPolarity;
+  dataSource?: string;
 }
 
 export function Inequalities({
@@ -21,6 +22,7 @@ export function Inequalities({
   searchState,
   benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown,
   polarity = IndicatorPolarity.Unknown,
+  dataSource,
 }: Readonly<InequalitiesProps>) {
   return (
     <div data-testid="inequalities-component">
@@ -30,12 +32,14 @@ export function Inequalities({
         benchmarkComparisonMethod={benchmarkComparisonMethod}
         polarity={polarity}
         searchState={searchState}
+        dataSource={dataSource}
       />
       <br />
       <InequalitiesTrend
         healthIndicatorData={healthIndicatorData}
         measurementUnit={measurementUnit}
         searchState={searchState}
+        dataSource={dataSource}
       />
     </div>
   );

--- a/frontend/fingertips-frontend/components/organisms/PopulationPyramidWithTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/PopulationPyramidWithTable/index.tsx
@@ -24,6 +24,7 @@ import {
 import { usePathname, useRouter } from 'next/navigation';
 import { ArrowExpander } from '@/components/molecules/ArrowExpander';
 import { PopulationPyramidChartTable } from '../PopulationPyramidChartTable';
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 const getHeaderTitle = (
   healthData: HealthDataForArea | undefined,
@@ -59,6 +60,7 @@ interface PyramidPopulationChartViewProps {
   xAxisTitle: string;
   yAxisTitle: string;
   searchState: SearchStateParams;
+  dataSource?: string;
 }
 export const PopulationPyramidWithTable = ({
   healthDataForAreas,
@@ -66,6 +68,7 @@ export const PopulationPyramidWithTable = ({
   yAxisTitle,
   groupAreaSelected,
   searchState,
+  dataSource,
 }: Readonly<PyramidPopulationChartViewProps>) => {
   const stateManager = SearchStateManager.initialise(searchState);
   const { [SearchParams.PopulationAreaSelected]: areaCode } =
@@ -199,6 +202,7 @@ export const PopulationPyramidWithTable = ({
                   ),
                 },
               ]}
+              footer={<DataSource dataSource={dataSource} />}
             />
           ) : null}
         </div>

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
@@ -159,6 +159,7 @@ export function OneIndicatorOneAreaViewPlots({
         benchmarkComparisonMethod={benchmarkComparisonMethod}
         polarity={polarity}
         searchState={searchState}
+        dataSource={indicatorMetadata?.dataSource}
       />
     </section>
   );

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
@@ -9,9 +9,7 @@ import {
 } from '@/lib/chartHelpers/chartHelpers';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams } from '@/lib/searchStateManager';
-import { H3, Paragraph } from 'govuk-react';
-import styled from 'styled-components';
-import { typography } from '@govuk-react/lib';
+import { H3 } from 'govuk-react';
 import { OneIndicatorViewPlotProps } from '../ViewPlotProps';
 import {
   BenchmarkComparisonMethod,
@@ -26,10 +24,7 @@ import {
 import { useEffect, useState } from 'react';
 import { getAllDataWithoutInequalities } from '@/components/organisms/Inequalities/inequalitiesHelpers';
 import { useSearchState } from '@/context/SearchStateContext';
-
-const StyledParagraphDataSource = styled(Paragraph)(
-  typography.font({ size: 16 })
-);
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 function shouldLineChartBeShown(
   dataWithoutEnglandOrGroup: HealthDataForArea[],
@@ -150,15 +145,7 @@ export function OneIndicatorOneAreaViewPlots({
                 ),
               },
             ]}
-            footer={
-              <>
-                {indicatorMetadata ? (
-                  <StyledParagraphDataSource>
-                    {`Data source: ${indicatorMetadata.dataSource}`}
-                  </StyledParagraphDataSource>
-                ) : null}
-              </>
-            }
+            footer={<DataSource dataSource={indicatorMetadata?.dataSource} />}
           />
         </>
       )}

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/index.tsx
@@ -7,10 +7,8 @@ import { BarChartEmbeddedTable } from '@/components/organisms/BarChartEmbeddedTa
 import { seriesDataWithoutEnglandOrGroup } from '@/lib/chartHelpers/chartHelpers';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams } from '@/lib/searchStateManager';
-import { H3, Paragraph } from 'govuk-react';
+import { H3 } from 'govuk-react';
 import { OneIndicatorViewPlotProps } from '@/components/viewPlots/ViewPlotProps';
-import styled from 'styled-components';
-import { typography } from '@govuk-react/lib';
 import { MapGeographyData } from '@/components/organisms/ThematicMap/thematicMapHelpers';
 import { ThematicMap } from '@/components/organisms/ThematicMap';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
@@ -22,10 +20,7 @@ import { useEffect, useState } from 'react';
 import { useSearchState } from '@/context/SearchStateContext';
 import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client/models/BenchmarkComparisonMethod';
 import { IndicatorPolarity } from '@/generated-sources/ft-api-client';
-
-const StyledParagraphDataSource = styled(Paragraph)(
-  typography.font({ size: 16 })
-);
+import { DataSource } from '@/components/atoms/DataSource/DataSource';
 
 interface OneIndicatorTwoOrMoreAreasViewPlotsProps
   extends OneIndicatorViewPlotProps {
@@ -130,15 +125,7 @@ export function OneIndicatorTwoOrMoreAreasViewPlots({
                 ),
               },
             ]}
-            footer={
-              <>
-                {indicatorMetadata ? (
-                  <StyledParagraphDataSource>
-                    {`Data source: ${indicatorMetadata.dataSource}`}
-                  </StyledParagraphDataSource>
-                ) : null}
-              </>
-            }
+            footer={<DataSource dataSource={indicatorMetadata?.dataSource} />}
           />
         </>
       )}
@@ -167,7 +154,8 @@ export function OneIndicatorTwoOrMoreAreasViewPlots({
         measurementUnit={indicatorMetadata?.unitLabel}
         benchmarkComparisonMethod={benchmarkMethod}
         polarity={polarity}
-      ></BarChartEmbeddedTable>
+        dataSource={indicatorMetadata?.dataSource}
+      />
     </section>
   );
 }


### PR DESCRIPTION
# Description

Jira ticket: https://bjss-enterprise.atlassian.net/browse/DHSCFT-507

adds data source to single indicator views

### areas bar chart
![image](https://github.com/user-attachments/assets/c9e3a945-5dcd-4610-a969-27f6315daabe)

### inequalities line chart
![image](https://github.com/user-attachments/assets/eb7def64-5dbc-472b-99e6-ec32f49f0486)

### inequalities bar chart
![image](https://github.com/user-attachments/assets/b29156eb-1298-4c56-8c7f-70cb1e6606bf)

### population pyramid
![image](https://github.com/user-attachments/assets/cc82c666-3dae-4f47-ac22-8ad8cfd6abfd)

## Validation
added data source to test data, additional testing on pop pyramid for extra metadata call

