### PR TITLE
DHSCFT-694: Show spine chart row when an area is missing

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -111,7 +111,10 @@ describe('Spine chart table row', () => {
     render(
       <table>
         <tbody>
-          <SpineChartTableRow indicatorData={indicatorDataWithTwoAreas} />
+          <SpineChartTableRow
+            indicatorData={indicatorDataWithTwoAreas}
+            twoAreasRequested
+          />
         </tbody>
       </table>
     );

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
@@ -23,10 +23,12 @@ import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 
 export interface SpineChartTableRowProps {
   indicatorData: SpineChartIndicatorData;
+  twoAreasRequested?: boolean;
 }
 
 export const SpineChartTableRow: FC<SpineChartTableRowProps> = ({
   indicatorData,
+  twoAreasRequested = false,
 }) => {
   const {
     indicatorName,
@@ -39,7 +41,7 @@ export const SpineChartTableRow: FC<SpineChartTableRowProps> = ({
   } = indicatorData;
   const { best, worst } = orderStatistics(quartileData);
   const groupIsEngland = groupData?.areaCode === areaCodeForEngland;
-  const twoAreasRequested = areasHealthData.length === 2;
+
   let twoAreasLatestPeriodMatching = true;
 
   if (twoAreasRequested) {

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -59,7 +59,10 @@ export function SpineChartTable({
           />
           {sortedData.map((indicatorData) => (
             <React.Fragment key={indicatorData.indicatorId}>
-              <SpineChartTableRow indicatorData={indicatorData} />
+              <SpineChartTableRow
+                indicatorData={indicatorData}
+                twoAreasRequested={areaNames.length > 1}
+              />
             </React.Fragment>
           ))}
         </StyledTable>

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.test.tsx
@@ -105,7 +105,7 @@ describe('spineChartTableHelpers tests', () => {
         areasSelected,
         selectedGroupCode
       );
-      expect(result).toEqual([]);
+      expect(result[0]).toHaveProperty('areasHealthData', []);
     });
 
     it('should return [] if quartiles are missing', () => {
@@ -131,7 +131,7 @@ describe('spineChartTableHelpers tests', () => {
         areasSelected,
         selectedGroupCode
       );
-      expect(result).toEqual([]);
+      expect(result[0]).toHaveProperty('areasHealthData', []);
     });
 
     it('should return [] if indicatorData is missing id', () => {

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -90,7 +90,7 @@ export const buildSpineChartIndicatorData = (
       if (!areasHealthData[0]) {
         // there was missing data for an area
         console.warn(`No area data`);
-        return null;
+        // return null;
       }
 
       const matchedQuartileData = quartileData.find(
@@ -116,8 +116,8 @@ export const buildSpineChartIndicatorData = (
         benchmarkComparisonMethod: indicatorData.benchmarkMethod,
         // The latest period for the first area's data (health data is sorted be year ASC)
         latestDataPeriod:
-          areasHealthData[0].healthData[
-            areasHealthData[0].healthData.length - 1
+          areasHealthData[0]?.healthData[
+            areasHealthData[0]?.healthData.length - 1
           ].year,
         areasHealthData,
         groupData,

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -6,11 +6,7 @@ import {
 } from '@/generated-sources/ft-api-client';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 
-export const spineChartImproperUsageError =
-  'Improper usage: Spine chart should only be shown when 1-2 areas are selected';
 export const spineChartIndicatorTitleColumnMinWidth = 240;
-export const spineChartPeriodColumnMinWidth = 50;
-export const paddingSize = 8;
 
 export interface SpineChartIndicatorData {
   indicatorId: string;
@@ -66,6 +62,9 @@ export const buildSpineChartIndicatorData = (
         indicatorData.name === null
       ) {
         // the entire row will be missing
+        console.warn(
+          `indicatorData.indicatorId=${indicatorData.indicatorId} indicatorData.name=${indicatorData.name}`
+        );
         return null;
       }
       const indicatorId = indicatorData.indicatorId.toString();
@@ -77,15 +76,20 @@ export const buildSpineChartIndicatorData = (
 
       const areasHealthData = areasSelected
         .map((areaCode) => {
-          return getHealthDataForArea(indicatorData.areaHealthData, areaCode);
+          const areaData = getHealthDataForArea(
+            indicatorData.areaHealthData,
+            areaCode
+          );
+          if (!areaData) {
+            console.warn(`Area data missing for ${areaCode}`);
+          }
+          return areaData;
         })
         .filter((areaData) => areaData !== null);
 
-      if (
-        areasHealthData.length !== areasSelected.length ||
-        !areasHealthData[0]
-      ) {
+      if (!areasHealthData[0]) {
         // there was missing data for an area
+        console.warn(`No area data`);
         return null;
       }
 
@@ -96,6 +100,7 @@ export const buildSpineChartIndicatorData = (
 
       if (!matchedQuartileData) {
         // No quartile data found for the requested indicator ID: ${indicatorData.indicatorId}
+        console.warn('No quartile data found');
         return null;
       }
 

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/spineChartTableHelpers.tsx
@@ -90,7 +90,6 @@ export const buildSpineChartIndicatorData = (
       if (!areasHealthData[0]) {
         // there was missing data for an area
         console.warn(`No area data`);
-        // return null;
       }
 
       const matchedQuartileData = quartileData.find(


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-694](https://bjss-enterprise.atlassian.net/browse/DHSCFT-694)

## Changes

- Include spine chart row in table even if an area is missing data
- Pull out the show two areas so that the row is told rather than deduce from the data, as if the data is missing it would render alternate layout for a single area

## Validation

Before row missing...

![image](https://github.com/user-attachments/assets/a076b7bd-3da3-49a3-9c4a-57c9e7a3414f)

Showing the row but not forcing the row into multiple area rendering view...
![image](https://github.com/user-attachments/assets/04bdd72f-853f-4085-be35-001826b38826)

After, note the second row is showing but has X for Derbyshire and only shows one marker on the spine
![image](https://github.com/user-attachments/assets/1dc8561e-db66-4cc1-8f6f-4effc9b1a82d)...

When the only area is missing
![image](https://github.com/user-attachments/assets/99daa3a3-8f76-4687-ae61-a8b51b4bfc0c)