### PR TITLE
DHSCFT-689: Line chart plot not showing when only England

### DIFF
--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -1289,10 +1289,20 @@ describe('getLatestYearForAreas', () => {
   it('should return the latest year for a group of areas', () => {
     expect(getLatestYearForAreas(mockData)).toBe(2006);
   });
+
+  it('should return undefined when the data provided is an empty list', () => {
+    expect(getLatestYearForAreas([])).toBeUndefined();
+  });
 });
 
 describe('getFirstYearForAreas', () => {
   it('should return the latest year for a group of areas', () => {
     expect(getFirstYearForAreas(mockData)).toBe(2004);
+  });
+
+  // This can occur when no area is selected. When undefined is returned, the chart min/max
+  // simply use those of the default benchmark i.e. England
+  it('should return undefined when the data provided is an empty list', () => {
+    expect(getFirstYearForAreas([])).toBeUndefined();
   });
 });

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -209,6 +209,10 @@ export function getFirstYear(
 export function getLatestYearForAreas(
   healthDataForAreas: HealthDataForArea[]
 ): number | undefined {
+  if (!healthDataForAreas.length) {
+    return undefined;
+  }
+
   const years = healthDataForAreas.map(
     (area) => getLatestYear(area.healthData) ?? 0
   );
@@ -219,6 +223,10 @@ export function getLatestYearForAreas(
 export function getFirstYearForAreas(
   healthDataForAreas: HealthDataForArea[]
 ): number | undefined {
+  if (!healthDataForAreas.length) {
+    return undefined;
+  }
+
   const years = healthDataForAreas.map(
     (area) => getFirstYear(area.healthData) ?? 0
   );


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-689](https://bjss-enterprise.atlassian.net/browse/DHSCFT-689)

Replication steps can be seen on the ticket. You can check out this branch, run the same steps and see that the plot line for England has returned.

This fixes the problem by putting in appropriate handling for when there is no area data.

I had hoped screenshot testing would catch this, but I think all the Line Chart screenshots include an area, region and England. Could be a nice test to have in future to avoid regression?

## Root cause

It is valid that a user may reach this page having not yet selected an area other than England, which is there by default.

We had no checking that the array for area data (which excludes England) was not empty. This resulted us running `Math.max(...[])` and `Math.min([])` which resolve to `Infinity` and `-Infinity` respectively. As you can imagine, this had some undesirable consequences when passed into the mix max properties for the highchart options.
