### PR TITLE
DHSCFT-652: Only show heatmap when all areas in group selected

### DIFF
--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
@@ -15,6 +15,7 @@ import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { HeatmapIndicatorData } from '@/components/organisms/Heatmap/heatmapUtil';
+import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 
 jest.mock('next/navigation', () => {
   const originalModule = jest.requireActual('next/navigation');
@@ -29,12 +30,7 @@ const indicatorIds = ['123', '321'];
 const mockAreas = ['A001', 'A002', 'A003'];
 const mockGroupArea = 'G001';
 
-const mockSearchParams: SearchStateParams = {
-  [SearchParams.SearchedIndicator]: 'testing',
-  [SearchParams.IndicatorsSelected]: indicatorIds,
-  [SearchParams.AreasSelected]: mockAreas,
-  [SearchParams.GroupSelected]: mockGroupArea,
-};
+let mockSearchParams: SearchStateParams;
 
 const mockGroupHealthData: HealthDataForArea = {
   areaCode: mockGroupArea,
@@ -213,6 +209,17 @@ const mockBenchmarkStatistics = [
 ];
 
 describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
+  beforeEach(() => {
+    // Ensure defaults are not overwritten
+    mockSearchParams = {
+      [SearchParams.SearchedIndicator]: 'testing',
+      [SearchParams.IndicatorsSelected]: indicatorIds,
+      [SearchParams.AreasSelected]: mockAreas,
+      [SearchParams.GroupSelected]: mockGroupArea,
+      [SearchParams.GroupAreaSelected]: undefined,
+    };
+  });
+
   it('should render all components with up to 2 areas selected', () => {
     const areas = [mockAreas[0], mockAreas[1]];
     mockSearchParams[SearchParams.AreasSelected] = areas;
@@ -225,8 +232,28 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
         benchmarkStatistics={mockBenchmarkStatistics}
       />
     );
+
     expect(screen.getByTestId('heatmapChart-component')).toBeInTheDocument();
     expect(screen.getByTestId('spineChartTable-component')).toBeInTheDocument();
+  });
+
+  it('should render the heatmap but not the spine chart when all areas in a group are selected', () => {
+    mockSearchParams[SearchParams.AreasSelected] = undefined;
+    mockSearchParams[SearchParams.GroupAreaSelected] = ALL_AREAS_SELECTED;
+
+    render(
+      <TwoOrMoreIndicatorsAreasViewPlot
+        searchState={mockSearchParams}
+        indicatorData={mockIndicatorData}
+        indicatorMetadata={mockMetaData}
+        benchmarkStatistics={mockBenchmarkStatistics}
+      />
+    );
+
+    expect(screen.getByTestId('heatmapChart-component')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('spineChartTable-component')
+    ).not.toBeInTheDocument();
   });
 
   it('should not render the spine chart component with more than 2 areas selected', () => {
@@ -241,6 +268,7 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
         benchmarkStatistics={mockBenchmarkStatistics}
       />
     );
+
     expect(screen.getByTestId('heatmapChart-component')).toBeInTheDocument();
     expect(
       screen.queryByTestId('spineChartTable-component')

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
@@ -18,25 +18,23 @@ import {
 import { determineAreaCodes } from '@/lib/chartHelpers/chartHelpers';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 
-interface ComponentRenderFlags {
-  showHeatmap: boolean;
-  showSpineChart: boolean;
+function shouldShowHeatmap(
+  areaCodes: string[],
+  groupAreaSelected?: string
+): boolean {
+  return areaCodes.length > 1 || groupAreaSelected === ALL_AREAS_SELECTED;
 }
 
-function getComponentRenderFlags(
+function shouldShowSpineChart(
   areaCodes: string[],
   spineChartIndicatorData: SpineChartIndicatorData[],
   groupAreaSelected?: string
-): ComponentRenderFlags {
-  const areAllAreasSelected = groupAreaSelected === ALL_AREAS_SELECTED;
-
-  return {
-    showHeatmap: areaCodes.length > 1 || areAllAreasSelected,
-    showSpineChart:
-      areaCodes.length < 3 &&
-      spineChartIndicatorData.length > 0 &&
-      !areAllAreasSelected,
-  };
+): boolean {
+  return (
+    areaCodes.length < 3 &&
+    spineChartIndicatorData.length > 0 &&
+    groupAreaSelected !== ALL_AREAS_SELECTED
+  );
 }
 
 export function extractHeatmapIndicatorData(
@@ -108,18 +106,17 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
     areaCodes,
     selectedGroupCode
   );
-  const { showHeatmap, showSpineChart } = getComponentRenderFlags(
-    areaCodes,
-    spineChartIndicatorData,
-    groupAreaSelected
-  );
 
   return (
     <section data-testid="twoOrMoreIndicatorsAreasViewPlot-component">
-      {showSpineChart ? (
+      {shouldShowSpineChart(
+        areaCodes,
+        spineChartIndicatorData,
+        groupAreaSelected
+      ) ? (
         <SpineChartTable indicatorData={spineChartIndicatorData} />
       ) : null}
-      {showHeatmap ? (
+      {shouldShowHeatmap(areaCodes, groupAreaSelected) ? (
         <Heatmap
           indicatorData={buildHeatmapIndicatorData(
             indicatorData,

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
@@ -11,8 +11,33 @@ import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { SpineChartTable } from '@/components/organisms/SpineChartTable';
 import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { HeatmapIndicatorData } from '@/components/organisms/Heatmap/heatmapUtil';
-import { buildSpineChartIndicatorData } from '@/components/organisms/SpineChartTable/spineChartTableHelpers';
+import {
+  buildSpineChartIndicatorData,
+  SpineChartIndicatorData,
+} from '@/components/organisms/SpineChartTable/spineChartTableHelpers';
 import { determineAreaCodes } from '@/lib/chartHelpers/chartHelpers';
+import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
+
+interface ComponentRenderFlags {
+  showHeatmap: boolean;
+  showSpineChart: boolean;
+}
+
+function getComponentRenderFlags(
+  areaCodes: string[],
+  spineChartIndicatorData: SpineChartIndicatorData[],
+  groupAreaSelected?: string
+): ComponentRenderFlags {
+  const areAllAreasSelected = groupAreaSelected === ALL_AREAS_SELECTED;
+
+  return {
+    showHeatmap: areaCodes.length > 1 || areAllAreasSelected,
+    showSpineChart:
+      areaCodes.length < 3 &&
+      spineChartIndicatorData.length > 0 &&
+      !areAllAreasSelected,
+  };
+}
 
 export function extractHeatmapIndicatorData(
   indicatorData: IndicatorWithHealthDataForArea,
@@ -44,6 +69,7 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
   const {
     [SearchParams.AreasSelected]: areasSelected,
     [SearchParams.GroupSelected]: selectedGroupCode,
+    [SearchParams.GroupAreaSelected]: groupAreaSelected,
   } = stateManager.getSearchState();
 
   const areaCodes = determineAreaCodes(
@@ -82,13 +108,18 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
     areaCodes,
     selectedGroupCode
   );
+  const { showHeatmap, showSpineChart } = getComponentRenderFlags(
+    areaCodes,
+    spineChartIndicatorData,
+    groupAreaSelected
+  );
 
   return (
     <section data-testid="twoOrMoreIndicatorsAreasViewPlot-component">
-      {areaCodes.length < 3 && spineChartIndicatorData.length ? (
+      {showSpineChart ? (
         <SpineChartTable indicatorData={spineChartIndicatorData} />
       ) : null}
-      {areaCodes.length > 1 ? (
+      {showHeatmap ? (
         <Heatmap
           indicatorData={buildHeatmapIndicatorData(
             indicatorData,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-652](https://bjss-enterprise.atlassian.net/browse/DHSCFT-652)

We had not coded for this scenario and this was highlighted in the demo.

## Changes

- Added extra logic to check for the `SearchParams.GroupAreaSelected` value and render accordingly
- Added additional unit test for this scenario

## Validation

Tested locally and also ran a regression checking all the other scenarios documented in the ticket.
