### PR TITLE
Feature/dhscft 679 align benchmark and group year linechart

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/LineChart/__snapshots__/lineChartHelpers.test.ts.snap
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/__snapshots__/lineChartHelpers.test.ts.snap
@@ -69,6 +69,8 @@ exports[`generateStandardLineChartOptions should generate standard line chart op
         "fontSize": 16,
       },
     },
+    "max": 2006,
+    "min": 2004,
     "tickLength": 0,
     "title": {
       "margin": 20,
@@ -209,6 +211,8 @@ exports[`generateStandardLineChartOptions should generate standard line chart op
         "fontSize": 16,
       },
     },
+    "max": 2006,
+    "min": 2004,
     "tickLength": 0,
     "title": {
       "margin": 20,

--- a/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.test.ts
@@ -349,13 +349,17 @@ describe('generateStandardLineChartOptions', () => {
     expect((generatedOptions.yAxis as any)!.title.text).toBe('yAxis');
     expect((generatedOptions.xAxis as any)!.title.text).toBe('xAxis');
     expect(generatedOptions.accessibility!.description).toBe('accessibility');
+    expect((generatedOptions.xAxis as any)!.max).toBe(2006);
+    expect((generatedOptions.xAxis as any)!.min).toBe(2004);
 
     expect(generatedOptions).toMatchSnapshot();
   });
 
   it('should generate standard line chart options with benchmark data', () => {
-    expect(
-      generateStandardLineChartOptions([mockIndicatorData[0]], false, {
+    const generatedOptions = generateStandardLineChartOptions(
+      [mockIndicatorData[0]],
+      false,
+      {
         benchmarkData: mockBenchmarkData,
         groupIndicatorData: mockParentData,
         yAxisTitle: 'yAxis',
@@ -364,9 +368,10 @@ describe('generateStandardLineChartOptions', () => {
         accessibilityLabel: 'accessibility',
         colours: chartColours,
         symbols,
-      })
-    ).toMatchSnapshot();
+      }
+    );
+    expect(generatedOptions).toMatchSnapshot();
+    expect((generatedOptions.xAxis as any)!.max).toBe(2006);
+    expect((generatedOptions.xAxis as any)!.min).toBe(2004);
   });
-  it.todo('should test for xaxis.min');
-  it.todo('should test for xaxis.max');
 });

--- a/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.test.ts
@@ -367,4 +367,6 @@ describe('generateStandardLineChartOptions', () => {
       })
     ).toMatchSnapshot();
   });
+  it.todo('should test for xaxis.min');
+  it.todo('should test for xaxis.max');
 });

--- a/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
@@ -14,7 +14,7 @@ import {
   AXIS_LABEL_FONT_SIZE,
   getTooltipContent,
   AreaTypeLabelEnum,
-  getMostRecentYearForAreas,
+  getLatestYearForAreas,
   getFirstYearForAreas,
 } from '@/lib/chartHelpers/chartHelpers';
 import { formatNumber } from '@/lib/numberFormatter';
@@ -316,7 +316,7 @@ export function generateStandardLineChartOptions(
         formatter: optionalParams?.xAxisLabelFormatter,
       },
       min: getFirstYearForAreas(sortedHealthIndicatorData),
-      max: getMostRecentYearForAreas(sortedHealthIndicatorData),
+      max: getLatestYearForAreas(sortedHealthIndicatorData),
     },
     series: seriesData,
     tooltip: {

--- a/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
@@ -14,7 +14,6 @@ import {
   AXIS_LABEL_FONT_SIZE,
   getTooltipContent,
   AreaTypeLabelEnum,
-  getLatestYear,
   getMostRecentYearForAreas,
   getFirstYearForAreas,
 } from '@/lib/chartHelpers/chartHelpers';

--- a/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/LineChart/lineChartHelpers.ts
@@ -14,6 +14,9 @@ import {
   AXIS_LABEL_FONT_SIZE,
   getTooltipContent,
   AreaTypeLabelEnum,
+  getLatestYear,
+  getMostRecentYearForAreas,
+  getFirstYearForAreas,
 } from '@/lib/chartHelpers/chartHelpers';
 import { formatNumber } from '@/lib/numberFormatter';
 import { pointFormatterHelper } from '@/lib/chartHelpers/pointFormatterHelper';
@@ -313,6 +316,8 @@ export function generateStandardLineChartOptions(
         ...(lineChartDefaultOptions.yAxis as Highcharts.XAxisOptions)?.labels,
         formatter: optionalParams?.xAxisLabelFormatter,
       },
+      min: getFirstYearForAreas(sortedHealthIndicatorData),
+      max: getMostRecentYearForAreas(sortedHealthIndicatorData),
     },
     series: seriesData,
     tooltip: {

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -502,5 +502,38 @@ describe('Line chart table suite', () => {
         /^2008Not comparedXXXXNot compared500966.00.00.0966.0$/
       );
     });
