### PR TITLE
DHSCFT-662: Improve get latest data functionality

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
+++ b/api/DHSC.FingertipsNext.Modules.Area/Controllers/V1/AreaController.cs
@@ -16,7 +16,7 @@ namespace DHSC.FingertipsNext.Modules.Area.Controllers.V1;
 public class AreaController : ControllerBase
 {
     private readonly IAreaService _areaService;
-    private const int MaxNumberAreas = 100;
+    private const int MaxNumberAreas = 300;
 
     /// <summary>
     ///

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataPredicates.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataPredicates.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DHSC.FingertipsNext.Modules.HealthData.Repository;
 
-public class HealthDataPredicates
+public static class HealthDataPredicates
 {
     private const string ENGLAND_AREA_CODE = "E92000001";
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataPredicates.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataPredicates.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+using DHSC.FingertipsNext.Modules.HealthData.Repository.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DHSC.FingertipsNext.Modules.HealthData.Repository;
+
+public class HealthDataPredicates
+{
+    private const string ENGLAND_AREA_CODE = "E92000001";
+
+    public static Expression<Func<HealthMeasureModel, bool>> IsInAreaCodes(string[] areaCodes) {
+        return healthMeasure => areaCodes.Length == 0 || EF.Constant(areaCodes).Contains(healthMeasure.AreaDimension.Code);
+    }
+
+    /// <summary>
+    /// Checks that when multiple areas are requested - i.e. more than one area code or no area codes (so everything) -
+    /// that the a given area code is not the one for England.
+    /// </summary>
+    public static Expression<Func<HealthMeasureModel, bool>> IsNotEnglandWhenMultipleRequested(string[] areaCodes) {
+        return healthMeasure => areaCodes.Length == 1 || healthMeasure.AreaDimension.Code != ENGLAND_AREA_CODE;
+    }
+}

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -9,16 +9,19 @@ namespace DHSC.FingertipsNext.Modules.HealthData.Repository;
 [SuppressMessage("ReSharper", "SimplifyConditionalTernaryExpression")]
 public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHealthDataRepository
 {
+    private const string ENGLAND_AREA_CODE = "E92000001";
     private const string SEX = "sex";
     private const string AGE = "age";
     private const string DEPRIVATION = "deprivation";
 
     private readonly HealthDataDbContext _dbContext = healthDataDbContext ?? throw new ArgumentNullException(nameof(healthDataDbContext));
 
-    public async Task<IndicatorDimensionModel> GetIndicatorDimensionAsync(int indicatorId)
+    public async Task<IndicatorDimensionModel> GetIndicatorDimensionAsync(int indicatorId, string[] areaCodes)
     {
         var model = await _dbContext.HealthMeasure
            .Where(healthMeasure => healthMeasure.IndicatorDimension.IndicatorId == indicatorId)
+           .Where(healthMeasure => areaCodes.Length == 0 || EF.Constant(areaCodes).Contains(healthMeasure.AreaDimension.Code))
+           .Where(healthMeasure => areaCodes.Length == 1 || healthMeasure.AreaDimension.Code != ENGLAND_AREA_CODE)
            .OrderByDescending(healthMeasure => healthMeasure.Year)
            .Include(healthMeasure => healthMeasure.IndicatorDimension)
            .Select(healthMeasure => new IndicatorDimensionModel

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -16,6 +16,16 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
 
     private readonly HealthDataDbContext _dbContext = healthDataDbContext ?? throw new ArgumentNullException(nameof(healthDataDbContext));
 
+    /// <summary>
+    /// Will retrieve the indicator dimension data for the requested indicator ID while also
+    /// obtaining the latest year that data is available for the indicator based on the area codes provided.
+    /// 
+    /// Note: both in terms of intent and performance this is sub-optimal and should be refactored at the earliest opportunity
+    /// post-POC.
+    /// </summary>
+    /// <param name="indicatorId"></param>
+    /// <param name="areaCodes"></param>
+    /// <returns>IndicatorDimensionModel containing relevant indicator metadata</returns>
     public async Task<IndicatorDimensionModel> GetIndicatorDimensionAsync(int indicatorId, string[] areaCodes)
     {
         var model = await _dbContext.HealthMeasure

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -56,7 +56,7 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
                LatestYear = healthMeasure.Year
            })
            .Take(1)
-           .FirstOrDefaultAsync();;
+           .FirstOrDefaultAsync();
     }
     
     public async Task<IEnumerable<HealthMeasureModel>> GetIndicatorDataAsync(int indicatorId, string[] areaCodes, int[] years, string[] inequalities)

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -31,7 +31,7 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
         var model = await _dbContext.HealthMeasure
            .Where(healthMeasure => healthMeasure.IndicatorDimension.IndicatorId == indicatorId)
            .Where(healthMeasure => areaCodes.Length == 0 || EF.Constant(areaCodes).Contains(healthMeasure.AreaDimension.Code))
-           .Where(healthMeasure => areaCodes.Length == 1 || healthMeasure.AreaDimension.Code != ENGLAND_AREA_CODE)
+           .Where(healthMeasure => IsNotEnglandWhenMultipleRequested(healthMeasure.AreaDimension.Code, areaCodes))
            .OrderByDescending(healthMeasure => healthMeasure.Year)
            .Include(healthMeasure => healthMeasure.IndicatorDimension)
            .Select(healthMeasure => new IndicatorDimensionModel
@@ -210,4 +210,11 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
         return retVal;
     }
 
+    /// <summary>
+    /// Checks that when multiple areas are requested - i.e. more than one area code or no area codes (so everything) -
+    /// that the a given area code is not the one for England.
+    /// </summary>
+    private static bool IsNotEnglandWhenMultipleRequested(string areaCode, string[] areaCodes) {
+        return areaCodes.Length == 1 || areaCode != ENGLAND_AREA_CODE;
+    }
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/IHealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/IHealthDataRepository.cs
@@ -15,7 +15,7 @@ public interface IHealthDataRepository
                                                                  int[] years,
                                                                  string areaType);
 
-    Task<IndicatorDimensionModel> GetIndicatorDimensionAsync(int indicatorId);
+    Task<IndicatorDimensionModel> GetIndicatorDimensionAsync(int indicatorId, string[] areaCodes);
     Task<IEnumerable<QuartileDataModel>> GetQuartileDataAsync(IEnumerable<int> indicatorIds, string areaCode, string areaTypeKey, string ancestorCode);
 
     Task<IEnumerable<AreaDimensionModel>> GetAreasAsync(string[] areaCodes);

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
@@ -45,7 +45,7 @@ public class IndicatorService(IHealthDataRepository healthDataRepository, IMappe
         bool includeEmptyAreas = false,
         bool latestOnly = false)
     {
-        var indicatorData = await healthDataRepository.GetIndicatorDimensionAsync(indicatorId);
+        var indicatorData = await healthDataRepository.GetIndicatorDimensionAsync(indicatorId, [.. areaCodes]);
         if (indicatorData == null) 
             return new ServiceResponse<IndicatorWithHealthDataForAreas>(ResponseStatus.IndicatorDoesNotExist);
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
@@ -119,6 +119,29 @@ public class HealthDataRepositoryTests
         result.LatestYear.ShouldBe(ENGLAND_YEAR);
     }
 
+    [Fact]
+    public async Task Repository_ShouldReturnCorrectIndicatorAndLatestYearForEnglandWhenAreasContainNoData()
+    {
+        const int ENGLAND_YEAR = 2024;
+        const string ENGLAND_AREA_CODE = "E92000001";
+        const int INDICATORID = 1;
+        // arrange
+        PopulateDatabase(new HealthMeasureModelHelper(year: ENGLAND_YEAR)
+            .WithIndicatorDimension(indicatorId: INDICATORID)
+            .WithAreaDimension(code: ENGLAND_AREA_CODE)
+            .Build());
+
+        // act
+        var result = await _healthDataRepository.GetIndicatorDimensionAsync(1, [
+            ENGLAND_AREA_CODE,
+            "TESTAREA_ONE",
+            "TESTAREA_TWO"
+        ]);
+
+        // assert
+        result.LatestYear.ShouldBe(ENGLAND_YEAR);
+    }
+
     #endregion
 
     #region GetIndicatorDataAsync

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Repository/HealthDataRepositoryTests.cs
@@ -30,9 +30,20 @@ public class HealthDataRepositoryTests
     }
 
     [Fact]
-    public async Task Repository_ShouldReturnCorrectIndicatorAndLatestYear()
+    public void RepositoryInitialisation_ShouldThrowError_IfNullDBContextIsProvided()
     {
-        const int LATESTYEAR= 2099;
+        var act = () => _healthDataRepository = new HealthDataRepository(null!);
+
+        act.ShouldThrow<ArgumentNullException>()
+            .Message.ShouldBe("Value cannot be null. (Parameter 'healthDataDbContext')");
+    }
+
+    #region GetIndicatorDimensionAsync
+
+    [Fact]
+    public async Task Repository_ShouldReturnCorrectIndicatorAndLatestYearWhenNoAreaCodesProvided()
+    {
+        const int LATESTYEAR = 2099;
         const int INDICATORID = 1;
         // arrange
         PopulateDatabase(new HealthMeasureModelHelper(year: LATESTYEAR)
@@ -48,21 +59,67 @@ public class HealthDataRepositoryTests
         });
 
         // act
-        var result = await _healthDataRepository.GetIndicatorDimensionAsync(1);
+        var result = await _healthDataRepository.GetIndicatorDimensionAsync(1, []);
 
         // assert
         result.LatestYear.ShouldBe(LATESTYEAR);
     }
 
