### PR TITLE
DHSCFT-667: Benchmark label white when not compated

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/BenchmarkLabelConfig.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/BenchmarkLabelConfig.ts
@@ -10,13 +10,24 @@ import {
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
 
+const similar = {
+  backgroundColor: GovukColours.Yellow,
+  color: GovukColours.Black,
+};
+
+const notCompared = {
+  backgroundColor: 'transparent',
+  color: GovukColours.Black,
+  border: '1px solid #0B0C0C',
+};
+
 export const getBenchmarkTagStyle = (
   group: BenchmarkComparisonMethod,
   type: BenchmarkOutcome,
   polarity: IndicatorPolarity
 ) => {
   const groupConfig = benchmarkLabelGroupConfig[group];
-  if (!groupConfig) return null;
+  if (!groupConfig) return notCompared;
 
   // special case Middle is used by Quintiles with and without judgement but has different colours
   if (
@@ -27,17 +38,6 @@ export const getBenchmarkTagStyle = (
   }
 
   return groupConfig[type] ?? groupConfig.default;
-};
-
-const similar = {
-  backgroundColor: GovukColours.Yellow,
-  color: GovukColours.Black,
-};
-
-const notCompared = {
-  backgroundColor: 'transparent',
-  color: GovukColours.Black,
-  border: '1px solid #0B0C0C',
 };
 
 export const benchmarkLabelGroupConfig: BenchmarkLabelGroupConfig = {

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/index.tsx
@@ -21,6 +21,7 @@ export const BenchmarkTagStyle = styled(Tag)<{
   polarity: IndicatorPolarity;
 }>(({ outcome, group, polarity }) => {
   const theme = getBenchmarkTagStyle(group, outcome, polarity);
+
   return {
     padding: '5px 8px 4px 8px',
     alignItems: 'center',


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-667](https://bjss-enterprise.atlassian.net/browse/DHSCFT-667)

## Changes

- default benchmark colours are Not Defined

## Validation

<img width="662" alt="image" src="https://github.com/user-attachments/assets/e02df2b8-e3ec-4b49-a180-c1ccba49f8a1" />
