### PR TITLE
DHSCFT-595: Clear selected indicators for a new home page search

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
@@ -15,13 +15,10 @@ const $IndicatorSearchFormSchema = z
   })
   .refine((data) => {
     const stateParsed = JSON.parse(data.searchState);
-    if (
-      data.indicator.trim().length > 0 ||
-      stateParsed[SearchParams.AreasSelected]?.length > 0
-    ) {
-      return true;
-    }
-    return false;
+
+    return data.indicator.trim().length > 0 ||
+      stateParsed[SearchParams.AreasSelected]?.length > 0;
+
   });
 
 export type State = {

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/indicatorSearchActions.ts
@@ -16,9 +16,10 @@ const $IndicatorSearchFormSchema = z
   .refine((data) => {
     const stateParsed = JSON.parse(data.searchState);
 
-    return data.indicator.trim().length > 0 ||
-      stateParsed[SearchParams.AreasSelected]?.length > 0;
-
+    return (
+      data.indicator.trim().length > 0 ||
+      stateParsed[SearchParams.AreasSelected]?.length > 0
+    );
   });
 
 export type State = {

--- a/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
+++ b/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
@@ -44,7 +44,6 @@ const areasSelectedState = JSON.stringify({
   [SearchParams.AreasSelected]: ['foo', 'bar'],
 });
 
-
 const indicatorsSelectedState = JSON.stringify({
   [SearchParams.IndicatorsSelected]: ['1', '2'],
 });
@@ -150,7 +149,6 @@ describe('Search actions', () => {
       RedirectType.push
     );
   });
-
 });
 
 describe('getSearchSuggestions', () => {

--- a/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
+++ b/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.test.ts
@@ -11,6 +11,7 @@ import { SearchParams } from '@/lib/searchStateManager';
 import { SearchServiceFactory } from '@/lib/search/searchServiceFactory';
 import { AreaDocument } from '@/lib/search/searchTypes';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
+import { IndicatorSearchFormState } from '@/components/forms/IndicatorSearchForm/indicatorSearchActions';
 
 jest.mock('next/navigation');
 const redirectMock = jest.mocked(redirect);
@@ -43,6 +44,11 @@ const areasSelectedState = JSON.stringify({
   [SearchParams.AreasSelected]: ['foo', 'bar'],
 });
 
+
+const indicatorsSelectedState = JSON.stringify({
+  [SearchParams.IndicatorsSelected]: ['1', '2'],
+});
+
 const initialStateWithoutAreas: SearchFormState = {
   indicator: 'some indicator',
   searchState: noAreasSelectedState,
@@ -51,6 +57,11 @@ const initialStateWithoutAreas: SearchFormState = {
 const initialStateWithAreas: SearchFormState = {
   indicator: 'some indicator',
   searchState: areasSelectedState,
+};
+
+const initialStateWithIndicatorsSelected: IndicatorSearchFormState = {
+  indicator: 'some indicator',
+  searchState: indicatorsSelectedState,
 };
 
 describe('Search actions', () => {
@@ -125,6 +136,21 @@ describe('Search actions', () => {
       'Please enter an indicator ID or select at least one area'
     );
   });
+
+  it('should redirect to search results and remove any indicators selected from URL', async () => {
+    const formData = getMockFormData({
+      indicator: 'boom',
+      searchState: indicatorsSelectedState,
+    });
+
+    await searchIndicator(initialStateWithIndicatorsSelected, formData);
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `/results?${SearchParams.SearchedIndicator}=boom`,
+      RedirectType.push
+    );
+  });
+
 });
 
 describe('getSearchSuggestions', () => {

--- a/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.ts
+++ b/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.ts
@@ -19,10 +19,11 @@ const $SearchFormSchema = z
   .refine((data) => {
     const stateParsed = JSON.parse(data.searchState);
 
-    return data.indicator.trim().length > 0 ||
+    return (
+      data.indicator.trim().length > 0 ||
       stateParsed[SearchParams.AreasSelected]?.length > 0 ||
-      stateParsed[SearchParams.GroupAreaSelected] === ALL_AREAS_SELECTED;
-
+      stateParsed[SearchParams.GroupAreaSelected] === ALL_AREAS_SELECTED
+    );
   });
 
 export type State = {

--- a/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.ts
+++ b/frontend/fingertips-frontend/components/forms/SearchForm/searchActions.ts
@@ -18,14 +18,11 @@ const $SearchFormSchema = z
   })
   .refine((data) => {
     const stateParsed = JSON.parse(data.searchState);
-    if (
-      data.indicator.trim().length > 0 ||
+
+    return data.indicator.trim().length > 0 ||
       stateParsed[SearchParams.AreasSelected]?.length > 0 ||
-      stateParsed[SearchParams.GroupAreaSelected] === ALL_AREAS_SELECTED
-    ) {
-      return true;
-    }
-    return false;
+      stateParsed[SearchParams.GroupAreaSelected] === ALL_AREAS_SELECTED;
+
   });
 
 export type State = {
@@ -70,6 +67,8 @@ export async function searchIndicator(
     SearchParams.SearchedIndicator,
     indicator
   );
+
+  searchStateManager.removeAllParamFromState(SearchParams.IndicatorsSelected);
 
   redirect(searchStateManager.generatePath('/results'), RedirectType.push);
 }

--- a/frontend/fingertips-frontend/components/pages/home/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/home/index.tsx
@@ -10,7 +10,7 @@ import {
   UnorderedList,
   SectionBreak,
 } from 'govuk-react';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchStateParams } from '@/lib/searchStateManager';
 import { SearchForm } from '@/components/forms/SearchForm';
 import {
   SearchFormState,
@@ -42,15 +42,7 @@ export const Home = ({
   const { setSearchState } = useSearchState();
 
   useEffect(() => {
-    const currentSearchState = searchState ?? {};
-    setSearchState({
-      [SearchParams.SearchedIndicator]:
-        currentSearchState[SearchParams.SearchedIndicator],
-      [SearchParams.AreasSelected]:
-        currentSearchState[SearchParams.AreasSelected],
-      [SearchParams.AreaTypeSelected]:
-        currentSearchState[SearchParams.AreaTypeSelected],
-    });
+    setSearchState(searchState ?? {});
   }, [searchState, setSearchState]);
 
   useEffect(() => {

--- a/frontend/fingertips-frontend/components/pages/home/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/home/index.tsx
@@ -48,6 +48,8 @@ export const Home = ({
         currentSearchState[SearchParams.SearchedIndicator],
       [SearchParams.AreasSelected]:
         currentSearchState[SearchParams.AreasSelected],
+      [SearchParams.AreaTypeSelected]:
+        currentSearchState[SearchParams.AreaTypeSelected],
     });
   }, [searchState, setSearchState]);
 

--- a/frontend/fingertips-frontend/components/pages/home/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/home/index.tsx
@@ -10,7 +10,7 @@ import {
   UnorderedList,
   SectionBreak,
 } from 'govuk-react';
-import { SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { SearchForm } from '@/components/forms/SearchForm';
 import {
   SearchFormState,
@@ -42,7 +42,13 @@ export const Home = ({
   const { setSearchState } = useSearchState();
 
   useEffect(() => {
-    setSearchState(searchState ?? {});
+    const currentSearchState = searchState ?? {};
+    setSearchState({
+      [SearchParams.SearchedIndicator]:
+        currentSearchState[SearchParams.SearchedIndicator],
+      [SearchParams.AreasSelected]:
+        currentSearchState[SearchParams.AreasSelected],
+    });
   }, [searchState, setSearchState]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-595](https://bjss-enterprise.atlassian.net/browse/DHSCFT-595)

Clear selected indicators when the user actions a new search from the homepage

## Changes

- When the `searchAction` on the homepage is actioned, remove selected indicators from search state before generating results page url.

## Validation
Ran the unit tests. Manually check the scenario in the video.