+    [Fact]
+    public async Task Repository_ShouldReturnCorrectIndicatorAndLatestYearWhenAreaCodesProvided()
+    {
+        // Replicates scenario where England data may be published ahead of sub-areas
+        const int ENGLAND_YEAR = 2024;
+        const int DISTRICT_YEAR = 2023;
+        const string ENGLAND_AREA_CODE = "E92000001";
+        const string DISTRICT_ONE_AREA_CODE = "ABC123";
+        const string DISTRICT_TWO_AREA_CODE = "123ABC";
+        const int INDICATORID = 1;
+        // arrange
+        PopulateDatabase(new HealthMeasureModelHelper(year: ENGLAND_YEAR)
+            .WithIndicatorDimension(indicatorId: INDICATORID)
+            .WithAreaDimension(code: ENGLAND_AREA_CODE)
+            .Build());
+        PopulateDatabase(new HealthMeasureModelHelper(year: DISTRICT_YEAR, key: 2)
+            .WithIndicatorDimension(indicatorId: INDICATORID)
+            .WithAreaDimension(code: DISTRICT_ONE_AREA_CODE)
+            .Build());
+        PopulateDatabase(new HealthMeasureModelHelper(year: DISTRICT_YEAR, key: 3)
+            .WithIndicatorDimension(indicatorId: INDICATORID)
+            .WithAreaDimension(code: DISTRICT_TWO_AREA_CODE)
+            .Build());
+
+        // act
+        var result = await _healthDataRepository.GetIndicatorDimensionAsync(1, [
+            ENGLAND_AREA_CODE,
+            DISTRICT_ONE_AREA_CODE,
+            DISTRICT_TWO_AREA_CODE
+        ]);
+
+        // assert
+        result.LatestYear.ShouldBe(DISTRICT_YEAR);
+    }
 
     [Fact]
