### PR TITLE
Bugfix/dhscft 668 add `than England` to the hovers

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChart/SpineChartOptions.ts
@@ -111,8 +111,12 @@ function formatSymbolHover(props: FormatSymbolHoverProps) {
                     padding:0.5em;
                     ">
                     <span style="display: block;">${formatNumber(props.value)}${formatUnits(props.units)}</span>
-                    <span style="display: block;">${props.outcome}</span>
-                    <span style="display: block;">${benchmarkComparisonMethodToString(props.benchmarkComparisonMethod)}</span>
+                    ${
+                      props.outcome === 'Not compared'
+                        ? '<span style="display: block;">Not compared</span>'
+                        : `<span style="display: block;">${props.outcome} than England</span>
+                         <span style="display: block;">${benchmarkComparisonMethodToString(props.benchmarkComparisonMethod)}</span>`
+                    }
                   </div>
               </div>
             <div>


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-668](https://bjss-enterprise.atlassian.net/browse/DHSCFT-668)

## Changes

- Add 'than England' to the spine chart hovers

## Validation
<img width="388" alt="image" src="https://github.com/user-attachments/assets/4bc5b4b3-ba06-4260-b203-dc2dc57f1f22" />
