### PR TITLE
DHSCFT-682 compare areas table sort order

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/barChartEmbeddedTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/barChartEmbeddedTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { BarChartEmbeddedTable } from '@/components/organisms/BarChartEmbeddedTable/index';
 import {
   HealthDataForArea,
@@ -157,9 +157,11 @@ describe('BarChartEmbeddedTable', () => {
     ],
   };
 
-  it('should render BarChartEmbeddedTable component', () => {
-    render(
-      <BarChartEmbeddedTable healthIndicatorData={mockHealthIndicatorData} />
+  it('should render BarChartEmbeddedTable component', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable healthIndicatorData={mockHealthIndicatorData} />
+      )
     );
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(
@@ -167,24 +169,28 @@ describe('BarChartEmbeddedTable', () => {
     ).toBeInTheDocument();
   });
 
-  it('should always display benchmark data in the first table row of data', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+  it('should always display benchmark data in the first table row of data', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
     expect(screen.getAllByRole('row')[2]).toHaveTextContent('England');
     expect(screen.getByTestId('table-row-benchmark')).toBeInTheDocument();
   });
 
-  it('should display group data in the second row of table data, when the group selected is not England', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-        groupIndicatorData={mockGroupData}
-      />
+  it('should display group data in the second row of table data, when the group selected is not England', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+          groupIndicatorData={mockGroupData}
+        />
+      )
     );
     expect(screen.getAllByRole('row')[3]).toHaveTextContent(
       'NHS North West Region'
@@ -192,25 +198,29 @@ describe('BarChartEmbeddedTable', () => {
     expect(screen.getByTestId('table-row-group')).toBeInTheDocument();
   });
 
-  it('should not display group row or benchmark row in the table, when no data is passed', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={undefined}
-        groupIndicatorData={undefined}
-      />
+  it('should not display group row or benchmark row in the table, when no data is passed', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={undefined}
+          groupIndicatorData={undefined}
+        />
+      )
     );
 
     expect(screen.queryByTestId('table-row-group')).not.toBeInTheDocument();
     expect(screen.queryByTestId('table-row-benchmark')).not.toBeInTheDocument();
   });
 
-  it('should display data table row colours for benchmark and group', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+  it('should display data table row colours for benchmark and group', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
     // benchmark row
     expect(screen.getAllByRole('row')[1]).toHaveStyle(
@@ -222,9 +232,11 @@ describe('BarChartEmbeddedTable', () => {
     );
   });
 
-  it('should order the data displayed by largest value', () => {
-    render(
-      <BarChartEmbeddedTable healthIndicatorData={mockHealthIndicatorData} />
+  it('should order the data displayed by largest value', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable healthIndicatorData={mockHealthIndicatorData} />
+      )
     );
 
     const header = screen.getAllByRole('columnheader');
@@ -242,24 +254,28 @@ describe('BarChartEmbeddedTable', () => {
     expect(values).toEqual(sortedValues);
   });
 
-  it('should display an X in the table cell if there is no value', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+  it('should display an X in the table cell if there is no value', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
 
     const noValueCells = screen.getAllByText('X');
     expect(noValueCells).toHaveLength(2);
   });
 
-  it('should display correct aria label when then is no value', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+  it('should display correct aria label when then is no value', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
 
     const noValueCells = screen.getAllByLabelText('Not compared');
@@ -267,11 +283,13 @@ describe('BarChartEmbeddedTable', () => {
   });
 
   it('should render the SparklineChart bars for each area displayed in the table and benchmark legend', async () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
 
     const sparkline = await screen.findAllByTestId(
@@ -283,23 +301,27 @@ describe('BarChartEmbeddedTable', () => {
   });
 
   it('should render the checkbox', async () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
     const checkbox = await screen.findByRole('checkbox');
     expect(checkbox).toBeInTheDocument();
   });
 
   // DHSCFT-372 - Add trends to the compare areas bar charts
-  it('should render the correct trend for all data provided', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-      />
+  it('should render the correct trend for all data provided', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+        />
+      )
     );
 
     const trendTags = screen.getAllByTestId('trend-tag-component');
@@ -311,13 +333,15 @@ describe('BarChartEmbeddedTable', () => {
     expect(trendTags[3].textContent).toEqual('No trend data available'); // A1425 trend
   });
 
-  it('should render the data source if provided', () => {
-    render(
-      <BarChartEmbeddedTable
-        healthIndicatorData={mockHealthIndicatorData}
-        benchmarkData={mockBenchmarkData}
-        dataSource={'bar chart data source'}
-      />
+  it('should render the data source if provided', async () => {
+    await act(() =>
+      render(
+        <BarChartEmbeddedTable
+          healthIndicatorData={mockHealthIndicatorData}
+          benchmarkData={mockBenchmarkData}
+          dataSource={'bar chart data source'}
+        />
+      )
     );
 
     expect(

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -31,6 +31,23 @@ import {
   getMaxValue,
 } from '@/components/organisms/BarChartEmbeddedTable/barChartEmbeddedTableHelpers';
 
+function sortByValueAndAreaName(
+  a: BarChartEmbeddedTableRow,
+  b: BarChartEmbeddedTableRow
+): number {
+  if (!a.value && !b.value) return 0;
+
+  if (!a.value) return 1;
+
+  if (!b.value) return -1;
+
+  const valueResult = b.value - a.value;
+
+  if (valueResult != 0) return valueResult;
+
+  return a.area.localeCompare(b.area, undefined, { sensitivity: 'base' });
+}
+
 const ConfidenceLimitsHeader: FC<{ confidenceLimit?: number }> = ({
   confidenceLimit,
 }) => {
@@ -84,12 +101,7 @@ export function BarChartEmbeddedTable({
     })
     .filter(filterUndefined) as BarChartEmbeddedTableRow[];
 
-  const sortedTableRows = tableRows.toSorted((a, b) => {
-    if (!a.value && !b.value) return 0;
-    if (!a.value) return 1;
-    if (!b.value) return -1;
-    return b.value - a.value;
-  });
+  const sortedTableRows = tableRows.toSorted(sortByValueAndAreaName);
 
   const benchmarkDataPoint = benchmarkData?.healthData.find(
     (point) => point.year === fullYear

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/inequalities.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/inequalities.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { Inequalities } from '.';
 import { MOCK_HEALTH_DATA } from '@/lib/tableHelpers/mocks';
@@ -50,11 +50,13 @@ jest.mock('next/navigation', () => {
 
 describe('Inequalities suite', () => {
   it('should render inequalities component', async () => {
-    render(
-      <Inequalities
-        healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
-      />
+    await act(() =>
+      render(
+        <Inequalities
+          healthIndicatorData={MOCK_HEALTH_DATA}
+          searchState={state}
+        />
+      )
     );
 
     await waitFor(async () => {
@@ -80,12 +82,14 @@ describe('Inequalities suite', () => {
     });
   });
 
-  it('should render expected text', () => {
-    render(
-      <Inequalities
-        healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
-      />
+  it('should render expected text', async () => {
+    await act(() =>
+      render(
+        <Inequalities
+          healthIndicatorData={MOCK_HEALTH_DATA}
+          searchState={state}
+        />
+      )
     );
 
     expect(
@@ -96,13 +100,15 @@ describe('Inequalities suite', () => {
     ).toBeInTheDocument();
   });
 
-  it('check if the measurement unit value "kg" is rendered correctly', () => {
-    render(
-      <Inequalities
-        healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
-        measurementUnit="kg"
-      />
+  it('check if the measurement unit value "kg" is rendered correctly', async () => {
+    await act(() =>
+      render(
+        <Inequalities
+          healthIndicatorData={MOCK_HEALTH_DATA}
+          searchState={state}
+          measurementUnit="kg"
+        />
+      )
     );
     expect(screen.getByText('kg')).toBeInTheDocument();
   });

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/OneIndicatorOneAreaViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/OneIndicatorOneAreaViewPlots.test.tsx
@@ -1,7 +1,7 @@
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { OneIndicatorOneAreaViewPlots } from '.';
 import { mockHealthData } from '@/mock/data/healthdata';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { IndicatorWithHealthDataForArea } from '@/generated-sources/ft-api-client';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchStateContext } from '@/context/SearchStateContext';
@@ -65,12 +65,14 @@ const testHealthData: IndicatorWithHealthDataForArea = {
 
 describe('OneIndicatorOneAreaViewPlots', () => {
   it('should render the LineChart components', async () => {
-    render(
-      <OneIndicatorOneAreaViewPlots
-        indicatorData={testHealthData}
-        searchState={searchState}
-        indicatorMetadata={mockMetaData}
-      />
+    await act(() =>
+      render(
+        <OneIndicatorOneAreaViewPlots
+          indicatorData={testHealthData}
+          searchState={searchState}
+          indicatorMetadata={mockMetaData}
+        />
+      )
     );
 
     await waitFor(async () => {
@@ -102,12 +104,14 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       [SearchParams.AreasSelected]: mockAreas,
     };
 
-    render(
-      <OneIndicatorOneAreaViewPlots
-        indicatorData={{ areaHealthData: [mockHealthData['108'][0]] }}
-        searchState={searchState}
-        indicatorMetadata={mockMetaData}
-      />
+    await act(() =>
+      render(
+        <OneIndicatorOneAreaViewPlots
+          indicatorData={{ areaHealthData: [mockHealthData['108'][0]] }}
+          searchState={searchState}
+          indicatorMetadata={mockMetaData}
+        />
+      )
     );
 
     await waitFor(async () => {
@@ -135,12 +139,14 @@ describe('OneIndicatorOneAreaViewPlots', () => {
   });
 
   it('should display data source when metadata exists', async () => {
-    render(
-      <OneIndicatorOneAreaViewPlots
-        indicatorData={testHealthData}
-        searchState={searchState}
-        indicatorMetadata={mockMetaData}
-      />
+    await act(() =>
+      render(
+        <OneIndicatorOneAreaViewPlots
+          indicatorData={testHealthData}
+          searchState={searchState}
+          indicatorMetadata={mockMetaData}
+        />
+      )
     );
 
     const actual = await screen.findAllByText('Data source:', { exact: false });
@@ -159,12 +165,14 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       ],
     };
 
-    render(
-      <OneIndicatorOneAreaViewPlots
-        indicatorData={MOCK_DATA}
-        searchState={searchState}
-        indicatorMetadata={mockMetaData}
-      />
+    await act(() =>
+      render(
+        <OneIndicatorOneAreaViewPlots
+          indicatorData={MOCK_DATA}
+          searchState={searchState}
+          indicatorMetadata={mockMetaData}
+        />
+      )
     );
 
     expect(
@@ -186,12 +194,14 @@ describe('OneIndicatorOneAreaViewPlots', () => {
   });
 
   it('should render the inequalities component', async () => {
-    render(
-      <OneIndicatorOneAreaViewPlots
-        indicatorData={testHealthData}
-        searchState={searchState}
-        indicatorMetadata={mockMetaData}
-      />
+    await act(() =>
+      render(
+        <OneIndicatorOneAreaViewPlots
+          indicatorData={testHealthData}
+          searchState={searchState}
+          indicatorMetadata={mockMetaData}
+        />
+      )
     );
 
     expect(


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-682](https://bjss-enterprise.atlassian.net/browse/DHSCFT-682)

Compare areas table should sort in consistent order when rows have the same value.

## Changes

- Sort table by value, then by area name
- Update a bunch of unit tests to use act() to reduce unit test noise.

## Validation