-    public void RepositoryInitialisation_ShouldThrowError_IfNullDBContextIsProvided()
+    public async Task Repository_ShouldReturnCorrectIndicatorAndLatestYearWhenEnglandRequested()
     {
-        var act = () => _healthDataRepository = new HealthDataRepository(null!);
+        const int ENGLAND_YEAR = 2024;
+        const string ENGLAND_AREA_CODE = "E92000001";
+        const int INDICATORID = 1;
+        // arrange
+        PopulateDatabase(new HealthMeasureModelHelper(year: ENGLAND_YEAR)
+            .WithIndicatorDimension(indicatorId: INDICATORID)
+            .WithAreaDimension(code: ENGLAND_AREA_CODE)
+            .Build());
 
-        act.ShouldThrow<ArgumentNullException>()
-            .Message.ShouldBe("Value cannot be null. (Parameter 'healthDataDbContext')");
+        // act
+        var result = await _healthDataRepository.GetIndicatorDimensionAsync(1, [ENGLAND_AREA_CODE]);
+
+        // assert
+        result.LatestYear.ShouldBe(ENGLAND_YEAR);
     }
+
+    #endregion
 
     #region GetIndicatorDataAsync
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Services/IndicatorServiceTests.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.UnitTests/Services/IndicatorServiceTests.cs
@@ -75,7 +75,7 @@ public class IndicatorServiceTests
             HealthData = expectedHealthData
         };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns([healthMeasure]);
 
         var result = await _indicatorService.GetIndicatorDataAsync(1, [], string.Empty, [], []);
@@ -105,7 +105,7 @@ public class IndicatorServiceTests
                 }
             }
         };
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), Arg.Any<int[]>(), []).Returns(
             new List<HealthMeasureModel>
                 { healthMeasure2 });
