### PR TITLE
DHSCFT-696_ghost_CIs_for_inequalities_trend

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.test.ts
@@ -52,7 +52,6 @@ import {
   generateHealthDataPoint,
   generateMockHealthDataForArea,
 } from '@/lib/chartHelpers/testHelpers';
-import { log } from 'console';
 
 const MOCK_INEQUALITIES_DATA: HealthDataForArea = {
   areaCode: 'A1425',
@@ -924,6 +923,7 @@ describe('generateLineChartSeriesData', () => {
     const actualPersonsErrorbars = actual.filter(
       (series) => series.type === 'errorbar' && series.name === 'Persons'
     )[0];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((actualPersonsErrorbars as any).data).toEqual(expected);
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.test.ts
@@ -52,6 +52,7 @@ import {
   generateHealthDataPoint,
   generateMockHealthDataForArea,
 } from '@/lib/chartHelpers/testHelpers';
+import { log } from 'console';
 
 const MOCK_INEQUALITIES_DATA: HealthDataForArea = {
   areaCode: 'A1425',
@@ -839,19 +840,29 @@ describe('generateLineChartSeriesData', () => {
   it('should only include years for which the selected areas have data', () => {
     const areasSelected = ['A1'];
     const mockChartDataWithExtraYears: InequalitiesChartData = {
-      areaName: 'West BarFoo',
+      areaName: 'A1',
       rowData: [
         ...mockInequalitiesRowData,
         {
           period: 2003,
           inequalities: {
-            Persons: { isAggregate: true },
+            Persons: {
+              value: 333,
+              upper: 334,
+              lower: 332,
+              isAggregate: true,
+            },
           },
         },
         {
           period: 2009,
           inequalities: {
-            Persons: { isAggregate: true },
+            Persons: {
+              value: 333,
+              upper: 334,
+              lower: 332,
+              isAggregate: true,
+            },
           },
         },
       ],
@@ -865,6 +876,55 @@ describe('generateLineChartSeriesData', () => {
       false
     );
     expect(actual).toEqual(seriesData);
+  });
+
+  it('should include CIs for aggregate series only for years for which the selected areas have data', () => {
+    const areasSelected = ['A1'];
+    const mockChartDataWithExtraYears: InequalitiesChartData = {
+      areaName: 'A1',
+      rowData: [
+        ...mockInequalitiesRowData,
+        {
+          period: 2003,
+          inequalities: {
+            Persons: {
+              value: 333,
+              upper: 334,
+              lower: 332,
+              isAggregate: true,
+            },
+          },
+        },
+        {
+          period: 2009,
+          inequalities: {
+            Persons: {
+              value: 333,
+              upper: 334,
+              lower: 332,
+              isAggregate: true,
+            },
+          },
+        },
+      ],
+    };
+    const expected = [
+      [2004, undefined, undefined],
+      [2008, 441.69151, 578.32766],
+    ];
+
+    const actual = generateInequalitiesLineChartSeriesData(
+      sexKeys,
+      InequalitiesTypes.Sex,
+      mockChartDataWithExtraYears,
+      areasSelected,
+      true
+    );
+
+    const actualPersonsErrorbars = actual.filter(
+      (series) => series.type === 'errorbar' && series.name === 'Persons'
+    )[0];
+    expect((actualPersonsErrorbars as any).data).toEqual(expected);
   });
 });
 

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/inequalitiesHelpers.ts
@@ -261,11 +261,15 @@ export const generateInequalitiesLineChartSeriesData = (
       const confidenceIntervalSeries: Highcharts.SeriesOptionsType =
         generateConfidenceIntervalSeries(
           key,
-          chartData.rowData.map((data) => [
-            data.period,
-            data.inequalities[key]?.lower,
-            data.inequalities[key]?.upper,
-          ]),
+          chartData.rowData
+            .filter(
+              (data) => data.period >= firstYear && data.period <= lastYear
+            )
+            .map((data) => [
+              data.period,
+              data.inequalities[key]?.lower,
+              data.inequalities[key]?.upper,
+            ]),
           showConfidenceIntervalsData
         );
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-696](https://bjss-enterprise.atlassian.net/browse/DHSCFT-696)

Filter inequalities CIs within first and last year to be consistent with series.

## Changes

- Add filter to `generateConfidenceIntervalSeries()`

## Validation
Behaviour as expected against local api:
http://localhost:3000/chart?si=22401&is=22401&ats=england&gts=england&gs=E92000001&gas=ALL&ilts=Districts+and+Unitary+Authorities+deprivation+deciles%3A+Apr+2023+geography+%28Index+of+Multiple+Deprivation+2019%29

![image](https://github.com/user-attachments/assets/688804cc-23d6-4a52-9e5d-a80baeb90c4f)

