### PR TITLE
DHSCFT-551: Add quintiles to the sparkline chart hover

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
@@ -123,5 +123,39 @@ describe('SparklineChart', () => {
         comparisonLabel: '',
       });
     });
+
+    it('should return tooltip for quintiles with no CI% shown', () => {
+      const benchmarkOutcome = BenchmarkOutcome.Worse;
+      const benchmarkComparisonMethod = BenchmarkComparisonMethod.Quintiles;
+
+      const result = sparklineTooltipContent(
+        benchmarkOutcome,
+        SparklineLabelEnum.Area,
+        benchmarkComparisonMethod
+      );
+
+      expect(result).toEqual({
+        benchmarkLabel: 'Worse quintile',
+        category: '',
+        comparisonLabel: '',
+      });
+    });
+
+    it('should not return Not compared when the benchmark outcome method of "Not compared" is passed in', () => {
+      const benchmarkOutcome = BenchmarkOutcome.NotCompared;
+      const benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown;
+
+      const result = sparklineTooltipContent(
+        benchmarkOutcome,
+        SparklineLabelEnum.Area,
+        benchmarkComparisonMethod
+      );
+
+      expect(result).toEqual({
+        benchmarkLabel: 'Not compared',
+        category: '',
+        comparisonLabel: '',
+      });
+    });
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
@@ -141,7 +141,7 @@ describe('SparklineChart', () => {
       });
     });
 
-    it('should not return Not compared when the benchmark outcome method of "Not compared" is passed in', () => {
+    it('should return Not compared when the benchmark outcome method of "Not compared" is passed in', () => {
       const benchmarkOutcome = BenchmarkOutcome.NotCompared;
       const benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown;
 

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
@@ -17,8 +17,8 @@ import {
 } from '@/generated-sources/ft-api-client';
 import { SparklineLabelEnum } from '@/components/organisms/BarChartEmbeddedTable';
 import { pointFormatterHelper } from '@/lib/chartHelpers/pointFormatterHelper';
-import { getBenchmarkLabelText } from '@/components/organisms/BenchmarkLabel';
 import { formatNumber } from '@/lib/numberFormatter';
+import { getBenchmarkLabelText } from '@/components/organisms/BenchmarkLabel';
 
 interface SparklineChartProps {
   value: (number | undefined)[];
@@ -34,37 +34,75 @@ interface SparklineChartProps {
   measurementUnit: string | undefined;
 }
 
+const getCategory = (
+  benchmarkOutcome: BenchmarkOutcome,
+  label: string
+): string => {
+  switch (true) {
+    case label === SparklineLabelEnum.Benchmark && !!benchmarkOutcome:
+      return 'Benchmark: ';
+    case label === SparklineLabelEnum.Group:
+      return 'Group: ';
+    default:
+      return '';
+  }
+};
+
+const getComparisonLabelText = (
+  benchmarkComparisonMethod: BenchmarkComparisonMethod,
+  benchmarkOutcome: BenchmarkOutcome
+) => {
+  if (
+    !benchmarkOutcome ||
+    benchmarkOutcome === BenchmarkOutcome.NotCompared ||
+    benchmarkComparisonMethod === BenchmarkComparisonMethod.Quintiles
+  )
+    return '';
+  const comparison = getConfidenceLimitNumber(benchmarkComparisonMethod);
+  return `(${formatNumber(comparison)}%)`;
+};
+
+const getBenchmarkLabel = (
+  benchmarkComparisonMethod: BenchmarkComparisonMethod,
+  benchmarkOutcome: BenchmarkOutcome
+) => {
+  if (!benchmarkOutcome || benchmarkOutcome === BenchmarkOutcome.NotCompared)
+    return 'Not compared';
+
+  if (benchmarkComparisonMethod === BenchmarkComparisonMethod.Quintiles)
+    return `${benchmarkOutcome} quintile`;
+
+  const joiningWord =
+    benchmarkOutcome === BenchmarkOutcome.Similar ? 'to' : 'than';
+  const outcome = getBenchmarkLabelText(benchmarkOutcome);
+  return `${outcome} ${joiningWord} England`;
+};
+
 export const sparklineTooltipContent = (
   benchmarkOutcome: BenchmarkOutcome,
   label: string,
   benchmarkComparisonMethod: BenchmarkComparisonMethod
 ) => {
-  let category = '';
-  let benchmarkLabel = '';
-  let comparisonLabel = '';
-  const outcome = getBenchmarkLabelText(benchmarkOutcome);
-  const comparison = getConfidenceLimitNumber(benchmarkComparisonMethod);
+  const category = getCategory(benchmarkOutcome, label);
 
-  if (label === SparklineLabelEnum.Benchmark && benchmarkOutcome) {
-    category = 'Benchmark: ';
-    return { benchmarkLabel, category, comparisonLabel };
-  }
-  if (label === SparklineLabelEnum.Group) {
-    category = 'Group: ';
-  }
-
-  if (benchmarkOutcome === BenchmarkOutcome.Similar) {
-    benchmarkLabel = `${outcome} to England`;
-    comparisonLabel = `(${formatNumber(comparison)}%)`;
-  } else if (
-    benchmarkOutcome &&
-    benchmarkOutcome !== BenchmarkOutcome.NotCompared
+  if (
+    label === SparklineLabelEnum.Benchmark ||
+    label === SparklineLabelEnum.Group
   ) {
-    benchmarkLabel = `${outcome} than England`;
-    comparisonLabel = `(${formatNumber(comparison)}%)`;
+    return { category, benchmarkLabel: '', comparisonLabel: '' };
   }
 
-  return { benchmarkLabel, category, comparisonLabel };
+  return {
+    category,
+    benchmarkLabel: getBenchmarkLabel(
+      benchmarkComparisonMethod,
+      benchmarkOutcome
+    ),
+    comparisonLabel: getComparisonLabelText(
+      benchmarkComparisonMethod,
+      benchmarkOutcome
+    ),
+  };
 };
 
 export function SparklineChart({


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-551](https://bjss-enterprise.atlassian.net/browse/DHSCFT-551)

## Changes

- Refactored the `sparklineTooltipContent` function to shown quintile values in hover

## Validation

Showing not compared
<img width="504" alt="image" src="https://github.com/user-attachments/assets/5d1fd2e2-3e19-4b44-ac9b-2258c13c2798" />

Showing worst quintile
<img width="500" alt="image" src="https://github.com/user-attachments/assets/27d2d61b-6562-4880-9587-3398f5cb8dc6" />

Showing better quintile
<img width="475" alt="image" src="https://github.com/user-attachments/assets/3cf452e7-e64a-4cdd-b16f-1bcfbdc22ed9" />