@@ -150,7 +150,7 @@ public class IndicatorServiceTests
                 }
             }
         };
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns(
             new List<HealthMeasureModel>
                 { healthMeasure1, healthMeasure2, healthMeasure3 });
@@ -183,7 +183,7 @@ public class IndicatorServiceTests
         mockHealthData.Add(healthMeasure2);
 
         testIndicator.Polarity = polarity;
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns(mockHealthData);
 
         var result =
@@ -219,7 +219,7 @@ public class IndicatorServiceTests
         healthMeasure2.Value = 2;
         mockHealthData.Add(healthMeasure2);
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns(mockHealthData);
 
         var result =
@@ -292,7 +292,7 @@ public class IndicatorServiceTests
                 englandMaleDataPoint2022, englandFemaleDataPoint2022
             };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], Arg.Any<string[]>())
             .Returns(mockHealthData);
 
@@ -465,7 +465,7 @@ public class IndicatorServiceTests
         var mockHealthData = new List<HealthMeasureModel>
             { englandPoint, aggregatePoint, disAggregatePoint };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], Arg.Any<string[]>())
             .Returns(mockHealthData);
 
@@ -525,7 +525,7 @@ public class IndicatorServiceTests
         var mockHealthData = new List<HealthMeasureModel>
             { englandPoint, aggregatePoint, disAggregatePoint1, disAggregatePoint2 };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], Arg.Any<string[]>())
             .Returns(mockHealthData);
 
@@ -623,7 +623,7 @@ public class IndicatorServiceTests
                 }
             };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(theIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(theIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(),
                 [], Arg.Any<string[]>())
             .Returns(mockHealthData);
@@ -646,7 +646,7 @@ public class IndicatorServiceTests
         var mockHealthData = new List<HealthMeasureModel>
         { };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(Task.FromResult<IndicatorDimensionModel>(null));
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(Task.FromResult<IndicatorDimensionModel>(null));
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], Arg.Any<string[]>())
             .Returns(mockHealthData);
 
@@ -659,7 +659,7 @@ public class IndicatorServiceTests
     [Fact]
     public async Task GetIndicatorDataAsync_ReturnsEmptyArray_WhenNoDataFoundButValidIndicatorSelected()
     {
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(Task.FromResult<IndicatorDimensionModel>(new IndicatorDimensionModel() { Name = "Foo" }));
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(Task.FromResult<IndicatorDimensionModel>(new IndicatorDimensionModel() { Name = "Foo" }));
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], Arg.Any<string[]>())
             .Returns([]);
 
@@ -727,7 +727,7 @@ public class IndicatorServiceTests
             }
         };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns(
             [
                 healthMeasure0,
@@ -789,7 +789,7 @@ public class IndicatorServiceTests
             new(){AreaKey=3, Code = expectedAreaCodes[3], Name = expectedAreaNames[3]}
         };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns([healthMeasure0, healthMeasure1, healthMeasure2]);
         _healthDataRepository.GetAreasAsync(Arg.Any<string[]>()).Returns(missingAreas);
 
@@ -841,7 +841,7 @@ public class IndicatorServiceTests
             new(){AreaKey=3, Code = expectedAreaCodes[3], Name = expectedAreaNames[3]}
         };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns([healthMeasure0, healthMeasure1, healthMeasure2]);
         _healthDataRepository.GetAreasAsync(Arg.Any<string[]>()).Returns(missingAreas);
 
@@ -890,7 +890,7 @@ public class IndicatorServiceTests
             new(){AreaKey=3, Code = expectedAreaCodes[3], Name = expectedAreaNames[3]}
         };
 
