### PR TITLE
DHSCFT-735: pagination with shallow url navigation

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
@@ -158,12 +158,11 @@ export function IndicatorSelectionForm({
     searchState?.[SearchParams.IndicatorsSelected] || [];
 
   const setCurrentPage = (page: number) => {
-    setIsLoading(true);
     stateManager.setState({
       ...searchState,
       [SearchParams.PageNumber]: page.toString(),
     });
-    replace(stateManager.generatePath(pathname), { scroll: false });
+    history.replaceState({}, '', stateManager.generatePath(pathname));
   };
 
   const { sortedResults, selectedSortOrder, handleSortOrder } =

--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
@@ -406,6 +406,10 @@ describe('IndicatorSelectionForm', () => {
   });
 
   describe('Pagination', () => {
+    beforeEach(() => {
+      window.history.replaceState = jest.fn();
+    });
+
     const generateMockSearchResults = (resultsToGenerate: number) => {
       return Array.from({ length: resultsToGenerate }, (_, index) => ({
         indicatorID: index.toString(),
@@ -550,9 +554,11 @@ describe('IndicatorSelectionForm', () => {
       const paginationNext = screen.getByText(/Next/i);
       await user.click(paginationNext);
 
-      expect(mockReplace).toHaveBeenCalledWith(expectedPath, {
-        scroll: false,
-      });
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        {},
+        '',
+        expectedPath
+      );
     });
 
     it('should only select indicators on the current page when "Select all" is checked', async () => {

--- a/frontend/fingertips-frontend/components/pages/results/Results.test.tsx
+++ b/frontend/fingertips-frontend/components/pages/results/Results.test.tsx
@@ -14,7 +14,14 @@ jest.mock('next/navigation', () => {
   return {
     ...originalModule,
     usePathname: jest.fn(),
-    useSearchParams: () => {},
+    useSearchParams: () => {
+      return {
+        get: (key: string) => {
+          if (key === 'pn') return '1';
+          return null;
+        },
+      };
+    },
     useRouter: jest.fn().mockImplementation(() => ({
       replace: jest.fn(),
     })),

--- a/frontend/fingertips-frontend/components/pages/results/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/results/index.tsx
@@ -23,6 +23,7 @@ import { IndicatorSelectionForm } from '@/components/forms/IndicatorSelectionFor
 import { AreaFilterData } from '@/components/molecules/SelectAreasFilterPanel';
 import { useLoadingState } from '@/context/LoaderContext';
 import { useSearchState } from '@/context/SearchStateContext';
+import { useSearchParams } from 'next/navigation';
 
 type SearchResultsProps = {
   initialIndicatorSelectionState: IndicatorSelectionState;
@@ -52,6 +53,7 @@ export function SearchResults({
 }: Readonly<SearchResultsProps>) {
   const { setIsLoading } = useLoadingState();
   const { setSearchState } = useSearchState();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     setSearchState(searchState ?? {});
@@ -78,7 +80,7 @@ export function SearchResults({
   const searchTerm = searchState?.[SearchParams.SearchedIndicator] ?? '';
 
   const currentPageFromState =
-    Number(searchState?.[SearchParams.PageNumber]) || 1;
+    Number(searchParams.get(SearchParams.PageNumber)) || 1;
   const totalPages = Math.ceil(searchResults.length / RESULTS_PER_PAGE);
   const currentPageToUse =
     currentPageFromState <= totalPages ? currentPageFromState : 1;


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-735](https://bjss-enterprise.atlassian.net/browse/DHSCFT-735)

Changes page number without reloading entire page

## Changes

- useSearchParams hook from Next
- change url with history.replaceState (or history.pushState)

## Validation

Existing tests still pass