### PR TITLE
Feature/dhscft 634 missing data for spine chart

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartHelpers.test.ts
@@ -5,12 +5,7 @@ describe('Spine chart helper', () => {
   it('empty stats should return zeros', () => {
     const emptyStats = {};
 
-    const emptyResults = {
-      best: 0,
-      bestQuartile: 0,
-      worstQuartile: 0,
-      worst: 0,
-    };
+    const emptyResults = {};
 
     expect(orderStatistics(emptyStats)).toEqual(emptyResults);
   });

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartHelpers.ts
@@ -4,17 +4,22 @@ import {
 } from '@/generated-sources/ft-api-client';
 
 type orderedQuartiles = {
-  best: number;
-  bestQuartile: number;
-  worstQuartile: number;
-  worst: number;
+  best?: number;
+  bestQuartile?: number;
+  worstQuartile?: number;
+  worst?: number;
 };
 
 export function orderStatistics(quartileData: QuartileData): orderedQuartiles {
-  const q0Value = quartileData.q0Value ?? 0;
-  const q1Value = quartileData.q1Value ?? 0;
-  const q3Value = quartileData.q3Value ?? 0;
-  const q4Value = quartileData.q4Value ?? 0;
+  const { q0Value, q1Value, q3Value, q4Value } = quartileData;
+  if (
+    q0Value === undefined ||
+    q1Value === undefined ||
+    q3Value === undefined ||
+    q4Value === undefined
+  ) {
+    return {};
+  }
 
   switch (quartileData.polarity) {
     case IndicatorPolarity.LowIsGood:

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
@@ -107,6 +107,14 @@ export function generateSeriesData({
     worstQuartile: lowerQuartile,
     worst,
   } = orderStatistics(quartileData);
+  if (
+    best === undefined ||
+    upperQuartile === undefined ||
+    lowerQuartile === undefined ||
+    worst === undefined
+  ) {
+    return null;
+  }
 
   const maxDiffFromBenchmark = Math.max(
     absDiff(best, benchmarkValue),
@@ -267,8 +275,18 @@ export function generateSeriesData({
   return seriesData;
 }
 export function generateChartOptions(props: Readonly<SpineChartProps>) {
-  const categories = [''];
+  const { quartileData } = props;
+  const { q0Value, q1Value, q3Value, q4Value } = quartileData;
+  if (
+    q0Value === undefined ||
+    q1Value === undefined ||
+    q3Value === undefined ||
+    q4Value === undefined
+  ) {
+    return null;
+  }
 
+  const categories = [''];
   return {
     chart: {
       type: 'bar',

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
@@ -275,13 +275,14 @@ export function generateSeriesData({
   return seriesData;
 }
 export function generateChartOptions(props: Readonly<SpineChartProps>) {
-  const { quartileData } = props;
+  const { quartileData, benchmarkValue } = props;
   const { q0Value, q1Value, q3Value, q4Value } = quartileData;
   if (
     q0Value === undefined ||
     q1Value === undefined ||
     q3Value === undefined ||
-    q4Value === undefined
+    q4Value === undefined ||
+    benchmarkValue === undefined
   ) {
     return null;
   }

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/index.tsx
@@ -27,7 +27,9 @@ export interface SpineChartProps {
 export function SpineChart(props: Readonly<SpineChartProps>) {
   const spineChartsOptions = generateChartOptions(props);
   if (!spineChartsOptions)
-    return <div style={{ textAlign: 'center' }}>Insufficient data</div>;
+    return (
+      <div style={{ textAlign: 'center' }}>Insufficient data available</div>
+    );
 
   const { benchmarkValue } = props;
 

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/index.tsx
@@ -26,6 +26,9 @@ export interface SpineChartProps {
 
 export function SpineChart(props: Readonly<SpineChartProps>) {
   const spineChartsOptions = generateChartOptions(props);
+  if (!spineChartsOptions)
+    return <div style={{ textAlign: 'center' }}>Insufficient data</div>;
+
   const { benchmarkValue } = props;
 
   return (

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -5,6 +5,7 @@ import { GovukColours } from '@/lib/styleHelpers/colours';
 import {
   BenchmarkComparisonMethod,
   BenchmarkOutcome,
+  HealthDataForArea,
   HealthDataPointTrendEnum,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
@@ -104,12 +105,14 @@ describe('Spine chart table row', () => {
   });
 
   it('should have X for missing data', () => {
+    const groupData: HealthDataForArea = {
+      areaCode: '90210',
+      areaName: 'Manchester',
+      healthData: [],
+    };
     const indicatorWithMissingData: SpineChartIndicatorData = {
       ...mockIndicatorData,
-      groupData: {
-        ...mockIndicatorData.groupData,
-        healthData: [],
-      },
+      groupData,
       areasHealthData: [
         {
           ...mockIndicatorData.areasHealthData[0],

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -3,78 +3,19 @@ import { expect } from '@jest/globals';
 import { SpineChartTableRow } from './SpineChartTableRow';
 import { GovukColours } from '@/lib/styleHelpers/colours';
 import {
-  BenchmarkComparisonMethod,
-  BenchmarkOutcome,
   HealthDataForArea,
   HealthDataPointTrendEnum,
-  IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
 import { SpineChartIndicatorData } from './spineChartTableHelpers';
 import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
+import { mockSpineIndicatorData } from '@/components/organisms/SpineChartTable/spineChartMockTestData';
 
 describe('Spine chart table row', () => {
-  const mockIndicatorData: SpineChartIndicatorData = {
-    indicatorId: '1',
-    indicatorName: 'indicator',
-    latestDataPeriod: 2025,
-    valueUnit: '%',
-    benchmarkComparisonMethod:
-      BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
-    areasHealthData: [
-      {
-        areaCode: 'A1425',
-        areaName: 'Greater Manchester ICB - 00T',
-        healthData: [
-          {
-            year: 2025,
-            count: 222,
-            value: 690.305692,
-            lowerCi: 341.69151,
-            upperCi: 478.32766,
-            ageBand: allAgesAge,
-            sex: personsSex,
-            trend: HealthDataPointTrendEnum.CannotBeCalculated,
-            deprivation: noDeprivation,
-            benchmarkComparison: {
-              method: BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
-              outcome: BenchmarkOutcome.Similar,
-            },
-          },
-        ],
-      },
-    ],
-    groupData: {
-      areaCode: '90210',
-      areaName: 'Manchester',
-      healthData: [
-        {
-          year: 2025,
-          count: 3333,
-          value: 890.305692,
-          lowerCi: 341.69151,
-          upperCi: 478.32766,
-          ageBand: allAgesAge,
-          sex: personsSex,
-          trend: HealthDataPointTrendEnum.NotYetCalculated,
-          deprivation: noDeprivation,
-        },
-      ],
-    },
-    quartileData: {
-      polarity: IndicatorPolarity.HighIsGood,
-      q0Value: 999,
-      q1Value: 760,
-      q3Value: 500,
-      q4Value: 345,
-      areaValue: 550,
-    },
-  };
-
   it('should have dark grey cell color for benchmark column', () => {
     render(
       <table>
         <tbody>
-          <SpineChartTableRow indicatorData={mockIndicatorData} />
+          <SpineChartTableRow indicatorData={mockSpineIndicatorData} />
         </tbody>
       </table>
     );
@@ -94,7 +35,7 @@ describe('Spine chart table row', () => {
     render(
       <table>
         <tbody>
-          <SpineChartTableRow indicatorData={mockIndicatorData} />
+          <SpineChartTableRow indicatorData={mockSpineIndicatorData} />
         </tbody>
       </table>
     );
@@ -104,27 +45,24 @@ describe('Spine chart table row', () => {
     );
   });
 
-  it('should have X for missing data', () => {
+  it('should have X for missing data and insufficient data', () => {
     const groupData: HealthDataForArea = {
       areaCode: '90210',
       areaName: 'Manchester',
       healthData: [],
     };
     const indicatorWithMissingData: SpineChartIndicatorData = {
-      ...mockIndicatorData,
+      ...mockSpineIndicatorData,
       groupData,
       areasHealthData: [
         {
-          ...mockIndicatorData.areasHealthData[0],
+          ...mockSpineIndicatorData.areasHealthData[0],
           areaCode: 'A1425',
           areaName: 'Greater Manchester ICB - 00T',
           healthData: [],
         },
       ],
-      quartileData: {
-        ...mockIndicatorData.quartileData,
-        areaValue: undefined,
-      },
+      quartileData: {},
     };
 
     render(
@@ -142,13 +80,15 @@ describe('Spine chart table row', () => {
     expect(screen.getByTestId('group-value-cell')).toHaveTextContent(`X`);
 
     expect(screen.getByTestId('benchmark-value-cell')).toHaveTextContent(`X`);
+
+    expect(screen.getByText('Insufficient data available')).toBeInTheDocument();
   });
 
   it('should have an additional count and value section when an 2 areas are requested', () => {
     const indicatorDataWithTwoAreas = {
-      ...mockIndicatorData,
+      ...mockSpineIndicatorData,
       areasHealthData: [
-        mockIndicatorData.areasHealthData[0],
+        mockSpineIndicatorData.areasHealthData[0],
         {
           areaCode: 'A1426',
           areaName: 'Greater Manchester ICB - 01T',
@@ -187,7 +127,7 @@ describe('Spine chart table row', () => {
 
   it('should not render a cell for group if the group is England', () => {
     const indicatorDataGroupEngland = {
-      ...mockIndicatorData,
+      ...mockSpineIndicatorData,
       groupData: {
         areaCode: 'E92000001',
         areaName: 'England',

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
@@ -39,7 +39,7 @@ export function SpineChartTableRow({
     quartileData,
   } = indicatorData;
   const { best, worst } = orderStatistics(quartileData);
-  const groupIsEngland = groupData.areaCode === areaCodeForEngland;
+  const groupIsEngland = groupData?.areaCode === areaCodeForEngland;
   const twoAreasRequested = areasHealthData.length === 2;
   let twoAreasLatestPeriodMatching = true;
 
@@ -113,7 +113,7 @@ export function SpineChartTableRow({
 
       {!groupIsEngland ? (
         <StyledGroupCell data-testid={`group-value-cell`}>
-          {formatNumber(groupData.healthData.at(-1)?.value)}
+          {formatNumber(groupData?.healthData.at(-1)?.value)}
         </StyledGroupCell>
       ) : null}
       <StyledBenchmarkCell data-testid={`benchmark-value-cell`}>
@@ -139,11 +139,11 @@ export function SpineChartTableRow({
             areasHealthData[1]?.healthData.at(-1)?.benchmarkComparison?.outcome
           }
           groupValue={
-            !groupIsEngland ? groupData.healthData.at(-1)?.value : undefined
+            !groupIsEngland ? groupData?.healthData.at(-1)?.value : undefined
           }
-          groupName={!groupIsEngland ? (groupData.areaName ?? '') : ''}
+          groupName={!groupIsEngland ? (groupData?.areaName ?? '') : ''}
           groupOutcome={
-            groupData.healthData.at(-1)?.benchmarkComparison?.outcome
+            groupData?.healthData.at(-1)?.benchmarkComparison?.outcome
           }
           benchmarkMethod={benchmarkComparisonMethod}
         />

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Table } from 'govuk-react';
-import React from 'react';
+import React, { FC } from 'react';
 
 import {
   StyledAlignCentreTableCell,
@@ -26,9 +26,9 @@ export interface SpineChartTableRowProps {
   indicatorData: SpineChartIndicatorData;
 }
 
-export function SpineChartTableRow({
+export const SpineChartTableRow: FC<SpineChartTableRowProps> = ({
   indicatorData,
-}: Readonly<SpineChartTableRowProps>) {
+}) => {
   const {
     indicatorName,
     benchmarkComparisonMethod,
@@ -153,4 +153,4 @@ export function SpineChartTableRow({
       </StyledBenchmarkCell>
     </Table.Row>
   );
-}
+};

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -42,7 +42,7 @@ export function SpineChartTable({
       <SpineChartHeading>Compare indicators by areas</SpineChartHeading>
       <SpineChartLegend
         legendsToShow={methods}
-        groupName={sortedData[0].groupData.areaName}
+        groupName={sortedData[0].groupData?.areaName}
         areaNames={areaNames}
       />
       <SpineChartQuartilesInfoContainer />
@@ -50,7 +50,7 @@ export function SpineChartTable({
         <StyledTable>
           <SpineChartTableHeader
             areaNames={areaNames}
-            groupName={sortedData[0].groupData.areaName}
+            groupName={sortedData[0].groupData?.areaName ?? 'Group'}
           />
           {sortedData.map((indicatorData) => (
             <React.Fragment key={indicatorData.indicatorId}>

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -23,7 +23,7 @@ export interface SpineChartTableProps {
 
 const sortByIndicator = (indicatorData: SpineChartIndicatorData[]) =>
   indicatorData.toSorted((a, b) =>
-    a.indicatorName.localeCompare(b.indicatorName, 'en', {
+    a.indicatorName?.localeCompare(b.indicatorName, 'en', {
       sensitivity: 'base',
     })
   );

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartMockTestData.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartMockTestData.ts
@@ -1,0 +1,109 @@
+import { SpineChartIndicatorData } from '@/components/organisms/SpineChartTable/spineChartTableHelpers';
+import {
+  BenchmarkComparisonMethod,
+  BenchmarkOutcome,
+  HealthDataForArea,
+  HealthDataPointTrendEnum,
+  IndicatorPolarity,
+  IndicatorWithHealthDataForArea,
+  QuartileData,
+} from '@/generated-sources/ft-api-client';
+import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
+import { IndicatorDocument } from '@/lib/search/searchTypes';
+
+export const mockSpineHealthDataForArea: HealthDataForArea = {
+  areaCode: 'A1425',
+  areaName: 'Greater Manchester ICB - 00T',
+  healthData: [
+    {
+      year: 2025,
+      count: 222,
+      value: 690.305692,
+      lowerCi: 341.69151,
+      upperCi: 478.32766,
+      ageBand: allAgesAge,
+      sex: personsSex,
+      trend: HealthDataPointTrendEnum.CannotBeCalculated,
+      deprivation: noDeprivation,
+      benchmarkComparison: {
+        method: BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
+        outcome: BenchmarkOutcome.Similar,
+      },
+    },
+  ],
+};
+
+export const mockSpineGroupData = {
+  areaCode: '90210',
+  areaName: 'Manchester',
+  healthData: [
+    {
+      year: 2025,
+      count: 3333,
+      value: 890.305692,
+      lowerCi: 341.69151,
+      upperCi: 478.32766,
+      ageBand: allAgesAge,
+      sex: personsSex,
+      trend: HealthDataPointTrendEnum.NotYetCalculated,
+      deprivation: noDeprivation,
+    },
+  ],
+};
+
+export const mockSpineQuartileData: QuartileData = {
+  indicatorId: 1,
+  polarity: IndicatorPolarity.HighIsGood,
+  q0Value: 999,
+  q1Value: 760,
+  q3Value: 500,
+  q4Value: 345,
+  areaValue: 550,
+};
+
+export const mockSpineIndicatorData: SpineChartIndicatorData = {
+  indicatorId: '1',
+  indicatorName: 'indicator',
+  latestDataPeriod: 2025,
+  valueUnit: '%',
+  benchmarkComparisonMethod:
+    BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
+  areasHealthData: [mockSpineHealthDataForArea],
+  groupData: mockSpineGroupData,
+  quartileData: mockSpineQuartileData,
+};
+
+export const mockSpineIndicatorWithHealthData: IndicatorWithHealthDataForArea =
+  {
+    indicatorId: 1,
+    name: 'indicator',
+    polarity: IndicatorPolarity.HighIsGood,
+    benchmarkMethod: BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
+    areaHealthData: [mockSpineHealthDataForArea],
+  };
+
+export const mockSpineIndicatorWithHealthDataWithGroup: IndicatorWithHealthDataForArea =
+  {
+    ...mockSpineIndicatorWithHealthData,
+    areaHealthData: [mockSpineHealthDataForArea, mockSpineGroupData],
+  };
+
+export const mockSpineIndicatorWithNoHealthData: IndicatorWithHealthDataForArea =
+  {
+    ...mockSpineIndicatorWithHealthData,
+    areaHealthData: [],
+  };
+
+export const mockSpineIndicatorDocument: IndicatorDocument = {
+  // for spine chart we only need indicatorId and unitLabel
+  indicatorID: '1',
+  unitLabel: '%',
+  //
+  dataSource: '',
+  earliestDataPeriod: '',
+  hasInequalities: false,
+  indicatorDefinition: '',
+  indicatorName: '',
+  lastUpdatedDate: new Date(),
+  latestDataPeriod: '',
+};

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
@@ -1,30 +1,20 @@
+import { HealthDataForArea } from '@/generated-sources/ft-api-client';
 import {
-  HealthDataForArea,
-  HealthDataPointTrendEnum,
-} from '@/generated-sources/ft-api-client';
-import { getHealthDataForArea } from './spineChartTableHelpers';
-import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
+  buildSpineChartIndicatorData,
+  getHealthDataForArea,
+} from './spineChartTableHelpers';
+import {
+  mockSpineHealthDataForArea,
+  mockSpineIndicatorData,
+  mockSpineIndicatorDocument,
+  mockSpineIndicatorWithHealthData,
+  mockSpineIndicatorWithHealthDataWithGroup,
+  mockSpineIndicatorWithNoHealthData,
+  mockSpineQuartileData,
+} from '@/components/organisms/SpineChartTable/spineChartMockTestData';
 
 describe('spineChartTableHelpers tests', () => {
-  const mockAreaHealthData: HealthDataForArea[] = [
-    {
-      areaCode: 'A1425',
-      areaName: 'Greater Manchester ICB - 00T',
-      healthData: [
-        {
-          year: 2025,
-          count: 222,
-          value: 690.305692,
-          lowerCi: 341.69151,
-          upperCi: 478.32766,
-          ageBand: allAgesAge,
-          sex: personsSex,
-          trend: HealthDataPointTrendEnum.CannotBeCalculated,
-          deprivation: noDeprivation,
-        },
-      ],
-    },
-  ];
+  const mockAreaHealthData: HealthDataForArea[] = [mockSpineHealthDataForArea];
 
   describe('getHealthDataForArea', () => {
     test('returns null if undefined provided as the area health data param', () => {
@@ -40,6 +30,125 @@ describe('spineChartTableHelpers tests', () => {
       expect(getHealthDataForArea(mockAreaHealthData, 'A1425')).toBe(
         mockAreaHealthData[0]
       );
+    });
+  });
+
+  describe('buildSpineChartIndicatorData', () => {
+    it('should return empty array when no data supplied', () => {
+      const result = buildSpineChartIndicatorData([], [], [], [], '');
+      expect(result).toEqual([]);
+    });
+
+    it('should return spine chart row data', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithHealthDataWithGroup],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([mockSpineIndicatorData]);
+    });
+
+    it('should return spine chart row data when group is missing', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithHealthData],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      const expected = { ...mockSpineIndicatorData, groupData: null };
+      expect(result).toEqual([expected]);
+    });
+
+    it('should return spine chart row data when indicator meta is missing', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithHealthDataWithGroup],
+        [],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+
+      // value unit is the only thing we lose is indicator meta is missing
+      const expected = { ...mockSpineIndicatorData, valueUnit: '' };
+      expect(result).toEqual([expected]);
+    });
+
+    it('should return [] if indicators are missing', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] if areas do not match', () => {
+      const areasSelected: string[] = ['A142xxx'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithHealthDataWithGroup],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] if quartiles are missing', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithHealthDataWithGroup],
+        [mockSpineIndicatorDocument],
+        [],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] if area health data is missing', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const result = buildSpineChartIndicatorData(
+        [mockSpineIndicatorWithNoHealthData],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] if indicatorData is missing id', () => {
+      const areasSelected: string[] = ['A1425'];
+      const selectedGroupCode: string = '90210';
+      const indicatorWithMissingId = {
+        ...mockSpineIndicatorWithHealthDataWithGroup,
+        indicatorId: undefined,
+      };
+      const result = buildSpineChartIndicatorData(
+        [indicatorWithMissingId],
+        [mockSpineIndicatorDocument],
+        [mockSpineQuartileData],
+        areasSelected,
+        selectedGroupCode
+      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -19,7 +19,7 @@ export interface SpineChartIndicatorData {
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   valueUnit: string;
   areasHealthData: (HealthDataForArea | null)[];
-  groupData: HealthDataForArea;
+  groupData: HealthDataForArea | null;
   quartileData: QuartileData;
 }
 
@@ -72,6 +72,9 @@ export const buildSpineChartIndicatorData = (
 
       if (!relevantIndicatorMeta) {
         // No indicator AI search metadata found matching health data from API
+        console.log(
+          `No indicator AI search metadata found matching health data from API: ${indicatorData.indicatorId}`
+        );
         return null;
       }
 
@@ -83,6 +86,7 @@ export const buildSpineChartIndicatorData = (
 
       if (areasHealthData.length !== areasSelected.length) {
         // there was missing data
+        console.log('an area was missing');
         return null;
       }
 
@@ -93,12 +97,14 @@ export const buildSpineChartIndicatorData = (
 
       if (!matchedQuartileData) {
         // No quartile data found for the requested indicator ID: ${indicatorData.indicatorId}
+        console.log('No quartile data found matching health data from API');
         return null;
       }
 
       if (!areasHealthData[0]) {
         // there is no latestDataPeriod - use the above rather than length check to satisfy typescript
         // assertion that latestDataPeriod must be a number in the main return
+        console.log('No healthdata');
         return null;
       }
 
@@ -108,7 +114,8 @@ export const buildSpineChartIndicatorData = (
       );
       if (!groupData) {
         // no group data
-        return null;
+        console.log('No group data');
+        // return null;
       }
 
       return {

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -61,22 +61,19 @@ export const buildSpineChartIndicatorData = (
 ): SpineChartIndicatorData[] => {
   return allIndicatorData
     .map((indicatorData) => {
-      const relevantIndicatorMeta = allIndicatorMetadata.find(
-        (indicatorMetaData) => {
-          return (
-            indicatorMetaData.indicatorID ===
-            indicatorData.indicatorId?.toString()
-          );
-        }
-      );
-
-      if (!relevantIndicatorMeta) {
-        // No indicator AI search metadata found matching health data from API
-        console.log(
-          `No indicator AI search metadata found matching health data from API: ${indicatorData.indicatorId}`
-        );
+      if (
+        indicatorData.indicatorId === undefined ||
+        indicatorData.name === null
+      ) {
+        // the entire row will be missing
         return null;
       }
+      const indicatorId = indicatorData.indicatorId.toString();
+      const relevantIndicatorMeta = allIndicatorMetadata.find(
+        (indicatorMetaData) => {
+          return indicatorMetaData.indicatorID === indicatorId;
+        }
+      );
 
       const areasHealthData = areasSelected
         .map((areaCode) => {
@@ -84,9 +81,11 @@ export const buildSpineChartIndicatorData = (
         })
         .filter((areaData) => areaData !== null);
 
-      if (areasHealthData.length !== areasSelected.length) {
-        // there was missing data
-        console.log('an area was missing');
+      if (
+        areasHealthData.length !== areasSelected.length ||
+        !areasHealthData[0]
+      ) {
+        // there was missing data for an area
         return null;
       }
 
@@ -97,14 +96,6 @@ export const buildSpineChartIndicatorData = (
 
       if (!matchedQuartileData) {
         // No quartile data found for the requested indicator ID: ${indicatorData.indicatorId}
-        console.log('No quartile data found matching health data from API');
-        return null;
-      }
-
-      if (!areasHealthData[0]) {
-        // there is no latestDataPeriod - use the above rather than length check to satisfy typescript
-        // assertion that latestDataPeriod must be a number in the main return
-        console.log('No healthdata');
         return null;
       }
 
@@ -112,16 +103,11 @@ export const buildSpineChartIndicatorData = (
         indicatorData.areaHealthData,
         selectedGroupCode
       );
-      if (!groupData) {
-        // no group data
-        console.log('No group data');
-        // return null;
-      }
 
       return {
-        indicatorId: relevantIndicatorMeta.indicatorID,
-        indicatorName: relevantIndicatorMeta.indicatorName,
-        valueUnit: relevantIndicatorMeta.unitLabel,
+        indicatorId,
+        indicatorName: indicatorData.name as string,
+        valueUnit: relevantIndicatorMeta?.unitLabel ?? '',
         benchmarkComparisonMethod: indicatorData.benchmarkMethod,
         // The latest period for the first area's data (health data is sorted be year ASC)
         latestDataPeriod:


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-634](https://bjss-enterprise.atlassian.net/browse/DHSCFT-634)

Spine chart table should show X's and `Insufficient data available` when data is missing
## Changes

- show `Insufficient data available` message
- show X when missing data
- consolidate mock testing data for spine
- spine more resilient to missing data

## Validation

![image](https://github.com/user-attachments/assets/2ed88624-8346-42f9-83ce-ff8b363fa991)
