### PR TITLE
DHSCFT-746: Allow retrieval of tags in pipeline

### DIFF
--- a/.github/workflows/fingertips-workflow.yml
+++ b/.github/workflows/fingertips-workflow.yml
@@ -598,9 +598,11 @@ jobs:
       git_tag: ${{ steps.setvars.outputs.git_tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: setvars
         run: |
-          echo "git_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "git_tag=$(git describe --tags --abbrev=0 --always)" >> $GITHUB_OUTPUT
 
   deploy-frontend-dev:


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-716](https://bjss-enterprise.atlassian.net/browse/DHSCFT-716)

Quick addition to the PR from yesterday. You will see from the deployed site that a long commit rather than short is retrieved while the tag is not retrieved at all. This fixes it.

See reasoning for fetch-depth: 0 here - https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches
