### PR TITLE
DHSCFT-TECH: Improve API test output

### DIFF
--- a/.github/workflows/e2e-and-api-tests.yml
+++ b/.github/workflows/e2e-and-api-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run .http API tests
         working-directory: ./api
         run: |
-          npx httpyac send ./**/*.http --all --json --output-failed short --output short | tee httpyacresults.json
+          npx httpyac send ./**/*.http --all --json --filter only-failed --output-failed exchange | tee httpyacresults.json
           HTTP_EXIT_CODE=${PIPESTATUS[0]}
 
           # Exit with the same code that httpyac returned

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
@@ -1,7 +1,7 @@
 ### check get multiple areas returns the list of area details for the requested area codes.
 
 # North East Region and Yorkshire and the Humber Region
-GET http://localhost:5144/areas?area_codes=E12000001&area_codes=E12000003
+GET http://localhost:5144/pigeons?area_codes=E12000001&area_codes=E12000003
 
 > {%
     const expected = require ('./test-areas-multiple-areas-response.json');

--- a/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
+++ b/api/DHSC.FingertipsNext.Modules.Area/HttpClientScripts/test-areas-multiple-areas.http
@@ -1,7 +1,7 @@
 ### check get multiple areas returns the list of area details for the requested area codes.
 
 # North East Region and Yorkshire and the Humber Region
-GET http://localhost:5144/pigeons?area_codes=E12000001&area_codes=E12000003
+GET http://localhost:5144/areas?area_codes=E12000001&area_codes=E12000003
 
 > {%
     const expected = require ('./test-areas-multiple-areas-response.json');

--- a/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quintiles.http
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quintiles.http
@@ -57,50 +57,56 @@ GET http://localhost:5144/indicators/94103/data?area_codes=E08000029&area_codes=
 
 ### check High is good TODO - POC data doesn't offer data to validate this
 
-### check No Judgement - current site doesn't 
+### check No Judgement - current site doesn't
 GET http://localhost:5144/indicators/90453/data?area_codes=K84031&area_codes=A84022&area_type=gps&years=2023&years=2022&years=2021&years=2020
 
 > {%
-        const expectedResults = [ 
-            {areaName:"Coquet Medical Group", year:2020, outcome:"Middle"},
-            {areaName:"Coquet Medical Group", year:2021, outcome:"Low"},
-            {areaName:"Coquet Medical Group", year:2022, outcome:"Highest"},
-            {areaName:"Coquet Medical Group", year:2023, outcome:"Highest"},
-            {areaName:"The Leys Health Centre", year:2020, outcome:"Middle"},
-            {areaName:"The Leys Health Centre", year:2021, outcome:"Low"},
-            {areaName:"The Leys Health Centre", year:2022, outcome:"Middle"},
-            {areaName:"The Leys Health Centre", year:2023, outcome:"High"},
-            ];
+        client.test("received expected health data with quintile comparison", () => {
+            const expectedResults = [ 
+                {areaName:"Coquet Medical Group", year:2020, outcome:"Middle"},
+                {areaName:"Coquet Medical Group", year:2021, outcome:"Poop"},
+                {areaName:"Coquet Medical Group", year:2022, outcome:"Highest"},
+                {areaName:"Coquet Medical Group", year:2023, outcome:"Highest"},
+                {areaName:"The Leys Health Centre", year:2020, outcome:"Middle"},
+                {areaName:"The Leys Health Centre", year:2021, outcome:"Low"},
+                {areaName:"The Leys Health Centre", year:2022, outcome:"Middle"},
+                {areaName:"The Leys Health Centre", year:2023, outcome:"High"},
+                ];
 
-        expectedResults.forEach((expected) => {
-             client.assert(
-                response.body.areaHealthData.find(area => area.areaName === expected.areaName)
-                .healthData.find(dataPoint => dataPoint.year === expected.year)
-                .benchmarkComparison.outcome === expected.outcome
-            );
-        });    
+            expectedResults.forEach((expected) => {
+                client.assert(
+                    response.body.areaHealthData.find(area => area.areaName === expected.areaName)
+                    .healthData.find(dataPoint => dataPoint.year === expected.year)
+                    .benchmarkComparison.outcome === expected.outcome,
+                    `failed for ${expected.areaName}`
+                );
+            });
+        });
 %}
 
 
-### check Low is good 
+### check Low is good polarity
 GET http://localhost:5144/indicators/94103/data?area_codes=E10000014&area_codes=E08000029&area_codes=E06000005&area_codes=E09000023&area_type=counties-and-unitary-authorities&years=2019&years=2018&years=2017&years=2016
 
 > {%
-        const expectedResults = [ 
-            {areaName:"Darlington", year:2016, outcome:"Worse"},
-            {areaName:"Darlington", year:2019, outcome:"Worse"},
-            {areaName:"Hampshire", year:2016, outcome:"Best"},
-            {areaName:"Hampshire", year:2019, outcome:"Best"},
-            {areaName:"Lewisham", year:2016, outcome:"Better"},
-            {areaName:"Lewisham", year:2019, outcome:"Better"},
-            ];
+        client.test("received expected health data with quintile comparison", () => {
+            const expectedResults = [
+                {areaName:"Darlington", year:2016, outcome:"Worse"},
+                {areaName:"Darlington", year:2019, outcome:"Worse"},
+                {areaName:"Hampshire", year:2016, outcome:"Best"},
+                {areaName:"Hampshire", year:2019, outcome:"Best"},
+                {areaName:"Lewisham", year:2016, outcome:"Better"},
+                {areaName:"Lewisham", year:2019, outcome:"Better"},
+                ];
 
-        expectedResults.forEach((expected) => {
-             client.assert(
-                response.body.areaHealthData.find(area => area.areaName === expected.areaName)
-                .healthData.find(dataPoint => dataPoint.year === expected.year)
-                .benchmarkComparison.outcome === expected.outcome
-            );
+            expectedResults.forEach((expected) => {
+                client.assert(
+                    response.body.areaHealthData.find(area => area.areaName === expected.areaName)
+                    .healthData.find(dataPoint => dataPoint.year === expected.year)
+                    .benchmarkComparison.outcome === expected.outcome,
+                    `failed for ${expected.areaName}`
+                );
+            });
         });
 %}
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quintiles.http
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quintiles.http
@@ -64,7 +64,7 @@ GET http://localhost:5144/indicators/90453/data?area_codes=K84031&area_codes=A84
         client.test("received expected health data with quintile comparison", () => {
             const expectedResults = [ 
                 {areaName:"Coquet Medical Group", year:2020, outcome:"Middle"},
-                {areaName:"Coquet Medical Group", year:2021, outcome:"Poop"},
+                {areaName:"Coquet Medical Group", year:2021, outcome:"Low"},
                 {areaName:"Coquet Medical Group", year:2022, outcome:"Highest"},
                 {areaName:"Coquet Medical Group", year:2023, outcome:"Highest"},
                 {areaName:"The Leys Health Centre", year:2020, outcome:"Middle"},

--- a/api/README.md
+++ b/api/README.md
@@ -26,10 +26,16 @@ This project includes unit tests which must be run and extended as needed. They 
 
 The project also includes .http files which define API requests and validation which should be run as integration tests with the DB. These can be run using the VSCode "REST Client" plugin.
 
-The .http files include embedded scripts to validate the responses. To execute these tests locally, first spin up the docker environment and then, from the api directory do:
+The .http files include embedded scripts to validate the responses. To execute these tests locally, first spin up the docker environment and then, from the api directory run:
 
+`npx httpyac send ./**/*.http --all --json --filter only-failed --output-failed exchange > httpyacresults.json`
+
+This will execute the .http test files and direct the output to the `httpyacresults.json` file. The report will only include failed tests
+and will provide the full failing response body and headers etc.
+
+The same command is also executed in the push and pull_request pipelines once the docker services have been started, and before the e2e tests run.
+
+Alternatively, if you would like a high-level report of all the tests, you can run:
 `npx httpyac send ./**/*.http --all --json --output-failed short --output short > httpyacresults.json`
 
-This will execute the .http test files and build an output report file.
-
-Note that these tests are executed in the push and pull_request pipelines, once the docker services have been started, and before the e2e tests run.
+For more info on this tool, please visit: [httpyac](https://www.npmjs.com/package/httpyac)


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-661](https://bjss-enterprise.atlassian.net/browse/DHSCFT-661)

See linked pipeline in ticket. We found that the output of the API test is truncated and it is also very difficult to identify what actually went wrong. This PR aims to improve this.

## Changes

- Updates the command that is run in the pipeline. The command will now 1. only show the failed output and overall summary (much less verbose) 2. show the full failing API response
- Adds a couple of improvements to one test file to ensure that errors are surfaced correctly
- Adds details to the Readme to make the usage and intent of httpyac clearer

## Validation

I created some failing tests so we can validate that A. the pipeline fails and B. the output is improved.

You can see the results of that pipeline run here: https://github.com/dhsc-govuk/FingertipsNext/actions/runs/14513047508?pr=482

I then reverted the failing pipeline and ensures that it passes on this PR.

Finally, I also verified that the command runs as expected locally.
