### PR TITLE
DHSCFT-TECH: Minor change to github branch protection for screenshots job

### DIFF
--- a/.github/workflows/e2e-and-api-tests.yml
+++ b/.github/workflows/e2e-and-api-tests.yml
@@ -29,7 +29,7 @@ jobs:
   execute-e2e-tests-docker:
     name: Execute e2e tests - Docker
     runs-on: ubuntu-latest
-    if: inputs.playwright-mode == 'docker' && (!inputs.update_screenshots || inputs.update_screenshots && github.ref_name != 'main')
+    if: inputs.playwright-mode == 'docker'
 
     defaults:
       run:

--- a/.github/workflows/e2e-and-api-tests.yml
+++ b/.github/workflows/e2e-and-api-tests.yml
@@ -29,7 +29,7 @@ jobs:
   execute-e2e-tests-docker:
     name: Execute e2e tests - Docker
     runs-on: ubuntu-latest
-    if: inputs.playwright-mode == 'docker'
+    if: inputs.playwright-mode == 'docker' && (!inputs.update_screenshots || inputs.update_screenshots && github.ref_name != 'main')
 
     defaults:
       run:

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,6 +7,7 @@ jobs:
   update-screenshots:
     name: Update Baseline Screenshots for E2E Tests
     uses: ./.github/workflows/e2e-and-api-tests.yml
+    if: github.ref_name != 'main'
     with:
       playwright-mode: docker
       update_screenshots: true

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,7 +7,7 @@ jobs:
   update-screenshots:
     name: Update Baseline Screenshots for E2E Tests
     uses: ./.github/workflows/e2e-and-api-tests.yml
-    if: github.ref_name != 'main'
+    if: github.ref_name != 'feature/DHSCFT-TECH_prevent-updating-main-screenshots'
     with:
       playwright-mode: docker
       update_screenshots: true

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,7 +7,7 @@ jobs:
   update-screenshots:
     name: Update Baseline Screenshots for E2E Tests
     uses: ./.github/workflows/e2e-and-api-tests.yml
-    if: github.ref_name != 'feature/DHSCFT-TECH_prevent-updating-main-screenshots'
+    if: github.ref_name != 'main'
     with:
       playwright-mode: docker
       update_screenshots: true


### PR DESCRIPTION
# Description

Currently, you can run the 'Update Baseline Screenshots' workflow against `main`. I did not test this (and hope that with the branch protection rules, the commit that is created in that workflow cannot be applied directly to main).

This if statement hopefully makes things a bit clearer - it simply will not run the job if update-screenshots has been passed as true but the ref is the `main` branch.

Had hoped there was a way to limit the refs that can be used from a workflow dispatch action but it seems note: https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch Only option seems to be to use an `if`.

## Validation
Temporarily pointed if statement against my branch, tried running the workflow and validated that the steps do not get run.
https://github.com/dhsc-govuk/FingertipsNext/actions/runs/14878869501
Outcome was successful.
