### PR TITLE
DHSCFT-537 - highcharts exception in e2e tests

### DIFF
--- a/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
@@ -28,9 +28,9 @@ const testBase = baseTest.extend<{
 
     // Uncaught exceptions
     page.on('pageerror', (error) => {
-        throw new Error(
-          `Page error: ${error.message}. Stack trace: ${error.stack}`
-        );
+      throw new Error(
+        `Page error: ${error.message}. Stack trace: ${error.stack}`
+      );
     });
 
     await use(page);

--- a/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pageFactory.ts
@@ -26,16 +26,11 @@ const testBase = baseTest.extend<{
       }
     });
 
-    // See DHSCFT-536 - for more details on exception
-    const knownHighchartsExc =
-      "Cannot read properties of undefined (reading 'stacks')";
     // Uncaught exceptions
     page.on('pageerror', (error) => {
-      if (failOnUnhandledError && error.message != knownHighchartsExc) {
         throw new Error(
           `Page error: ${error.message}. Stack trace: ${error.stack}`
         );
-      }
     });
 
     await use(page);


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-537](https://bjss-enterprise.atlassian.net/browse/DHSCFT-537)

Investigate, and if necessary/possible fix the unhandled exception from highcharts that was causing playwright tests to fail.

## Changes

- Removed code, added as a temporary workaround, that swallowed the exception.

## Validation

Ran the tests locally a few times, and in the pipeline. Error not present during testing. Decision made assume the issue has been resolved and see if it returns.
