### PR TITLE
DHSCFT-703 - Turn ticking CI checkbox ON for Inequalities on Chart components

### DIFF
--- a/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
@@ -163,18 +163,25 @@ export default class ChartPage extends AreaFilter {
       // if its one of the chart components that has a confidence interval checkbox then click it
       if (visibleComponent.componentProps.hasConfidenceIntervals) {
         const componentMapping: Record<string, string> = {
-          [ChartPage.inequalitiesForSingleTimePeriodComponent]: ChartPage.inequalitiesBarChartComponent,
-          [ChartPage.inequalitiesBarChartComponent]: ChartPage.inequalitiesBarChartComponent,
-          [ChartPage.barChartEmbeddedTableComponent]: ChartPage.barChartEmbeddedTableComponent,
-          [ChartPage.inequalitiesLineChartComponent]: ChartPage.inequalitiesLineChartComponent,
-          [ChartPage.inequalitiesTrendComponent]: ChartPage.inequalitiesLineChartComponent,
+          [ChartPage.inequalitiesForSingleTimePeriodComponent]:
+            ChartPage.inequalitiesBarChartComponent,
+          [ChartPage.inequalitiesBarChartComponent]:
+            ChartPage.inequalitiesBarChartComponent,
+          [ChartPage.barChartEmbeddedTableComponent]:
+            ChartPage.barChartEmbeddedTableComponent,
+          [ChartPage.inequalitiesLineChartComponent]:
+            ChartPage.inequalitiesLineChartComponent,
+          [ChartPage.inequalitiesTrendComponent]:
+            ChartPage.inequalitiesLineChartComponent,
         };
-      
+
         const defaultComponent = ChartPage.lineChartComponent;
-        const confidenceIntervalComponent = componentMapping[visibleComponent.componentLocator] || defaultComponent;
-      
+        const confidenceIntervalComponent =
+          componentMapping[visibleComponent.componentLocator] ||
+          defaultComponent;
+
         const testId = `confidence-interval-checkbox-${confidenceIntervalComponent.replace('-component', '')}`;
-      
+
         await this.checkAndAwaitLoadingComplete(this.page.getByTestId(testId));
       }
       // if its one of the chart components that has a details expander then click it

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
@@ -162,9 +162,23 @@ export default class ChartPage extends AreaFilter {
       }
       // if its one of the chart components that has a confidence interval checkbox then click it
       if (visibleComponent.componentProps.hasConfidenceIntervals) {
+        let confidenceIntervalComponent;
+        switch (visibleComponent.componentLocator) {
+          case ChartPage.inequalitiesForSingleTimePeriodComponent:
+          case ChartPage.inequalitiesBarChartComponent:
+            confidenceIntervalComponent =
+              ChartPage.inequalitiesBarChartComponent;
+            break;
+          case ChartPage.barChartEmbeddedTableComponent:
+            confidenceIntervalComponent =
+              ChartPage.barChartEmbeddedTableComponent;
+            break;
+          default:
+            confidenceIntervalComponent = ChartPage.lineChartComponent;
+        }
         await this.checkAndAwaitLoadingComplete(
           this.page.getByTestId(
-            `confidence-interval-checkbox-${visibleComponent.componentLocator.replace('-component', '')}`
+            `confidence-interval-checkbox-${confidenceIntervalComponent.replace('-component', '')}`
           )
         );
       }

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/chartPage.ts
@@ -162,25 +162,20 @@ export default class ChartPage extends AreaFilter {
       }
       // if its one of the chart components that has a confidence interval checkbox then click it
       if (visibleComponent.componentProps.hasConfidenceIntervals) {
-        let confidenceIntervalComponent;
-        switch (visibleComponent.componentLocator) {
-          case ChartPage.inequalitiesForSingleTimePeriodComponent:
-          case ChartPage.inequalitiesBarChartComponent:
-            confidenceIntervalComponent =
-              ChartPage.inequalitiesBarChartComponent;
-            break;
-          case ChartPage.barChartEmbeddedTableComponent:
-            confidenceIntervalComponent =
-              ChartPage.barChartEmbeddedTableComponent;
-            break;
-          default:
-            confidenceIntervalComponent = ChartPage.lineChartComponent;
-        }
-        await this.checkAndAwaitLoadingComplete(
-          this.page.getByTestId(
-            `confidence-interval-checkbox-${confidenceIntervalComponent.replace('-component', '')}`
-          )
-        );
+        const componentMapping: Record<string, string> = {
+          [ChartPage.inequalitiesForSingleTimePeriodComponent]: ChartPage.inequalitiesBarChartComponent,
+          [ChartPage.inequalitiesBarChartComponent]: ChartPage.inequalitiesBarChartComponent,
+          [ChartPage.barChartEmbeddedTableComponent]: ChartPage.barChartEmbeddedTableComponent,
+          [ChartPage.inequalitiesLineChartComponent]: ChartPage.inequalitiesLineChartComponent,
+          [ChartPage.inequalitiesTrendComponent]: ChartPage.inequalitiesLineChartComponent,
+        };
+      
+        const defaultComponent = ChartPage.lineChartComponent;
+        const confidenceIntervalComponent = componentMapping[visibleComponent.componentLocator] || defaultComponent;
+      
+        const testId = `confidence-interval-checkbox-${confidenceIntervalComponent.replace('-component', '')}`;
+      
+        await this.checkAndAwaitLoadingComplete(this.page.getByTestId(testId));
       }
       // if its one of the chart components that has a details expander then click it
       if (visibleComponent.componentProps.hasDetailsExpander) {

--- a/frontend/fingertips-frontend/playwright/testHelpers.ts
+++ b/frontend/fingertips-frontend/playwright/testHelpers.ts
@@ -68,6 +68,7 @@ export function getScenarioConfig(
     {
       componentLocator: ChartPage.inequalitiesForSingleTimePeriodComponent,
       componentProps: {
+        hasConfidenceIntervals: true,
         hasTimePeriodDropDown: true,
         hasTypeDropDown: true,
       },
@@ -75,6 +76,7 @@ export function getScenarioConfig(
     {
       componentLocator: ChartPage.inequalitiesTrendComponent,
       componentProps: {
+        hasConfidenceIntervals: true,
         hasTypeDropDown: true,
       },
     },


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-703](https://bjss-enterprise.atlassian.net/browse/DHSCFT-703)

Added functionality to tick the Confidence Interval checkbox for inequalitiesForSingleTimePeriodComponent and inequalitiesTrendComponent on the core journey tests

## Changes

- Added logic to chartPage to determine correct locator for CI checkbox
- Added flag for confidence interval to inequalitiesForSingleTimePeriodComponent and inequalitiesTrendComponent  components

## Validation

Existing test expanded to include the ticking of the checkbox
Manually checked ticking of the boxes through test runs (screenshots not regenerated due to current ongoing work on threshhold) 
![1](https://github.com/user-attachments/assets/24e59d03-286d-4a44-9166-b4d360560af4)
![2](https://github.com/user-attachments/assets/ad991f98-b645-4c0e-b328-255c7dba7fc9)
![3](https://github.com/user-attachments/assets/7d3202c3-f922-4837-963c-4d5cfd158236)
