### PR TITLE
DHSCFT-634: omit rows from spine chart table if any data is not found

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -104,7 +104,7 @@ describe('Spine chart table row', () => {
   });
 
   it('should have X for missing data', () => {
-    const indicatorWithMissingData = {
+    const indicatorWithMissingData: SpineChartIndicatorData = {
       ...mockIndicatorData,
       groupData: {
         ...mockIndicatorData.groupData,
@@ -113,6 +113,8 @@ describe('Spine chart table row', () => {
       areasHealthData: [
         {
           ...mockIndicatorData.areasHealthData[0],
+          areaCode: 'A1425',
+          areaName: 'Greater Manchester ICB - 00T',
           healthData: [],
         },
       ],

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
@@ -22,23 +22,13 @@ import { orderStatistics } from '../SpineChart/SpineChartHelpers';
 import { SpineChartIndicatorData } from './spineChartTableHelpers';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
-export interface SpineChartMissingData {
-  value?: number;
-}
-
-export interface SpineChartTableProps {
+export interface SpineChartTableRowProps {
   indicatorData: SpineChartIndicatorData;
-}
-
-export function SpineChartMissingValue({
-  value,
-}: Readonly<SpineChartMissingData>) {
-  return value ?? 'X';
 }
 
 export function SpineChartTableRow({
   indicatorData,
-}: Readonly<SpineChartTableProps>) {
+}: Readonly<SpineChartTableRowProps>) {
   const {
     indicatorName,
     benchmarkComparisonMethod,
@@ -55,12 +45,12 @@ export function SpineChartTableRow({
 
   if (twoAreasRequested) {
     twoAreasLatestPeriodMatching =
-      areasHealthData[0].healthData.at(-1)?.year ===
-      areasHealthData[1].healthData.at(-1)?.year;
+      areasHealthData[0]?.healthData.at(-1)?.year ===
+      areasHealthData[1]?.healthData.at(-1)?.year;
   }
 
   const areaNames = areasHealthData.map(
-    (areaHealthData) => areaHealthData.areaName
+    (areaHealthData) => areaHealthData?.areaName ?? ''
   );
 
   return (
@@ -78,17 +68,17 @@ export function SpineChartTableRow({
       {twoAreasRequested ? (
         <>
           <StyledAlignRightCellPadLeft data-testid={'area-1-count-cell'}>
-            {formatWholeNumber(areasHealthData[0].healthData.at(-1)?.count)}
+            {formatWholeNumber(areasHealthData[0]?.healthData.at(-1)?.count)}
           </StyledAlignRightCellPadLeft>
           <StyledAlignRightBorderRightTableCell
             data-testid={'area-1-value-cell'}
           >
-            {formatNumber(areasHealthData[0].healthData.at(-1)?.value)}
+            {formatNumber(areasHealthData[0]?.healthData.at(-1)?.value)}
           </StyledAlignRightBorderRightTableCell>
           <StyledAlignRightCellPadLeft data-testid={'area-2-count-cell'}>
             {formatWholeNumber(
               twoAreasLatestPeriodMatching
-                ? areasHealthData[1].healthData.at(-1)?.count
+                ? areasHealthData[1]?.healthData.at(-1)?.count
                 : undefined
             )}
           </StyledAlignRightCellPadLeft>
@@ -97,7 +87,7 @@ export function SpineChartTableRow({
           >
             {formatNumber(
               twoAreasLatestPeriodMatching
-                ? areasHealthData[1].healthData.at(-1)?.value
+                ? areasHealthData[1]?.healthData.at(-1)?.value
                 : undefined
             )}
           </StyledAlignRightBorderRightTableCell>
@@ -107,16 +97,16 @@ export function SpineChartTableRow({
           <StyledAlignCentreTableCell data-testid={`trend-cell`}>
             <TrendTag
               trendFromResponse={
-                areasHealthData[0].healthData.at(-1)?.trend ??
+                areasHealthData[0]?.healthData.at(-1)?.trend ??
                 HealthDataPointTrendEnum.CannotBeCalculated
               }
             />
           </StyledAlignCentreTableCell>
           <StyledAlignRightCellPadLeft data-testid={`count-cell`}>
-            {formatWholeNumber(areasHealthData[0].healthData.at(-1)?.count)}
+            {formatWholeNumber(areasHealthData[0]?.healthData.at(-1)?.count)}
           </StyledAlignRightCellPadLeft>
           <StyledAlignRightBorderRightTableCell data-testid={`value-cell`}>
-            {formatNumber(areasHealthData[0].healthData.at(-1)?.value)}
+            {formatNumber(areasHealthData[0]?.healthData.at(-1)?.value)}
           </StyledAlignRightBorderRightTableCell>
         </>
       )}
@@ -139,11 +129,11 @@ export function SpineChartTableRow({
           period={latestDataPeriod}
           benchmarkValue={quartileData.englandValue ?? 0}
           quartileData={quartileData}
-          areaOneValue={areasHealthData[0].healthData.at(-1)?.value}
+          areaOneValue={areasHealthData[0]?.healthData.at(-1)?.value}
           areaTwoValue={areasHealthData[1]?.healthData.at(-1)?.value}
           areaNames={areaNames}
           areaOneOutcome={
-            areasHealthData[0].healthData.at(-1)?.benchmarkComparison?.outcome
+            areasHealthData[0]?.healthData.at(-1)?.benchmarkComparison?.outcome
           }
           areaTwoOutcome={
             areasHealthData[1]?.healthData.at(-1)?.benchmarkComparison?.outcome

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -34,7 +34,7 @@ export function SpineChartTable({
   const sortedData = sortByIndicator(indicatorData);
   const methods = getMethodsAndOutcomes(indicatorData);
   const areaNames = sortedData[0].areasHealthData.map(
-    (areaHealthData) => areaHealthData.areaName
+    (areaHealthData) => areaHealthData?.areaName ?? ''
   );
 
   return (

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
@@ -27,17 +27,13 @@ describe('spineChartTableHelpers tests', () => {
   ];
 
   describe('getHealthDataForArea', () => {
-    test('throws an error if undefined provided as the area health data param', () => {
-      expect(() => getHealthDataForArea(undefined, 'A12345')).toThrow(
-        'Indicator contains no area health data'
-      );
+    test('returns null if undefined provided as the area health data param', () => {
+      expect(getHealthDataForArea(undefined, 'A12345')).toBeNull();
     });
 
     // Expectation is that the function is used in the context of both existing when gathering the data
-    test('throws an error if the areaHealthData does not contain an item for the requested area code', () => {
-      expect(() => getHealthDataForArea(mockAreaHealthData, 'A1234')).toThrow(
-        'No health data found for the requested area code'
-      );
+    test('returns null if the areaHealthData does not contain an item for the requested area code', () => {
+      expect(getHealthDataForArea(mockAreaHealthData, 'A1234')).toBeNull();
     });
 
     test('gets the relevant health data item based on the requested area code', () => {

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -1,8 +1,10 @@
 import {
   BenchmarkComparisonMethod,
   HealthDataForArea,
+  IndicatorWithHealthDataForArea,
   QuartileData,
 } from '@/generated-sources/ft-api-client';
+import { IndicatorDocument } from '@/lib/search/searchTypes';
 
 export const spineChartImproperUsageError =
   'Improper usage: Spine chart should only be shown when 1-2 areas are selected';
@@ -16,7 +18,7 @@ export interface SpineChartIndicatorData {
   latestDataPeriod: number;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   valueUnit: string;
-  areasHealthData: HealthDataForArea[];
+  areasHealthData: (HealthDataForArea | null)[];
   groupData: HealthDataForArea;
   quartileData: QuartileData;
 }
@@ -31,9 +33,9 @@ export interface SpineChartIndicatorData {
 export const getHealthDataForArea = (
   areaHealthData: HealthDataForArea[] | undefined,
   areaCode: string
-): HealthDataForArea => {
+): HealthDataForArea | null => {
   if (!areaHealthData) {
-    throw new Error('Indicator contains no area health data');
+    return null;
   }
 
   const matchedAreaHealthData = areaHealthData.find(
@@ -41,8 +43,88 @@ export const getHealthDataForArea = (
   );
 
   if (!matchedAreaHealthData) {
-    throw new Error('No health data found for the requested area code');
+    return null;
   }
 
   return matchedAreaHealthData;
+};
+
+/**
+ * Organises all the retrieved data into the desired structure for the spine chart.
+ */
+export const buildSpineChartIndicatorData = (
+  allIndicatorData: IndicatorWithHealthDataForArea[],
+  allIndicatorMetadata: IndicatorDocument[],
+  quartileData: QuartileData[],
+  areasSelected: string[],
+  selectedGroupCode: string
+): SpineChartIndicatorData[] => {
+  return allIndicatorData
+    .map((indicatorData) => {
+      const relevantIndicatorMeta = allIndicatorMetadata.find(
+        (indicatorMetaData) => {
+          return (
+            indicatorMetaData.indicatorID ===
+            indicatorData.indicatorId?.toString()
+          );
+        }
+      );
+
+      if (!relevantIndicatorMeta) {
+        // No indicator AI search metadata found matching health data from API
+        return null;
+      }
+
+      const areasHealthData = areasSelected
+        .map((areaCode) => {
+          return getHealthDataForArea(indicatorData.areaHealthData, areaCode);
+        })
+        .filter((areaData) => areaData !== null);
+
+      if (areasHealthData.length !== areasSelected.length) {
+        // there was missing data
+        return null;
+      }
+
+      const matchedQuartileData = quartileData.find(
+        (quartileDataItem) =>
+          quartileDataItem.indicatorId === indicatorData.indicatorId
+      );
+
+      if (!matchedQuartileData) {
+        // No quartile data found for the requested indicator ID: ${indicatorData.indicatorId}
+        return null;
+      }
+
+      if (!areasHealthData[0]) {
+        // there is no latestDataPeriod - use the above rather than length check to satisfy typescript
+        // assertion that latestDataPeriod must be a number in the main return
+        return null;
+      }
+
+      const groupData = getHealthDataForArea(
+        indicatorData.areaHealthData,
+        selectedGroupCode
+      );
+      if (!groupData) {
+        // no group data
+        return null;
+      }
+
+      return {
+        indicatorId: relevantIndicatorMeta.indicatorID,
+        indicatorName: relevantIndicatorMeta.indicatorName,
+        valueUnit: relevantIndicatorMeta.unitLabel,
+        benchmarkComparisonMethod: indicatorData.benchmarkMethod,
+        // The latest period for the first area's data (health data is sorted be year ASC)
+        latestDataPeriod:
+          areasHealthData[0].healthData[
+            areasHealthData[0].healthData.length - 1
+          ].year,
+        areasHealthData,
+        groupData,
+        quartileData: matchedQuartileData,
+      };
+    })
+    .filter((data) => data !== null);
 };

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
@@ -5,14 +5,12 @@ import {
 } from '.';
 import {
   BenchmarkComparisonMethod,
+  HealthDataForArea,
   HealthDataPointTrendEnum,
   IndicatorPolarity,
-} from '@/generated-sources/ft-api-client';
-import { render, screen } from '@testing-library/react';
-import {
-  HealthDataForArea,
   IndicatorWithHealthDataForArea,
 } from '@/generated-sources/ft-api-client';
+import { render, screen } from '@testing-library/react';
 import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
@@ -247,45 +245,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
     expect(
       screen.queryByTestId('spineChartTable-component')
     ).not.toBeInTheDocument();
-  });
-
-  it('should throw an error if no AI search indicator data present for on of the indicators with health data', () => {
-    const areas = [mockAreas[0], mockAreas[1]];
-    mockSearchParams[SearchParams.AreasSelected] = areas;
-
-    const renderComponentWithError = () =>
-      render(
-        <TwoOrMoreIndicatorsAreasViewPlot
-          searchState={mockSearchParams}
-          indicatorData={mockIndicatorData}
-          indicatorMetadata={[]}
-          benchmarkStatistics={mockBenchmarkStatistics}
-        />
-      );
-
-    expect(renderComponentWithError).toThrow(
-      'No indicator AI search metadata found matching health data from API'
-    );
-  });
-
-  it('should throw an error if no quartile data for one of the requested indicators', () => {
-    const areas = [mockAreas[0], mockAreas[1]];
-    mockSearchParams[SearchParams.AreasSelected] = areas;
-    const quartileDataMissingOne = [mockBenchmarkStatistics[0]];
-
-    const renderComponentWithError = () =>
-      render(
-        <TwoOrMoreIndicatorsAreasViewPlot
-          searchState={mockSearchParams}
-          indicatorData={mockIndicatorData}
-          indicatorMetadata={mockMetaData}
-          benchmarkStatistics={quartileDataMissingOne}
-        />
-      );
-
-    expect(renderComponentWithError).toThrow(
-      'No quartile data found for the requested indicator ID: 321'
-    );
   });
 });
 

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
@@ -6,16 +6,12 @@ import {
   BenchmarkComparisonMethod,
   IndicatorPolarity,
   IndicatorWithHealthDataForArea,
-  QuartileData,
 } from '@/generated-sources/ft-api-client';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { SpineChartTable } from '@/components/organisms/SpineChartTable';
 import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { HeatmapIndicatorData } from '@/components/organisms/Heatmap/heatmapUtil';
-import {
-  getHealthDataForArea,
-  SpineChartIndicatorData,
-} from '@/components/organisms/SpineChartTable/spineChartTableHelpers';
+import { buildSpineChartIndicatorData } from '@/components/organisms/SpineChartTable/spineChartTableHelpers';
 import { determineAreaCodes } from '@/lib/chartHelpers/chartHelpers';
 
 export function extractHeatmapIndicatorData(
@@ -60,66 +56,6 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
     throw new Error('Invalid parameters provided to view plot');
   }
 
-  /**
-   * Organises all the retrieved data into the desired structure for the spine chart.
-   */
-  const buildSpineChartIndicatorData = (
-    allIndicatorData: IndicatorWithHealthDataForArea[],
-    allIndicatorMetadata: IndicatorDocument[],
-    quartileData: QuartileData[],
-    areasSelected: string[],
-    selectedGroupCode: string
-  ): SpineChartIndicatorData[] => {
-    return allIndicatorData.map((indicatorData) => {
-      const relevantIndicatorMeta = allIndicatorMetadata.find(
-        (indicatorMetaData) => {
-          return (
-            indicatorMetaData.indicatorID ===
-            indicatorData.indicatorId?.toString()
-          );
-        }
-      );
-
-      if (!relevantIndicatorMeta) {
-        throw new Error(
-          'No indicator AI search metadata found matching health data from API'
-        );
-      }
-
-      const areasHealthData = areasSelected.map((areaCode) => {
-        return getHealthDataForArea(indicatorData.areaHealthData, areaCode);
-      });
-      const matchedQuartileData = quartileData.find(
-        (quartileDataItem) =>
-          quartileDataItem.indicatorId === indicatorData.indicatorId
-      );
-
-      if (!matchedQuartileData) {
-        throw new Error(
-          `No quartile data found for the requested indicator ID: ${indicatorData.indicatorId}`
-        );
-      }
-
-      return {
-        indicatorId: relevantIndicatorMeta.indicatorID,
-        indicatorName: relevantIndicatorMeta.indicatorName,
-        valueUnit: relevantIndicatorMeta.unitLabel,
-        benchmarkComparisonMethod: indicatorData.benchmarkMethod,
-        // The latest period for the first area's data (health data is sorted be year ASC)
-        latestDataPeriod:
-          areasHealthData[0].healthData[
-            areasHealthData[0].healthData.length - 1
-          ].year,
-        areasHealthData,
-        groupData: getHealthDataForArea(
-          indicatorData.areaHealthData,
-          selectedGroupCode
-        ),
-        quartileData: matchedQuartileData,
-      };
-    });
-  };
-
   const buildHeatmapIndicatorData = (
     allIndicatorData: IndicatorWithHealthDataForArea[],
     indicatorMetadata: IndicatorDocument[]
@@ -139,18 +75,18 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
       });
   };
 
+  const spineChartIndicatorData = buildSpineChartIndicatorData(
+    indicatorData,
+    indicatorMetadata,
+    benchmarkStatistics,
+    areaCodes,
+    selectedGroupCode
+  );
+
   return (
     <section data-testid="twoOrMoreIndicatorsAreasViewPlot-component">
-      {areaCodes.length < 3 ? (
-        <SpineChartTable
-          indicatorData={buildSpineChartIndicatorData(
-            indicatorData,
-            indicatorMetadata,
-            benchmarkStatistics,
-            areaCodes,
-            selectedGroupCode
-          )}
-        />
+      {areaCodes.length < 3 && spineChartIndicatorData.length ? (
+        <SpineChartTable indicatorData={spineChartIndicatorData} />
       ) : null}
       {areaCodes.length > 1 ? (
         <Heatmap


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-634](https://bjss-enterprise.atlassian.net/browse/DHSCFT-634)

Stopped spine charts from crashing if there is data missing

## Changes

- Returned null in place of throwing an error
- Filtered out null results

## Consideration

Began updating code to show X's when data was missing, but this turned out to be a much bigger issue than simply omitting the incomplete row data altogether.

## Validation

http://20.26.160.30/chart?si=age&is=30302&is=20401&as=E12000004&as=E12000006&ats=regions&gts=england&gs=E92000001&iys=2015

Indicator: "Hepatitis B vaccination coverage aged 2 years" is missing in the spine chart table illustrated below as there is missing data.
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/91420ce6-ccbb-41e7-b707-1755be26cf1d" />
