### PR TITLE
DHSCFT-786: Modal pane for displaying export options

### DIFF
--- a/frontend/fingertips-frontend/components/layouts/container/index.tsx
+++ b/frontend/fingertips-frontend/components/layouts/container/index.tsx
@@ -3,10 +3,10 @@
 import { LoaderProvider } from '@/context/LoaderContext';
 import { SearchStateProvider } from '@/context/SearchStateContext';
 import { Main } from 'govuk-react';
-import React from 'react';
 import styled from 'styled-components';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { reactQueryClient } from '@/lib/reactQueryClient';
+import { ModalProvider } from '@/context/ModalContext';
 
 const StyledMain = styled(Main)({
   minHeight: '80vh',
@@ -17,13 +17,15 @@ export function FTContainer({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <QueryClientProvider client={reactQueryClient}>
-      <SearchStateProvider>
-        <LoaderProvider>
-          <main>
-            <StyledMain>{children}</StyledMain>
-          </main>
-        </LoaderProvider>
-      </SearchStateProvider>
+      <ModalProvider>
+        <SearchStateProvider>
+          <LoaderProvider>
+            <main>
+              <StyledMain>{children}</StyledMain>
+            </main>
+          </LoaderProvider>
+        </SearchStateProvider>
+      </ModalProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.styles.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.styles.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { GovukColours } from '@/lib/styleHelpers/colours';
+
+export const ModalPaneContainer = styled.div({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  zIndex: 1000,
+});
+
+export const ModalPaneOverlay = styled.div({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  backgroundColor: `rgba(255, 255, 255, 0.75)`,
+  pointerEvents: 'auto',
+});
+
+export const ModalPaneInner = styled.div({
+  position: 'absolute',
+  top: '200px',
+  left: 'calc(50vw - 370px)',
+  width: '740px',
+  backgroundColor: GovukColours.White,
+  border: `1px solid ${GovukColours.Black}`,
+  padding: '16px',
+});
+
+export const ModalPaneBlankButton = styled.button({
+  appearance: 'none',
+  padding: '8px',
+  border: 'none',
+  backgroundColor: 'transparent',
+  position: 'absolute',
+  top: 0,
+  right: 0,
+});

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.test.tsx
@@ -1,0 +1,67 @@
+import { ModalPane } from '@/components/molecules/ModalPane/ModalPane';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockModalContext = {
+  content: <p>Modal content</p>,
+  title: 'Modal title',
+  setModal: jest.fn(),
+};
+
+jest.mock('@/context/ModalContext', () => {
+  return {
+    useModal: () => mockModalContext,
+  };
+});
+
+describe('ModalPane', () => {
+  beforeEach(() => {
+    mockModalContext.content = <p>Modal content</p>;
+    mockModalContext.title = 'Modal title';
+    mockModalContext.setModal = jest.fn();
+  });
+
+  it('should render an overlay with a close onClick', async () => {
+    render(<ModalPane />);
+
+    const container = screen.getByTestId('modalPane');
+    const overlay = container.firstChild;
+    expect(container).toBeInTheDocument();
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toMatchSnapshot();
+
+    await userEvent.click(overlay as Element);
+    expect(mockModalContext.setModal).toHaveBeenCalledWith({});
+  });
+
+  it('should render a title', () => {
+    render(<ModalPane />);
+
+    const title = screen.getByRole('heading', { level: 2 });
+    expect(title).toHaveTextContent('Modal title');
+  });
+
+  it('should not render a title if not supplied', () => {
+    mockModalContext.title = '';
+    render(<ModalPane />);
+    expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
+  });
+
+  it('should render a close button', async () => {
+    render(<ModalPane />);
+    const btn = screen.queryByLabelText('Close modal');
+    expect(btn).toBeInTheDocument();
+    expect(btn).toMatchSnapshot();
+    await userEvent.click(btn as Element);
+    expect(mockModalContext.setModal).toHaveBeenCalledWith({});
+  });
+
+  it('should display given child content', () => {
+    render(<ModalPane />);
+    const container = screen.getByTestId('modalPane');
+    const inner = container.children[1] as HTMLElement;
+    expect(inner).toBeInTheDocument();
+    const content = within(inner).getByRole('paragraph');
+    expect(content).toHaveTextContent('Modal content');
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPane.tsx
@@ -1,0 +1,32 @@
+import { useModal } from '@/context/ModalContext';
+
+import { SyntheticEvent } from 'react';
+import { H2 } from 'govuk-react';
+import {
+  ModalPaneContainer,
+  ModalPaneInner,
+  ModalPaneOverlay,
+} from '@/components/molecules/ModalPane/ModalPane.styles';
+import { ModalPaneCloseButton } from '@/components/molecules/ModalPane/ModalPaneCloseButton';
+
+export const ModalPane = () => {
+  const { content, setModal, title } = useModal();
+
+  if (!content) return null;
+
+  const onClose = (e: SyntheticEvent) => {
+    e.preventDefault();
+    setModal({});
+  };
+
+  return (
+    <ModalPaneContainer data-testid={'modalPane'}>
+      <ModalPaneOverlay onClick={onClose} />
+      <ModalPaneInner>
+        {title ? <H2>{title}</H2> : null}
+        <ModalPaneCloseButton onClick={onClose} />
+        {content}
+      </ModalPaneInner>
+    </ModalPaneContainer>
+  );
+};

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPaneCloseButton.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPaneCloseButton.tsx
@@ -1,0 +1,18 @@
+import { FC, SyntheticEvent } from 'react';
+import { RemoveIcon } from '@/components/atoms/RemoveIcon';
+import { GovukColours } from '@/lib/styleHelpers/colours';
+import { ModalPaneBlankButton } from '@/components/molecules/ModalPane/ModalPane.styles';
+
+interface ModalPaneCloseButtonProps {
+  onClick?: (e: SyntheticEvent) => void;
+}
+
+export const ModalPaneCloseButton: FC<ModalPaneCloseButtonProps> = ({
+  onClick,
+}) => {
+  return (
+    <ModalPaneBlankButton onClick={onClick} aria-label={'Close modal'}>
+      <RemoveIcon width={'16px'} height={'16px'} color={GovukColours.Black} />
+    </ModalPaneBlankButton>
+  );
+};

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/__snapshots__/ModalPane.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/__snapshots__/ModalPane.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalPane should render a close button 1`] = `
+.c0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 8px;
+  border: none;
+  background-color: transparent;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.c1 {
+  cursor: pointer;
+}
+
+@media print {
+
+}
+
+@media print {
+
+}
+
+@media only screen and (min-width:641px) {
+
+}
+
+@media only screen and (min-width:641px) {
+
+}
+
+<button
+  aria-label="Close modal"
+  class="c0"
+>
+  <svg
+    class="c1"
+    data-testid="x-icon"
+    fill="none"
+    height="16px"
+    stroke="#0B0C0C"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="3"
+    viewBox="0 0 25 25"
+    width="16px"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <line
+      x1="18"
+      x2="6"
+      y1="6"
+      y2="18"
+    />
+    <line
+      x1="6"
+      x2="18"
+      y1="6"
+      y2="18"
+    />
+  </svg>
+</button>
+`;
+
+exports[`ModalPane should render an overlay with a close onClick 1`] = `
+.c0 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(255,255,255,0.75);
+  pointer-events: auto;
+}
+
+@media print {
+
+}
+
+@media print {
+
+}
+
+@media only screen and (min-width:641px) {
+
+}
+
+@media only screen and (min-width:641px) {
+
+}
+
+<div
+  class="c0"
+/>
+`;

--- a/frontend/fingertips-frontend/context/ModalContext.test.tsx
+++ b/frontend/fingertips-frontend/context/ModalContext.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ModalProvider, useModal } from '@/context/ModalContext';
+
+const TestComponent = () => {
+  const { setModal } = useModal();
+  return (
+    <button
+      onClick={() =>
+        setModal({ title: 'Modal title', content: <p>Modal content</p> })
+      }
+    >
+      Open Modal
+    </button>
+  );
+};
+
+describe('ModalProvider', () => {
+  it('renders modal content when modal is set', async () => {
+    render(
+      <ModalProvider>
+        <TestComponent />
+      </ModalProvider>
+    );
+
+    await userEvent.click(screen.getByText(/open modal/i));
+
+    expect(await screen.findByText(/modal content/i)).toBeInTheDocument();
+    expect(screen.getByText(/modal title/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/fingertips-frontend/context/ModalContext.tsx
+++ b/frontend/fingertips-frontend/context/ModalContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, FC, ReactNode, useContext, useState } from 'react';
+import { ModalPane } from '@/components/molecules/ModalPane/ModalPane';
+
+export interface Modal {
+  content?: ReactNode;
+  title?: string;
+}
+
+export const ModalContext = createContext<{
+  modal: Modal;
+  setModal: (newPreview: Modal) => void;
+}>({ modal: {}, setModal: () => undefined });
+
+export const useModal = () => {
+  const { modal, setModal } = useContext(ModalContext);
+  const { content, title } = modal;
+  return { modal, setModal, content, title };
+};
+
+interface ModalProviderProps {
+  children: ReactNode;
+}
+
+export const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
+  const [modal, setModal] = useState<Modal>({});
+  return (
+    <ModalContext.Provider value={{ modal, setModal }}>
+      {children}
+      <ModalPane />
+    </ModalContext.Provider>
+  );
+};

--- a/frontend/fingertips-frontend/context/ModalContext.tsx
+++ b/frontend/fingertips-frontend/context/ModalContext.tsx
@@ -1,4 +1,11 @@
-import { createContext, FC, ReactNode, useContext, useState } from 'react';
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import { ModalPane } from '@/components/molecules/ModalPane/ModalPane';
 
 export interface Modal {
@@ -23,8 +30,16 @@ interface ModalProviderProps {
 
 export const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
   const [modal, setModal] = useState<Modal>({});
+  const providerValue = useMemo(
+    () => ({
+      modal,
+      setModal,
+    }),
+    [modal]
+  );
+
   return (
-    <ModalContext.Provider value={{ modal, setModal }}>
+    <ModalContext.Provider value={providerValue}>
       {children}
       <ModalPane />
     </ModalContext.Provider>


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-786](https://bjss-enterprise.atlassian.net/browse/DHSCFT-786)

A generic modal window pane for arbitrary content - in readiness for export chart preview and options

## Changes

- Added modal context
- Added a useModal hook for ease of use
- Added a modal pane component and close button

## Validation

Can be seen by adding...

```
const { setModal } = useModal();
  useEffect(() => {
    setModal({ title: 'This is a modal pane', content: <p>Hello world</p> });
  }, [setModal]);

```

...to any mounted component e.g. `pages/home/index.tsx` to open the modal box.

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/7bf8d28f-5dc9-43ba-a621-6740f50bf94d" />