### PR TITLE
DHSCFT-667: spine chart shapes should be white when benchmarking is undefined or Not Compared

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChart.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChart.test.tsx
@@ -9,6 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { generateSeriesData } from '@/components/organisms/SpineChart/SpineChartOptions';
 import Highcharts from 'highcharts';
+import { GovukColours } from '@/lib/styleHelpers/colours';
 
 describe('Spine chart', () => {
   const mockIndicator = 'mock indicator';
@@ -64,16 +65,16 @@ describe('Spine chart', () => {
     }) as Highcharts.SeriesScatterOptions[];
 
     expect(result[5].marker).toEqual({
-      fillColor: '#ffffff',
-      lineColor: '#000',
+      fillColor: GovukColours.White,
+      lineColor: GovukColours.Black,
       lineWidth: 1,
       radius: 6,
       symbol: 'circle',
     });
 
     expect(result[6].marker).toEqual({
-      fillColor: '#ffffff',
-      lineColor: '#000',
+      fillColor: GovukColours.White,
+      lineColor: GovukColours.Black,
       lineWidth: 1,
       radius: 6,
       symbol: 'square',

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChart.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChart.test.tsx
@@ -1,10 +1,14 @@
 import {
+  BenchmarkComparisonMethod,
+  BenchmarkOutcome,
   IndicatorPolarity,
   QuartileData,
 } from '@/generated-sources/ft-api-client';
 import { SpineChart } from '.';
 import { render, screen } from '@testing-library/react';
 import { expect } from '@jest/globals';
+import { generateSeriesData } from '@/components/organisms/SpineChart/SpineChartOptions';
+import Highcharts from 'highcharts';
 
 describe('Spine chart', () => {
   const mockIndicator = 'mock indicator';
@@ -39,5 +43,40 @@ describe('Spine chart', () => {
       'highcharts-react-component-spineChart'
     );
     expect(highChartChartComponent).toBeInTheDocument();
+  });
+
+  it('should show white shapes when benchmarking is unavailable', () => {
+    const result = generateSeriesData({
+      name: 'foo',
+      period: mockPeriod,
+      units: '%',
+      benchmarkValue: mockValue,
+      quartileData: mockQuartileData,
+      areaOneValue: 123,
+      areaOneOutcome: BenchmarkOutcome.NotCompared,
+      areaTwoValue: 456,
+      areaTwoOutcome: undefined,
+      areaNames: ['a', 'b'],
+      groupValue: 789,
+      groupName: 'g',
+      groupOutcome: BenchmarkOutcome.Better,
+      benchmarkMethod: BenchmarkComparisonMethod.CIOverlappingReferenceValue95,
+    }) as Highcharts.SeriesScatterOptions[];
+
+    expect(result[5].marker).toEqual({
+      fillColor: '#ffffff',
+      lineColor: '#000',
+      lineWidth: 1,
+      radius: 6,
+      symbol: 'circle',
+    });
+
+    expect(result[6].marker).toEqual({
+      fillColor: '#ffffff',
+      lineColor: '#000',
+      lineWidth: 1,
+      radius: 6,
+      symbol: 'square',
+    });
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
@@ -268,11 +268,12 @@ export function generateSeriesData({
   areas.forEach(({ value, outcome, areaName }, index) => {
     if (value === undefined) return;
 
-    const fillColor = getBenchmarkColour(
-      benchmarkMethod ?? BenchmarkComparisonMethod.Unknown,
-      outcome ?? BenchmarkOutcome.NotCompared,
-      quartileData.polarity ?? IndicatorPolarity.NoJudgement
-    );
+    const fillColor =
+      getBenchmarkColour(
+        benchmarkMethod ?? BenchmarkComparisonMethod.Unknown,
+        outcome ?? BenchmarkOutcome.NotCompared,
+        quartileData.polarity ?? IndicatorPolarity.NoJudgement
+      ) ?? '#ffffff';
 
     const absAreaValue =
       inverter * (Math.abs(value) - Math.abs(benchmarkValue));
@@ -287,7 +288,7 @@ export function generateSeriesData({
         value: value,
         units: units,
         outcome: outcome ?? 'Not compared',
-        colour: fillColor ?? '#ffffff',
+        colour: fillColor,
         shape: index === 0 ? SymbolsEnum.Circle : SymbolsEnum.Square,
       }),
       marker: {
@@ -317,6 +318,7 @@ export function generateSeriesData({
 
   return seriesData;
 }
+
 export function generateChartOptions(props: Readonly<SpineChartProps>) {
   const { quartileData, benchmarkValue } = props;
   const { q0Value, q1Value, q3Value, q4Value } = quartileData;

--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
@@ -246,14 +246,14 @@ export function generateSeriesData({
         value: groupValue,
         units: units,
         outcome: groupOutcome ?? 'Not compared',
-        colour: '#fff',
+        colour: GovukColours.White,
         shape: SymbolsEnum.Diamond,
       }),
       marker: {
         symbol: 'diamond',
         radius: 8,
-        fillColor: '#fff',
-        lineColor: '#000',
+        fillColor: GovukColours.White,
+        lineColor: GovukColours.Black,
         lineWidth: markerLineWidth,
       },
       data: [scaledGroup],
@@ -273,7 +273,7 @@ export function generateSeriesData({
         benchmarkMethod ?? BenchmarkComparisonMethod.Unknown,
         outcome ?? BenchmarkOutcome.NotCompared,
         quartileData.polarity ?? IndicatorPolarity.NoJudgement
-      ) ?? '#ffffff';
+      ) ?? GovukColours.White;
 
     const absAreaValue =
       inverter * (Math.abs(value) - Math.abs(benchmarkValue));
@@ -295,7 +295,7 @@ export function generateSeriesData({
         symbol: index === 0 ? 'circle' : 'square',
         radius: 6,
         fillColor,
-        lineColor: '#000',
+        lineColor: GovukColours.Black,
         lineWidth: markerLineWidth,
       },
       data: [scaledArea],
@@ -310,7 +310,7 @@ export function generateSeriesData({
       marker: {
         symbol: 'circle',
         radius: 2,
-        fillColor: '#000',
+        fillColor: GovukColours.Black,
       },
       data: [0],
     });


### PR DESCRIPTION

# Description

Jira ticket: [DHSCFT-667](https://bjss-enterprise.atlassian.net/browse/DHSCFT-667)

Change markers to white

## Changes

- Change markers to white when there is no benchmark data