### PR TITLE
Add environment variable to api

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -563,6 +563,11 @@ jobs:
             name        = "DB_PASSWORD"
             secret_name = "fingertips-sql-password"
             value       = null
+          },
+          {
+            name        = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+            secret_name = "fingertips-api-application-insights"
+            value       = null
           }
         ]
       container_liveness_probe: |


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-499](https://bjss-enterprise.atlassian.net/browse/DHSCFT-499)

Add environment variable to API container for connecting to new instance of Azure Application Insights

## Changes

- Connection string added through environment variable
- Environment variable points to a key vault secret where the connection string is stored

## Validation

Tested locally against the docker API
