### PR TITLE
add padding below search box

### DIFF
--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/__snapshots__/IndicatorSearchForm.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/__snapshots__/IndicatorSearchForm.test.tsx.snap
@@ -126,6 +126,10 @@ exports[`snapshot test - renders the form 1`] = `
   margin-bottom: 20px;
 }
 
+.c12 {
+  margin-top: 5px;
+}
+
 .c4 {
   padding-bottom: 2px;
 }
@@ -252,6 +256,9 @@ exports[`snapshot test - renders the form 1`] = `
         </svg>
       </button>
     </div>
+    <div
+      class="c12"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/index.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/index.tsx
@@ -15,8 +15,8 @@ const StyledFormGroup = styled(FormGroup)(
   spacing.withWhiteSpace({ marginBottom: 6 })
 );
 
-const StyledSearchBox = styled(SearchBox)({
-  paddingBottom: '5px',
+const StyledDivCharacterCountContainer = styled.div({
+  marginTop: '5px',
 });
 
 const StyledTitleParagraph = styled(styled(Paragraph)`
@@ -68,7 +68,7 @@ export const IndicatorSearchForm = ({
       ) : (
         ''
       )}
-      <StyledSearchBox>
+      <SearchBox>
         {SearchBox.Input && (
           <SearchBox.Input
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -98,12 +98,14 @@ export const IndicatorSearchForm = ({
             data-testid="indicator-search-form-submit"
           />
         )}
-      </StyledSearchBox>
-      <CharacterCount
-        textLength={inputTextLength}
-        characterLimit={INDICATOR_SEARCH_MAX_CHARACTERS}
-        thresholdPercentage={75}
-      />
+      </SearchBox>
+      <StyledDivCharacterCountContainer>
+        <CharacterCount
+          textLength={inputTextLength}
+          characterLimit={INDICATOR_SEARCH_MAX_CHARACTERS}
+          thresholdPercentage={75}
+        />
+      </StyledDivCharacterCountContainer>
     </StyledFormGroup>
   );
 };


### PR DESCRIPTION
# Description

https://bjss-enterprise.atlassian.net/browse/DHSCFT-828

add 5px padding below the search box on results page

## Changes
BEFORE
![image](https://github.com/user-attachments/assets/4d2057cc-e94f-4bc2-b539-8e81266029cd)

AFTER
![image](https://github.com/user-attachments/assets/e6c1ebfa-5bae-45e9-b0ca-e89fff844875)