-        _healthDataRepository.GetIndicatorDimensionAsync(1).Returns(testIndicator);
+        _healthDataRepository.GetIndicatorDimensionAsync(1, Arg.Any<string[]>()).Returns(testIndicator);
         _healthDataRepository.GetIndicatorDataAsync(1, Arg.Any<string[]>(), [], []).Returns([]);
         _healthDataRepository.GetAreasAsync(Arg.Any<string[]>()).Returns(missingAreas);
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
@@ -10,7 +10,7 @@ namespace DHSC.FingertipsNext.Modules.HealthData.Controllers.V1;
 [Route("indicators")]
 public class IndicatorsController(IIndicatorsService indicatorsService) : ControllerBase
 {
-    private const int MaxNumberAreas = 100;
+    private const int MaxNumberAreas = 300;
     private const int MaxNumberYears = 20;
     private const int MaxNumberIndicators = 50;
 

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -134,7 +134,7 @@ paths:
             application/json:
               schema:
                 type: array
-                maxItems: 100
+                maxItems: 300
                 items:
                   $ref: "#/components/schemas/Area"
         "400":
@@ -149,7 +149,7 @@ paths:
                     message: Please provide at least value for the parameter area_codes.
                 Too many area_codes:
                   value:
-                    message: Too many values supplied for parameter area_codes. The maximum is 100 but 101 supplied.
+                    message: Too many values supplied for parameter area_codes. The maximum is 300 but 301 supplied.
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -254,7 +254,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/IndicatorWithHealthDataForArea"
-
         "400":
           description: Bad request. The server could not process the request.
           content:
@@ -264,7 +263,7 @@ paths:
               examples:
                 Too many area_codes:
                   value:
-                    message: Too many values supplied for parameter area_codes. The maximum is 100 but 101 supplied.
+                    message: Too many values supplied for parameter area_codes. The maximum is 300 but 301 supplied.
                 Too many years:
                   value:
                     message: Too many values supplied for parameter years. The maximum is 20 but 21 supplied.
@@ -797,14 +796,14 @@ components:
     area_codes:
       in: query
       name: area_codes
-      description: A list of area codes, up to 100 area codes can be requested
+      description: A list of area codes, up to 300 area codes can be requested
       style: form
       schema:
         type: array
         items:
           type: string
           example: G82109
-        maxItems: 100
+        maxItems: 300
     area_type:
       in: query
       name: area_type

--- a/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
@@ -76,7 +76,7 @@ describe('PopulationPyramidWithTableDataProvider', () => {
         results.push(area);
       }
       return results;
-    })(130);
+    })(330);
 
     const areaCodes = areas.map((area: Area) => {
       return area.code;

--- a/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
+++ b/frontend/fingertips-frontend/app/chart/PopulationPyramidWithTableDataProvider/PopulationPyramidWithTableDataProvider.test.tsx
@@ -5,6 +5,7 @@ import { HierarchyNameTypes } from '@/lib/areaFilterHelpers/areaType';
 import { Area } from '@/generated-sources/ft-api-client';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { API_CACHE_CONFIG } from '@/lib/apiClient/apiClientFactory';
+import { maxNumAreasThatCanBeRequestedAPI } from '@/lib/chunkArray';
 
 const mockGetHealthDataForAnIndicator = jest.fn();
 
@@ -76,7 +77,7 @@ describe('PopulationPyramidWithTableDataProvider', () => {
         results.push(area);
       }
       return results;
-    })(330);
+    })(maxNumAreasThatCanBeRequestedAPI + 30);
 
     const areaCodes = areas.map((area: Area) => {
       return area.code;

--- a/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/AreasApi.ts
+++ b/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/AreasApi.ts
@@ -147,7 +147,7 @@ export interface AreasApiInterface {
     /**
      * Get the basic details without children, parent relationships etc. for 1 or more areas. Will return duplicate of areas that are applicable to multiple areaTypes.
      * @summary Get multiple areas
-     * @param {Array<string>} [areaCodes] A list of area codes, up to 100 area codes can be requested
+     * @param {Array<string>} [areaCodes] A list of area codes, up to 300 area codes can be requested
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AreasApiInterface

--- a/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
+++ b/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
@@ -89,7 +89,7 @@ export interface IndicatorsApiInterface {
      * Get data for a public health indicator. This will return all data for all areas and all years for the indicators. Optionally filter the results by supplying one or more area codes and one or more years in the query string.
      * @summary Get health data for an indicator
      * @param {number} indicatorId The unique identifier of the indicator
-     * @param {Array<string>} [areaCodes] A list of area codes, up to 100 area codes can be requested
+     * @param {Array<string>} [areaCodes] A list of area codes, up to 300 area codes can be requested
      * @param {string} [areaType] The area type which the areas belong to
      * @param {Array<number>} [years] A list of years, up to 20 years can be requested
      * @param {Array<'age' | 'sex' | 'deprivation'>} [inequalities] Determines the kind of inequality data that should be returned if an option is specified

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/apiClient/apiClientFactory';
 import { healthDataPoint } from './mocks';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
+import { maxNumAreasThatCanBeRequestedAPI } from './chunkArray';
 
 const mockIndicator: IndicatorWithHealthDataForArea = {
   indicatorId: 1,
@@ -51,7 +52,11 @@ describe('getHealthDataForIndicator', () => {
   });
 
   it('should make the appropriate number of API calls when a long list of areas is requested', async () => {
-    const testAreas = new Array(301).fill('a', 0, 301);
+    const testAreas = new Array(maxNumAreasThatCanBeRequestedAPI + 1).fill(
+      'a',
+      0,
+      maxNumAreasThatCanBeRequestedAPI + 1
+    );
 
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockIndicator
@@ -68,7 +73,11 @@ describe('getHealthDataForIndicator', () => {
     ).toHaveBeenNthCalledWith(
       1,
       {
-        areaCodes: new Array(300).fill('a', 0, 300),
+        areaCodes: new Array(maxNumAreasThatCanBeRequestedAPI).fill(
+          'a',
+          0,
+          maxNumAreasThatCanBeRequestedAPI
+        ),
         indicatorId: Number(1),
       },
       API_CACHE_CONFIG
@@ -87,7 +96,11 @@ describe('getHealthDataForIndicator', () => {
   });
 
   it('should return combined data when a long list of areas is requested', async () => {
-    const testAreas = new Array(301).fill('a', 0, 301);
+    const testAreas = new Array(maxNumAreasThatCanBeRequestedAPI + 1).fill(
+      'a',
+      0,
+      maxNumAreasThatCanBeRequestedAPI + 1
+    );
 
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockIndicator
@@ -269,7 +282,7 @@ describe('getIndicatorData', () => {
 
   const testParamsWithManyAreas = {
     ...testParamsWithGroup,
-    areasSelected: new Array(301).fill('a'),
+    areasSelected: new Array(maxNumAreasThatCanBeRequestedAPI + 1).fill('a'),
   };
 
   it('should make appropriate calls to the healthIndicatorApi when a long list of areas is specified', async () => {
@@ -286,14 +299,20 @@ describe('getIndicatorData', () => {
       mockIndicatorsApi.getHealthDataForAnIndicator.mock.calls[0][0];
     expect(call1arg).toHaveProperty(
       'areaCodes',
-      testParamsWithManyAreas.areasSelected.slice(0, 300)
+      testParamsWithManyAreas.areasSelected.slice(
+        0,
+        maxNumAreasThatCanBeRequestedAPI
+      )
     );
 
     const call2arg =
       mockIndicatorsApi.getHealthDataForAnIndicator.mock.calls[1][0];
     expect(call2arg).toHaveProperty(
       'areaCodes',
-      testParamsWithManyAreas.areasSelected.slice(300, 301)
+      testParamsWithManyAreas.areasSelected.slice(
+        maxNumAreasThatCanBeRequestedAPI,
+        maxNumAreasThatCanBeRequestedAPI + 1
+      )
     );
   });
 

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
@@ -296,4 +296,127 @@ describe('getIndicatorData', () => {
       testParamsWithManyAreas.areasSelected.slice(300, 301)
     );
   });
+
+  it('should specify the year in the calls for England and group when the latest only parameter is provided', async () => {
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValue(
+      mockIndicator
+    );
+
+    await getIndicatorData(testParamsWithGroup, true, true);
+    expect(mockIndicatorsApi.getHealthDataForAnIndicator).toHaveBeenCalledTimes(
+      3
+    );
+
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      1,
+      {
+        areaCodes: ['abc', 'def'],
+        areaType: 'test_area_type',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        latestOnly: true,
+      },
+      { next: { revalidate: 600 } }
+    );
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      2,
+      {
+        areaCodes: [areaCodeForEngland],
+        areaType: 'england',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        years: [2006],
+      },
+      { next: { revalidate: 600 } }
+    );
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      3,
+      {
+        areaCodes: ['ggg'],
+        areaType: 'test_group_type',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        years: [2006],
+      },
+      { next: { revalidate: 600 } }
+    );
+  });
+
+  // Edge case where client has navigated to chart page where no requested areas contain data for the given indicator
+  // AI search will only return results that have data for the indicator
+  // In this case, it suffices to set the calls for England and group to get data for the latest year since no sub areas contain data anyway
+  it('should request latest data in the calls for England and group when latest only parameter is provided and sub areas contain no data', async () => {
+    const mockEmptyIndicatorData: IndicatorWithHealthDataForArea = {
+      indicatorId: 1,
+      areaHealthData: [
+        {
+          areaCode: 'abc',
+          areaName: 'North FooBar',
+          healthData: [],
+        },
+        {
+          areaCode: 'def',
+          areaName: 'South FooBar',
+          healthData: [],
+        },
+      ],
+    };
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
+      mockEmptyIndicatorData
+    );
+    mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValue(
+      mockIndicator
+    );
+
+    await getIndicatorData(testParamsWithGroup, true, true);
+    expect(mockIndicatorsApi.getHealthDataForAnIndicator).toHaveBeenCalledTimes(
+      3
+    );
+
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      1,
+      {
+        areaCodes: ['abc', 'def'],
+        areaType: 'test_area_type',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        latestOnly: true,
+      },
+      { next: { revalidate: 600 } }
+    );
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      2,
+      {
+        areaCodes: [areaCodeForEngland],
+        areaType: 'england',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        latestOnly: true,
+      },
+      { next: { revalidate: 600 } }
+    );
+    expect(
+      mockIndicatorsApi.getHealthDataForAnIndicator
+    ).toHaveBeenNthCalledWith(
+      3,
+      {
+        areaCodes: ['ggg'],
+        areaType: 'test_group_type',
+        includeEmptyAreas: true,
+        indicatorId: 1,
+        latestOnly: true,
+      },
+      { next: { revalidate: 600 } }
+    );
+  });
 });

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
@@ -51,7 +51,7 @@ describe('getHealthDataForIndicator', () => {
   });
 
   it('should make the appropriate number of API calls when a long list of areas is requested', async () => {
-    const testAreas = new Array(101).fill('a', 0, 101);
+    const testAreas = new Array(301).fill('a', 0, 301);
 
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockIndicator
@@ -68,7 +68,7 @@ describe('getHealthDataForIndicator', () => {
     ).toHaveBeenNthCalledWith(
       1,
       {
-        areaCodes: new Array(100).fill('a', 0, 100),
+        areaCodes: new Array(300).fill('a', 0, 300),
         indicatorId: Number(1),
       },
       API_CACHE_CONFIG
@@ -87,7 +87,7 @@ describe('getHealthDataForIndicator', () => {
   });
 
   it('should return combined data when a long list of areas is requested', async () => {
-    const testAreas = new Array(101).fill('a', 0, 101);
+    const testAreas = new Array(301).fill('a', 0, 301);
 
     mockIndicatorsApi.getHealthDataForAnIndicator.mockResolvedValueOnce(
       mockIndicator
@@ -269,7 +269,7 @@ describe('getIndicatorData', () => {
 
   const testParamsWithManyAreas = {
     ...testParamsWithGroup,
-    areasSelected: new Array(101).fill('a'),
+    areasSelected: new Array(301).fill('a'),
   };
 
   it('should make appropriate calls to the healthIndicatorApi when a long list of areas is specified', async () => {
@@ -286,14 +286,14 @@ describe('getIndicatorData', () => {
       mockIndicatorsApi.getHealthDataForAnIndicator.mock.calls[0][0];
     expect(call1arg).toHaveProperty(
       'areaCodes',
-      testParamsWithManyAreas.areasSelected.slice(0, 100)
+      testParamsWithManyAreas.areasSelected.slice(0, 300)
     );
 
     const call2arg =
       mockIndicatorsApi.getHealthDataForAnIndicator.mock.calls[1][0];
     expect(call2arg).toHaveProperty(
       'areaCodes',
-      testParamsWithManyAreas.areasSelected.slice(100, 101)
+      testParamsWithManyAreas.areasSelected.slice(300, 301)
     );
   });
 });

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getSelectedAreasData.test.tsx
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getSelectedAreasData.test.tsx
@@ -121,7 +121,7 @@ describe('getSelectedAreasDataByAreaType', () => {
 
     mockAreasApi.getAreas.mockResolvedValue([area1, area2]);
 
-    const testAreas = new Array(101).fill('a');
+    const testAreas = new Array(301).fill('a');
 
     await getSelectedAreasDataByAreaType(testAreas, 'nhs-regions');
 
@@ -129,7 +129,7 @@ describe('getSelectedAreasDataByAreaType', () => {
     expect(mockAreasApi.getAreas).toHaveBeenNthCalledWith(
       1,
       {
-        areaCodes: new Array(100).fill('a'),
+        areaCodes: new Array(300).fill('a'),
       },
       API_CACHE_CONFIG
     );
@@ -151,7 +151,7 @@ describe('getSelectedAreasDataByAreaType', () => {
     mockAreasApi.getAreas.mockResolvedValueOnce([area1, area2]);
     mockAreasApi.getAreas.mockResolvedValueOnce([area3, area4]);
 
-    const testAreas = new Array(101).fill('a');
+    const testAreas = new Array(301).fill('a');
 
     const selectedAreaData = await getSelectedAreasDataByAreaType(
       testAreas,

--- a/frontend/fingertips-frontend/lib/areaFilterHelpers/getSelectedAreasData.test.tsx
+++ b/frontend/fingertips-frontend/lib/areaFilterHelpers/getSelectedAreasData.test.tsx
@@ -6,6 +6,7 @@ import {
   API_CACHE_CONFIG,
   ApiClientFactory,
 } from '@/lib/apiClient/apiClientFactory';
+import { maxNumAreasThatCanBeRequestedAPI } from '../chunkArray';
 
 const mockAreasApi = mockDeep<AreasApi>();
 ApiClientFactory.getAreasApiClient = () => mockAreasApi;
@@ -121,7 +122,7 @@ describe('getSelectedAreasDataByAreaType', () => {
 
     mockAreasApi.getAreas.mockResolvedValue([area1, area2]);
 
-    const testAreas = new Array(301).fill('a');
+    const testAreas = new Array(maxNumAreasThatCanBeRequestedAPI + 1).fill('a');
 
     await getSelectedAreasDataByAreaType(testAreas, 'nhs-regions');
 
@@ -129,7 +130,7 @@ describe('getSelectedAreasDataByAreaType', () => {
     expect(mockAreasApi.getAreas).toHaveBeenNthCalledWith(
       1,
       {
-        areaCodes: new Array(300).fill('a'),
+        areaCodes: new Array(maxNumAreasThatCanBeRequestedAPI).fill('a'),
       },
       API_CACHE_CONFIG
     );
@@ -151,7 +152,7 @@ describe('getSelectedAreasDataByAreaType', () => {
     mockAreasApi.getAreas.mockResolvedValueOnce([area1, area2]);
     mockAreasApi.getAreas.mockResolvedValueOnce([area3, area4]);
 
-    const testAreas = new Array(301).fill('a');
+    const testAreas = new Array(maxNumAreasThatCanBeRequestedAPI + 1).fill('a');
 
     const selectedAreaData = await getSelectedAreasDataByAreaType(
       testAreas,

--- a/frontend/fingertips-frontend/lib/chunkArray.ts
+++ b/frontend/fingertips-frontend/lib/chunkArray.ts
@@ -1,4 +1,4 @@
-const maxNumAreasThatCanBeRequestedAPI = 100;
+const maxNumAreasThatCanBeRequestedAPI = 300;
 
 export function chunkArray(
   arrayToChunk: string[],

--- a/frontend/fingertips-frontend/lib/chunkArray.ts
+++ b/frontend/fingertips-frontend/lib/chunkArray.ts
@@ -1,4 +1,4 @@
-const maxNumAreasThatCanBeRequestedAPI = 300;
+export const maxNumAreasThatCanBeRequestedAPI = 300;
 
 export function chunkArray(
   arrayToChunk: string[],


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-662](https://bjss-enterprise.atlassian.net/browse/DHSCFT-662)

Ensure we return data for the latest year when requested, scoped to the area codes provided by the client and excluding the latest date for England.

## Changes

- Upped the chunking limit to 300 for both the indicator data and areas API endpoints. This means that the largest collection i.e. all districts for England should not be chunked up which avoids the issue (edge case) where a set of areas might have a different latest year to another. (Due to the way data is collected this is unlikely but worth guarding against).
- Extended backend repository method so the latest year will be considering the area codes provided and will exclude England for the reasons articulated on the ticket.
- Added required additional tests for the backend and ensured UI tests continue to pass.

## Validation

Local manual testing. E2e tests continue to pass.

Validated the scenario described in the ticket in addition to a variety of other indicators. Re the scenario in the ticket, there is currently no change - it is not just an issue with the year for England in this situation - there is no data at all for any of the regions for any year.

Do we still want to show the empty areas and an outline to the map if not a single area has any data or would we want a different behaviour?

Regarding further scenarios, one example would be to compare chart?si=383&is=383&ats=districts-and-unitary-authorities&gts=regions&gs=E12000002&gas=ALL on local vs. deployed. The data will now be surfaced rather than empty.

QUESTION: the benchmark still shows the latest data for England, would we want to switch this to be the latest data that is being used for the areas? If so, part of this ticket or a follow on?
