### PR TITLE
DHSCFT-638 remove 20 indicator limit

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.test.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.test.ts
@@ -119,13 +119,14 @@ describe('useIndicatorSort', () => {
     ]);
   });
 
-  it('should limit the results to 20', () => {
+  it('should not limit the results to 20', () => {
+    // we have previously limited the results to 20, but don't anymore.
     mockGetSearchState.mockImplementation(() => ({
       [SearchParams.SearchedOrder]: SortOrderKeys.updated,
     }));
-    const lotsOfResults = new Array(30).map(() => mockApple);
+    const lotsOfResults = new Array(35).map(() => mockApple);
     const { result } = renderHook(() => useIndicatorSort(lotsOfResults));
-    expect(result.current.sortedResults).toHaveLength(20);
+    expect(result.current.sortedResults).toHaveLength(35);
   });
 
   it('should return a callback function to use on the select element', () => {

--- a/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSort/useIndicatorSort.ts
@@ -6,8 +6,6 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useLoadingState } from '@/context/LoaderContext';
 import { useSearchState } from '@/context/SearchStateContext';
 
-export const maxResults = 20;
-
 export const useIndicatorSort = (results: IndicatorDocument[]) => {
   const pathname = usePathname();
   const { replace } = useRouter();
@@ -46,12 +44,10 @@ export const useIndicatorSort = (results: IndicatorDocument[]) => {
     [selectedSortOrder]
   );
 
-  const sorted =
+  const sortedResults =
     selectedSortOrder === SortOrderKeys.relevance
       ? results
       : results.toSorted(sortFunction);
-
-  const sortedResults = sorted.slice(0, maxResults);
 
   return { sortedResults, handleSortOrder, selectedSortOrder };
 };


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-638](https://bjss-enterprise.atlassian.net/browse/DHSCFT-638)

Indicator searches were client side limited to 20 display results. This limit is being removed for the POC.

## Changes

- Removed the 20 indicator limit from `useIndicatorSort`.

## Validation

Quick run of the app plus check all the automated tests.