### PR TITLE
DHSCFT-625: Removed console logs in two indicators multiple areas tests

### DIFF
--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
@@ -87,8 +87,8 @@ const mockAreaHealthData: HealthDataForArea[] = [
     ],
   },
   {
-    areaCode: mockAreas[0],
-    areaName: 'Greater Manchester ICB - 00T',
+    areaCode: mockAreas[1],
+    areaName: 'Greater Manchester ICB - 01T',
     healthData: [
       {
         year: 2024,
@@ -104,8 +104,8 @@ const mockAreaHealthData: HealthDataForArea[] = [
     ],
   },
   {
-    areaCode: mockAreas[1],
-    areaName: 'Greater Manchester ICB - 00T',
+    areaCode: mockAreas[2],
+    areaName: 'Greater Manchester ICB - 02T',
     healthData: [
       {
         year: 2008,
@@ -120,23 +120,6 @@ const mockAreaHealthData: HealthDataForArea[] = [
       },
     ],
   },
-  {
-    areaCode: mockAreas[1],
-    areaName: 'Greater Manchester ICB - 00T',
-    healthData: [
-      {
-        year: 2024,
-        count: 111,
-        value: 690.305692,
-        lowerCi: 341.69151,
-        upperCi: 478.32766,
-        ageBand: allAgesAge,
-        sex: personsSex,
-        trend: HealthDataPointTrendEnum.NotYetCalculated,
-        deprivation: noDeprivation,
-      },
-    ],
-  },
 ];
 
 const mockIndicatorData: IndicatorWithHealthDataForArea[] = [
@@ -144,7 +127,7 @@ const mockIndicatorData: IndicatorWithHealthDataForArea[] = [
     indicatorId: Number(indicatorIds[0]),
     areaHealthData: [
       mockAreaHealthData[0],
-      mockAreaHealthData[2],
+      mockAreaHealthData[1],
       mockGroupHealthData,
       mockEnglandHealthData,
     ],
@@ -153,7 +136,7 @@ const mockIndicatorData: IndicatorWithHealthDataForArea[] = [
     indicatorId: Number(indicatorIds[1]),
     areaHealthData: [
       mockAreaHealthData[1],
-      mockAreaHealthData[3],
+      mockAreaHealthData[2],
       mockGroupHealthData,
       mockEnglandHealthData,
     ],
@@ -182,7 +165,7 @@ const mockMetaData = [
     earliestDataPeriod: '2023',
     latestDataPeriod: '2023',
     lastUpdatedDate: new Date('March 4, 2023'),
-    associatedAreaCodes: [mockAreas[0], mockAreas[1]],
+    associatedAreaCodes: [mockAreas[2], mockAreas[3]],
     unitLabel: 'values',
     hasInequalities: true,
     usedInPoc: false,


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-625](https://bjss-enterprise.atlassian.net/browse/DHSCFT-625)



## Changes
Does what it says on the tin. Removes the duplicate keys due to us repeating the area name in the test data.
