### PR TITLE
Update DataCreator paths to work on Mac

### DIFF
--- a/DataCreator/DataCreator/DataFileReader.cs
+++ b/DataCreator/DataCreator/DataFileReader.cs
@@ -6,12 +6,12 @@ namespace DataCreator
     public static class DataFileReader
     {
         private const string Persons = "Persons";
-        private static readonly string InFilePath = Path.Combine("..","..","..","data","in");
-        private static readonly string TempDirPath = Path.Combine(InFilePath, "temp");
+        private static readonly string InFilePath = Path.Join("..","..","..","data","in");
+        private static readonly string TempDirPath = Path.Join(InFilePath, "temp");
 
         public static List<SimpleIndicator> GetPocIndicators()
         {
-            var lines = File.ReadAllLines(Path.Combine(TempDirPath, "pocindicators.csv"));
+            var lines = File.ReadAllLines(Path.Join(TempDirPath, "pocindicators.csv"));
             var indicators = new List<SimpleIndicator>();
             foreach (var line in lines)
             {
@@ -39,7 +39,7 @@ namespace DataCreator
         {
 
             //this is a csv file that was downloaded from the Fingertips API
-            var filePath = Path.Combine(TempDirPath, $"{indicatorId}.csv");
+            var filePath = Path.Join(TempDirPath, $"{indicatorId}.csv");
             if (!File.Exists(filePath))
                 return Enumerable.Empty<HealthMeasureEntity>().ToList();
 
@@ -102,7 +102,7 @@ namespace DataCreator
         public static IEnumerable<IndicatorLastUpdatedEntity> GetLastUpdatedDataForIndicators()
         {
             //this is a csv file that was downloaded from the Fingertips API
-            var filePath = Path.Combine(TempDirPath, "lastupdated.csv");
+            var filePath = Path.Join(TempDirPath, "lastupdated.csv");
 
             var lines = File.ReadAllLines(filePath);
             var allData = new List<IndicatorLastUpdatedEntity>();
@@ -119,7 +119,7 @@ namespace DataCreator
             return allData;
         }
 
-        public static void UnzipSourceFiles() => ZipFile.ExtractToDirectory(Path.Combine(InFilePath, "in.zip"), TempDirPath);
+        public static void UnzipSourceFiles() => ZipFile.ExtractToDirectory(Path.Join(InFilePath, "in.zip"), TempDirPath);
 
         public static void DeleteTempFiles()
         {

--- a/DataCreator/DataCreator/DataFileReader.cs
+++ b/DataCreator/DataCreator/DataFileReader.cs
@@ -6,11 +6,12 @@ namespace DataCreator
     public static class DataFileReader
     {
         private const string Persons = "Persons";
-        private const string InFilePath = @"..\..\..\data\in\";
+        private static readonly string InFilePath = Path.Combine("..","..","..","data","in");
+        private static readonly string TempDirPath = Path.Combine(InFilePath, "temp");
 
         public static List<SimpleIndicator> GetPocIndicators()
         {
-            var lines = File.ReadAllLines(@$"{InFilePath}\temp\pocindicators.csv");
+            var lines = File.ReadAllLines(Path.Combine(TempDirPath, "pocindicators.csv"));
             var indicators = new List<SimpleIndicator>();
             foreach (var line in lines)
             {
@@ -38,7 +39,7 @@ namespace DataCreator
         {
 
             //this is a csv file that was downloaded from the Fingertips API
-            var filePath = @$"{InFilePath}\temp\{indicatorId}.csv";
+            var filePath = Path.Combine(TempDirPath, $"{indicatorId}.csv");
             if (!File.Exists(filePath))
                 return Enumerable.Empty<HealthMeasureEntity>().ToList();
 
@@ -101,7 +102,7 @@ namespace DataCreator
         public static IEnumerable<IndicatorLastUpdatedEntity> GetLastUpdatedDataForIndicators()
         {
             //this is a csv file that was downloaded from the Fingertips API
-            var filePath = @$"{InFilePath}\temp\lastupdated.csv";
+            var filePath = Path.Combine(TempDirPath, "lastupdated.csv");
 
             var lines = File.ReadAllLines(filePath);
             var allData = new List<IndicatorLastUpdatedEntity>();
@@ -118,13 +119,12 @@ namespace DataCreator
             return allData;
         }
 
-        public static void UnzipSourceFiles() => ZipFile.ExtractToDirectory(@$"{InFilePath}\in.zip", @$"{InFilePath}\temp");
+        public static void UnzipSourceFiles() => ZipFile.ExtractToDirectory(Path.Combine(InFilePath, "in.zip"), TempDirPath);
 
         public static void DeleteTempFiles()
         {
-            var directoryPath = @$"{InFilePath}\temp";
-            if (Directory.Exists(directoryPath))
-                Directory.Delete(directoryPath, true);
+            if (Directory.Exists(TempDirPath))
+                Directory.Delete(TempDirPath, true);
         }
 
         private static double? GetDoubleValue(string raw) => double.TryParse(raw.Trim(), out var value) ? value : null;

--- a/DataCreator/DataCreator/DataFileWriter.cs
+++ b/DataCreator/DataCreator/DataFileWriter.cs
@@ -5,9 +5,9 @@ namespace DataCreator
 {
     public static class DataFileWriter
     {
-        private static readonly string OutFilePath = Path.Combine("..","..","..", "data", "out");
-        private static readonly string RepositoryRoot = Path.Combine("..", "..", "..", "..", "..");
-        private static readonly string SearchSetupAssetsPath = Path.Combine(RepositoryRoot, "search-setup", "assets");
+        private static readonly string OutFilePath = Path.Join("..","..","..", "data", "out");
+        private static readonly string RepositoryRoot = Path.Join("..", "..", "..", "..", "..");
+        private static readonly string SearchSetupAssetsPath = Path.Join(RepositoryRoot, "search-setup", "assets");
 
         private static readonly CsvFileDescription CsvFileDescription = new() {EnforceCsvColumnAttribute=true};
         private static readonly JsonSerializerOptions JsonSerializerOptions = new()
@@ -18,29 +18,29 @@ namespace DataCreator
         public static void WriteIndicatorsJsonData(object data)
         {
             var contents = JsonSerializer.Serialize(data, JsonSerializerOptions);
-            File.WriteAllText(Path.Combine(RepositoryRoot, "trend-analysis", "TrendAnalysisApp", "SearchData", "assets", "indicators.json"), contents);
-            File.WriteAllText(Path.Combine(SearchSetupAssetsPath, "indicators.json"), contents);
+            File.WriteAllText(Path.Join(RepositoryRoot, "trend-analysis", "TrendAnalysisApp", "SearchData", "assets", "indicators.json"), contents);
+            File.WriteAllText(Path.Join(SearchSetupAssetsPath, "indicators.json"), contents);
         }
 
         public static void WriteAreasJsonData(object data)
         {
             var contents = JsonSerializer.Serialize(data, JsonSerializerOptions);
-            File.WriteAllText(Path.Combine(SearchSetupAssetsPath, "areas.json"), contents);
+            File.WriteAllText(Path.Join(SearchSetupAssetsPath, "areas.json"), contents);
         }
 
         public static void WriteHealthCsvData(string fileName, IEnumerable<HealthMeasureEntity> data) => 
-            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
+            new CsvContext().Write(data, Path.Join(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteSimpleIndicatorCsvData(string fileName, IEnumerable<SimpleIndicator> data) =>
-             new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
+             new CsvContext().Write(data, Path.Join(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteSimpleAreaCsvData(string fileName, IEnumerable<SimpleAreaWithChildren> data) =>
-             new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
+             new CsvContext().Write(data, Path.Join(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteAgeCsvData(string fileName, IEnumerable<AgeEntity> data) =>
-            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
+            new CsvContext().Write(data, Path.Join(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteCategoryCsvData(string fileName, IEnumerable<CategoryEntity> data) =>
-            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
+            new CsvContext().Write(data, Path.Join(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
     }
 }

--- a/DataCreator/DataCreator/DataFileWriter.cs
+++ b/DataCreator/DataCreator/DataFileWriter.cs
@@ -5,40 +5,42 @@ namespace DataCreator
 {
     public static class DataFileWriter
     {
-        private const string OutFilePath = @"..\..\..\data\out\";
+        private static readonly string OutFilePath = Path.Combine("..","..","..", "data", "out");
+        private static readonly string RepositoryRoot = Path.Combine("..", "..", "..", "..", "..");
+        private static readonly string SearchSetupAssetsPath = Path.Combine(RepositoryRoot, "search-setup", "assets");
 
-        private static readonly CsvFileDescription csvFileDescription=new() {EnforceCsvColumnAttribute=true};
-        private static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        private static readonly CsvFileDescription CsvFileDescription = new() {EnforceCsvColumnAttribute=true};
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
         public static void WriteIndicatorsJsonData(object data)
         {
-            var contents = JsonSerializer.Serialize(data, jsonSerializerOptions);
-            File.WriteAllText($@"..\..\..\..\..\trend-analysis\TrendAnalysisApp\SearchData\assets\indicators.json", contents);
-            File.WriteAllText($@"..\..\..\..\..\search-setup\assets\indicators.json", contents);
+            var contents = JsonSerializer.Serialize(data, JsonSerializerOptions);
+            File.WriteAllText(Path.Combine(RepositoryRoot, "trend-analysis", "TrendAnalysisApp", "SearchData", "assets", "indicators.json"), contents);
+            File.WriteAllText(Path.Combine(SearchSetupAssetsPath, "indicators.json"), contents);
         }
 
         public static void WriteAreasJsonData(object data)
         {
-            var contents = JsonSerializer.Serialize(data, jsonSerializerOptions);
-            File.WriteAllText($@"..\..\..\..\..\search-setup\assets\areas.json", contents);
+            var contents = JsonSerializer.Serialize(data, JsonSerializerOptions);
+            File.WriteAllText(Path.Combine(SearchSetupAssetsPath, "areas.json"), contents);
         }
 
         public static void WriteHealthCsvData(string fileName, IEnumerable<HealthMeasureEntity> data) => 
-            new CsvContext().Write(data, $"{OutFilePath}{fileName}.csv", csvFileDescription);
+            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteSimpleIndicatorCsvData(string fileName, IEnumerable<SimpleIndicator> data) =>
-             new CsvContext().Write(data, $"{OutFilePath}{fileName}.csv", csvFileDescription);
+             new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteSimpleAreaCsvData(string fileName, IEnumerable<SimpleAreaWithChildren> data) =>
-             new CsvContext().Write(data, $"{OutFilePath}{fileName}.csv", csvFileDescription);
+             new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteAgeCsvData(string fileName, IEnumerable<AgeEntity> data) =>
-            new CsvContext().Write(data, $"{OutFilePath}{fileName}.csv", csvFileDescription);
+            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
 
         public static void WriteCategoryCsvData(string fileName, IEnumerable<CategoryEntity> data) =>
-            new CsvContext().Write(data, $"{OutFilePath}{fileName}.csv", csvFileDescription);
+            new CsvContext().Write(data, Path.Combine(OutFilePath, $"{fileName}.csv"), CsvFileDescription);
     }
 }


### PR DESCRIPTION
# Description

Jira ticket: None.

This PR makes updates to the DataCreator application so that it can be run on Mac.

## Changes

- Replaced string literal paths with use of [`Path.Join`](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.join?view=net-9.0), so they are not always separated with `\`

## Validation

Deleted the contents of the `DataCreator/DataCreator/data/out` directory, ran the application using the latest Pholio DB export and without changing the other input data files, then verified using git that the files produced in `DataCreator/DataCreator/data/out` were unchanged.

@HowardMayBjss has also verified that he is able to perform the above verification on Windows.