### PR TITLE
DHSCFT-650: Bugfix - only the England bar should be dark grey

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
@@ -124,7 +124,8 @@ export function SparklineChart({
     benchmarkOutcome,
     polarity
   );
-  const color = benchmarkColor ?? GovukColours.DarkGrey;
+  const defaultColour = area === 'England' ? GovukColours.DarkGrey : '#fff';
+  const color = benchmarkColor ?? defaultColour;
 
   const [options, setOptions] = useState<Highcharts.Options>();
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-650](https://bjss-enterprise.atlassian.net/browse/DHSCFT-650)

## Changes

- Default bar colour to white unless the area is England

## Validation

![image](https://github.com/user-attachments/assets/fb4edd48-9d98-4da3-90fb-8d70b955d993)