### PR TITLE
change close button size from 14px to 20px

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPaneCloseButton.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/ModalPaneCloseButton.tsx
@@ -12,7 +12,7 @@ export const ModalPaneCloseButton: FC<ModalPaneCloseButtonProps> = ({
 }) => {
   return (
     <ModalPaneBlankButton onClick={onClick} aria-label={'Close modal'}>
-      <RemoveIcon width={'16px'} height={'16px'} color={GovukColours.Black} />
+      <RemoveIcon width={'20px'} height={'20px'} color={GovukColours.Black} />
     </ModalPaneBlankButton>
   );
 };

--- a/frontend/fingertips-frontend/components/molecules/ModalPane/__snapshots__/ModalPane.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/ModalPane/__snapshots__/ModalPane.test.tsx.snap
@@ -41,13 +41,13 @@ exports[`ModalPane should render a close button 1`] = `
     class="c1"
     data-testid="x-icon"
     fill="none"
-    height="16px"
+    height="20px"
     stroke="#0B0C0C"
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="3"
     viewBox="0 0 25 25"
-    width="16px"
+    width="20px"
     xmlns="http://www.w3.org/2000/svg"
   >
     <line


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-832](https://bjss-enterprise.atlassian.net/browse/DHSCFT-832)

<img width="638" alt="image" src="https://github.com/user-attachments/assets/d892c2c5-4f18-48d5-8011-f939347200dd" />


The modal dialog button font size height and width changed from 14px to 20px to match figma design.

## Changes

  -  Button width and height changed.
  -  Unit test snapshot updated.