+
+    it('should not render rows for benchmark or group years before or after the areas have data', () => {
+      const mockBenchmarkAreaWithEarlyYear = JSON.parse(
+        JSON.stringify(MOCK_ENGLAND_DATA)
+      );
+      mockBenchmarkAreaWithEarlyYear.healthData[1] = {
+        ...mockBenchmarkAreaWithEarlyYear.healthData[1],
+        year: 1999,
+      };
+
+      const mockGroupAreaWithLateYear = JSON.parse(
+        JSON.stringify(MOCK_PARENT_DATA)
+      );
+      mockGroupAreaWithLateYear.healthData[1] = {
+        ...mockBenchmarkAreaWithEarlyYear.healthData[1],
+        year: 2036,
+      };
+
+      render(
+        <LineChartTable
+          healthIndicatorData={MOCK_HEALTH_DATA}
+          englandBenchmarkData={mockBenchmarkAreaWithEarlyYear}
+          groupIndicatorData={mockGroupAreaWithLateYear}
+          measurementUnit="%"
+          benchmarkComparisonMethod={
+            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+          }
+        />
+      );
+
+      expect(screen.queryByText(/1999/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/2036/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -25,7 +25,11 @@ import {
 } from '@/lib/tableHelpers';
 import { BenchmarkLabel } from '@/components/organisms/BenchmarkLabel';
 import { TrendTag } from '@/components/molecules/TrendTag';
-import { getConfidenceLimitNumber } from '@/lib/chartHelpers/chartHelpers';
+import {
+  getConfidenceLimitNumber,
+  getFirstYearForAreas,
+  getMostRecentYearForAreas,
+} from '@/lib/chartHelpers/chartHelpers';
 import { formatNumber, formatWholeNumber } from '@/lib/numberFormatter';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
@@ -230,7 +234,16 @@ export function LineChartTable({
     ...(groupIndicatorData?.healthData ?? []),
     ...healthIndicatorData.flatMap((area) => area.healthData),
   ].map(({ year }) => year);
-  const allYears = [...new Set(allHealthPointYears)].sort((a, b) => a - b);
+
+  const firstYear = getFirstYearForAreas(healthIndicatorData);
+  const lastYear = getMostRecentYearForAreas(healthIndicatorData);
+  if (!firstYear || !lastYear) {
+    throw new Error('no data for any years');
+  }
+
+  const allYears = [...new Set(allHealthPointYears)]
+    .filter((year) => year >= firstYear && year <= lastYear)
+    .sort((a, b) => a - b);
 
   const rowData = allYears
     .map((year) => {

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -238,7 +238,7 @@ export function LineChartTable({
   const firstYear = getFirstYearForAreas(healthIndicatorData);
   const lastYear = getLatestYearForAreas(healthIndicatorData);
   if (!firstYear || !lastYear) {
-    throw new Error('no data for any years');
+    return null;
   }
 
   const allYears = [...new Set(allHealthPointYears)]

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -28,7 +28,7 @@ import { TrendTag } from '@/components/molecules/TrendTag';
 import {
   getConfidenceLimitNumber,
   getFirstYearForAreas,
-  getMostRecentYearForAreas,
+  getLatestYearForAreas,
 } from '@/lib/chartHelpers/chartHelpers';
 import { formatNumber, formatWholeNumber } from '@/lib/numberFormatter';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
@@ -236,7 +236,7 @@ export function LineChartTable({
   ].map(({ year }) => year);
 
   const firstYear = getFirstYearForAreas(healthIndicatorData);
-  const lastYear = getMostRecentYearForAreas(healthIndicatorData);
+  const lastYear = getLatestYearForAreas(healthIndicatorData);
   if (!firstYear || !lastYear) {
     throw new Error('no data for any years');
   }

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -13,6 +13,10 @@ import {
   AreaTypeLabelEnum,
   getTooltipContent,
   createTooltipHTML,
+  getLatestYear,
+  getFirstYear,
+  getLatestYearForAreas,
+  getFirstYearForAreas,
 } from '@/lib/chartHelpers/chartHelpers';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { areaCodeForEngland } from './constants';
@@ -1270,17 +1274,25 @@ describe('getTooltipHtml', () => {
 });
 
 describe('getLatestYear', () => {
-  it.todo('should test the function');
+  it('should return the latest year for an area', () => {
+    expect(getLatestYear(mockData[0].healthData)).toBe(2006);
+  });
 });
 
 describe('getFirstYear', () => {
-  it.todo('should test the function');
+  it('should return the first year for an area', () => {
+    expect(getFirstYear(mockData[0].healthData)).toBe(2004);
+  });
 });
 
-describe('getMostRecentYearForAreas', () => {
-  it.todo('should test the function');
+describe('getLatestYearForAreas', () => {
+  it('should return the latest year for a group of areas', () => {
+    expect(getLatestYearForAreas(mockData)).toBe(2006);
+  });
 });
 
 describe('getFirstYearForAreas', () => {
-  it.todo('should test the function');
+  it('should return the latest year for a group of areas', () => {
+    expect(getFirstYearForAreas(mockData)).toBe(2004);
+  });
 });

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -1268,3 +1268,19 @@ describe('getTooltipHtml', () => {
     ).toEqual(expected);
   });
 });
+
+describe('getLatestYear', () => {
+  it.todo('should test the function');
+});
+
+describe('getFirstYear', () => {
+  it.todo('should test the function');
+});
+
+describe('getMostRecentYearForAreas', () => {
+  it.todo('should test the function');
+});
+
+describe('getFirstYearForAreas', () => {
+  it.todo('should test the function');
+});

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -198,9 +198,10 @@ export function getFirstYear(
 ): number | undefined {
   if (!points || points.length < 1) return undefined;
 
-  const year = points.reduce((previous, point) => {
-    return Math.min(previous, point.year);
-  }, points[0].year);
+  const year = points.reduce(
+    (previous, point) => Math.min(previous, point.year),
+    points[0].year
+  );
   return year;
 }
 

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -204,7 +204,7 @@ export function getFirstYear(
   return year;
 }
 
-export function getMostRecentYearForAreas(
+export function getLatestYearForAreas(
   healthDataForAreas: HealthDataForArea[]
 ): number | undefined {
   const years = healthDataForAreas.map(
@@ -252,7 +252,7 @@ export function getAreaIndicatorDataForYear(
 export function getIndicatorDataForAreasForMostRecentYearOnly(
   healthDataForAreas: HealthDataForArea[]
 ): HealthDataForArea[] | undefined {
-  const mostRecentYearForAreas = getMostRecentYearForAreas(healthDataForAreas);
+  const mostRecentYearForAreas = getLatestYearForAreas(healthDataForAreas);
   if (!mostRecentYearForAreas) {
     return undefined;
   }

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -193,13 +193,34 @@ export function getLatestYear(
   return year;
 }
 
-function getMostRecentYearForAreas(
+export function getFirstYear(
+  points: HealthDataPoint[] | undefined
+): number | undefined {
+  if (!points || points.length < 1) return undefined;
+
+  const year = points.reduce((previous, point) => {
+    return Math.min(previous, point.year);
+  }, points[0].year);
+  return year;
+}
+
+export function getMostRecentYearForAreas(
   healthDataForAreas: HealthDataForArea[]
 ): number | undefined {
   const years = healthDataForAreas.map(
     (area) => getLatestYear(area.healthData) ?? 0
   );
   const mostRecentYear = Math.max(...years);
+  return mostRecentYear === 0 ? undefined : mostRecentYear;
+}
+
+export function getFirstYearForAreas(
+  healthDataForAreas: HealthDataForArea[]
+): number | undefined {
+  const years = healthDataForAreas.map(
+    (area) => getFirstYear(area.healthData) ?? 0
+  );
+  const mostRecentYear = Math.min(...years);
   return mostRecentYear === 0 ? undefined : mostRecentYear;
 }
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-679](https://bjss-enterprise.atlassian.net/browse/DHSCFT-679)/[DHSCFT-601](https://bjss-enterprise.atlassian.net/browse/DHSCFT-601)

Determine first and last year of data for selected areas and filter table data/limit chart axis to only show these years.

## Changes
- update utils functions to find first & last years
- filter table data for years within those limits
- set axis max/min to those years

## Validation
updated behaviour as expected against local api:
http://localhost:3000/chart?is=241&as=E38000231&ats=nhs-sub-integrated-care-boards&gts=england&gs=E92000001
![image](https://github.com/user-attachments/assets/6a799fb5-c440-4a7f-ba5f-4f3f455dc48d)
![image](https://github.com/user-attachments/assets/37facc58-7509-4c92-816a-c339c5597340)

compared with current deployment:
http://20.26.160.30/chart?is=241&as=E38000231&ats=nhs-sub-integrated-care-boards&gts=england&gs=E92000001
![image](https://github.com/user-attachments/assets/b5b2e836-989a-4068-943c-20792e114cbc)
![image](https://github.com/user-attachments/assets/5dde7028-cf42-4b92-8dac-e5a2fc52e185)




