### PR TITLE
DHSCFT-873: Bugfix add england data to spine chart csv export when its not the benchmark area

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/convertSpineChartTableToCsv.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/convertSpineChartTableToCsv.test.ts
@@ -1,4 +1,5 @@
 import {
+  mockSpineEnglandData,
   mockSpineGroupData,
   mockSpineHealthDataForArea,
   mockSpineIndicatorData,
@@ -74,25 +75,27 @@ describe('convertSpineChartTableToCsv', () => {
     expect(row[12]).toEqual(mockSpineQuartileData.q4Value);
   });
 
-  it('should convert spine benchmark data to csv', () => {
+  it('should convert spine england data to csv', () => {
     const result = convertSpineChartTableToCsv([mockSpineIndicatorData]);
     expect(result).toHaveLength(4);
 
     const row = result[3];
-    const healthPoint = mockSpineHealthDataForArea.healthData[0];
-    const areaBenchmark = healthPoint.benchmarkComparison;
 
     expect(row[0]).toEqual(mockSpineIndicatorData.indicatorId);
     expect(row[1]).toEqual(mockSpineIndicatorData.indicatorName);
     expect(row[2]).toEqual(mockSpineIndicatorData.latestDataPeriod);
-    expect(row[3]).toEqual(areaBenchmark?.benchmarkAreaName);
-    expect(row[4]).toEqual(areaBenchmark?.benchmarkAreaCode);
-    expect(row[5]).toEqual(undefined);
-    expect(row[6]).toEqual(undefined);
-    expect(row[7]).toEqual(undefined);
-    expect(row[8]).toEqual(undefined);
+    expect(row[3]).toEqual(mockSpineEnglandData.areaName);
+    expect(row[4]).toEqual(mockSpineEnglandData.areaCode);
+    expect(row[5]).toEqual(
+      mockSpineEnglandData.healthData[0].benchmarkComparison.benchmarkAreaCode
+    );
+    expect(row[6]).toEqual(
+      mockSpineEnglandData.healthData[0].benchmarkComparison.outcome
+    );
+    expect(row[7]).toEqual(mockSpineEnglandData.healthData[0].trend);
+    expect(row[8]).toEqual(mockSpineEnglandData.healthData[0].count);
     expect(row[9]).toEqual(mockSpineIndicatorData.valueUnit);
-    expect(row[10]).toEqual(areaBenchmark?.benchmarkValue);
+    expect(row[10]).toEqual(mockSpineEnglandData.healthData[0].value);
     expect(row[11]).toEqual(mockSpineQuartileData.q0Value);
     expect(row[12]).toEqual(mockSpineQuartileData.q4Value);
   });
@@ -104,62 +107,46 @@ describe('convertSpineChartTableToCsv', () => {
     expect(result).toHaveLength(3);
 
     expect(result[1][4]).toEqual(mockSpineHealthDataForArea.areaCode);
-
-    const row = result[2];
-    const healthPoint = mockSpineHealthDataForArea.healthData[0];
-    const areaBenchmark = healthPoint.benchmarkComparison;
-
-    expect(row[0]).toEqual(mockSpineIndicatorData.indicatorId);
-    expect(row[1]).toEqual(mockSpineIndicatorData.indicatorName);
-    expect(row[2]).toEqual(mockSpineIndicatorData.latestDataPeriod);
-    expect(row[3]).toEqual(areaBenchmark?.benchmarkAreaName);
-    expect(row[4]).toEqual(areaBenchmark?.benchmarkAreaCode);
-    expect(row[5]).toEqual(undefined);
-    expect(row[6]).toEqual(undefined);
-    expect(row[7]).toEqual(undefined);
-    expect(row[8]).toEqual(undefined);
-    expect(row[9]).toEqual(mockSpineIndicatorData.valueUnit);
-    expect(row[10]).toEqual(areaBenchmark?.benchmarkValue);
-    expect(row[11]).toEqual(mockSpineQuartileData.q0Value);
-    expect(row[12]).toEqual(mockSpineQuartileData.q4Value);
+    expect(result[2][4]).toEqual(mockSpineEnglandData.areaCode);
   });
 
-  it('should convert correctly when group data is benchmark group', () => {
-    const cloneMockSpineGroupData = JSON.parse(
-      JSON.stringify(mockSpineGroupData)
-    );
-    cloneMockSpineGroupData.areaCode =
-      mockSpineHealthDataForArea.healthData[0]?.benchmarkComparison?.benchmarkAreaCode;
-    cloneMockSpineGroupData.areaName =
-      mockSpineHealthDataForArea.healthData[0]?.benchmarkComparison?.benchmarkAreaName;
-
-    cloneMockSpineGroupData.healthData[0].benchmarkComparison = null;
-
+  it('should convert correctly when group data is missing', () => {
     const testData = {
       ...mockSpineIndicatorData,
-      groupData: cloneMockSpineGroupData,
+      groupData: null,
     };
 
     const result = convertSpineChartTableToCsv([testData]);
     expect(result).toHaveLength(3);
 
     expect(result[1][4]).toEqual(mockSpineHealthDataForArea.areaCode);
-    const row = result[2];
-    const healthPoint = mockSpineHealthDataForArea.healthData[0];
-    const areaBenchmark = healthPoint.benchmarkComparison;
+    expect(result[2][4]).toEqual(mockSpineEnglandData.areaCode);
+  });
 
-    expect(row[0]).toEqual(mockSpineIndicatorData.indicatorId);
-    expect(row[1]).toEqual(mockSpineIndicatorData.indicatorName);
-    expect(row[2]).toEqual(mockSpineIndicatorData.latestDataPeriod);
-    expect(row[3]).toEqual(areaBenchmark?.benchmarkAreaName);
-    expect(row[4]).toEqual(areaBenchmark?.benchmarkAreaCode);
-    expect(row[5]).toEqual(undefined);
-    expect(row[6]).toEqual(undefined);
-    expect(row[7]).toEqual(undefined);
-    expect(row[8]).toEqual(undefined);
-    expect(row[9]).toEqual(mockSpineIndicatorData.valueUnit);
-    expect(row[10]).toEqual(areaBenchmark?.benchmarkValue);
-    expect(row[11]).toEqual(mockSpineQuartileData.q0Value);
-    expect(row[12]).toEqual(mockSpineQuartileData.q4Value);
+  it('should convert correctly when england data is missing', () => {
+    const testData = {
+      ...mockSpineIndicatorData,
+      englandData: null,
+    };
+
+    const result = convertSpineChartTableToCsv([testData]);
+    expect(result).toHaveLength(3);
+
+    expect(result[1][4]).toEqual(mockSpineHealthDataForArea.areaCode);
+    expect(result[2][4]).toEqual(mockSpineGroupData.areaCode);
+  });
+
+  it('should not include england if england is also the group', () => {
+    const testData = {
+      ...mockSpineIndicatorData,
+      englandData: mockSpineGroupData,
+    };
+
+    const result = convertSpineChartTableToCsv([testData]);
+    expect(result).toHaveLength(3);
+
+    expect(result[1][4]).toEqual(mockSpineHealthDataForArea.areaCode);
+    expect(result[2][4]).toEqual(mockSpineGroupData.areaCode);
+    expect(result[2][3]).toEqual(`Group: ${mockSpineGroupData.areaName}`);
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/convertSpineChartTableToCsv.ts
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/convertSpineChartTableToCsv.ts
@@ -33,11 +33,10 @@ export const convertSpineChartTableToCsv = (
       valueUnit,
       quartileData,
       groupData,
+      englandData,
     } = indicator;
 
     const { best, worst } = orderStatistics(quartileData);
-    const { benchmarkAreaCode, benchmarkAreaName, benchmarkValue } =
-      areasHealthData[0]?.healthData[0]?.benchmarkComparison ?? {};
 
     areasHealthData.forEach((areasHealth) => {
       if (!areasHealth) return;
@@ -51,7 +50,7 @@ export const convertSpineChartTableToCsv = (
         latestDataPeriod,
         areaName,
         areaCode,
-        benchmarkAreaCode,
+        benchmarkComparison?.benchmarkAreaCode,
         benchmarkComparison?.outcome,
         trend,
         count,
@@ -63,7 +62,7 @@ export const convertSpineChartTableToCsv = (
       csvData.push(newRow);
     });
 
-    if (groupData && groupData?.areaCode !== benchmarkAreaCode) {
+    if (groupData) {
       const { areaCode, areaName, healthData } = groupData;
       const { benchmarkComparison, trend, count, value } = healthData[0];
       const groupRow: CsvRow = [
@@ -85,22 +84,26 @@ export const convertSpineChartTableToCsv = (
       csvData.push(groupRow);
     }
 
-    const benchmarkRow: CsvRow = [
-      indicatorId,
-      indicatorName,
-      latestDataPeriod,
-      benchmarkAreaName,
-      benchmarkAreaCode,
-      undefined, // benchmark area code
-      undefined, // benchmark outcome
-      undefined, // trend
-      undefined, // count
-      valueUnit,
-      benchmarkValue,
-      worst,
-      best,
-    ];
-    csvData.push(benchmarkRow);
+    if (englandData && englandData.areaCode !== groupData?.areaCode) {
+      const { areaCode, areaName, healthData } = englandData;
+      const { benchmarkComparison, trend, count, value } = healthData[0];
+      const newRow: CsvRow = [
+        indicatorId,
+        indicatorName,
+        latestDataPeriod,
+        areaName,
+        areaCode,
+        benchmarkComparison?.benchmarkAreaCode,
+        benchmarkComparison?.outcome,
+        trend,
+        count,
+        valueUnit,
+        value,
+        worst,
+        best,
+      ];
+      csvData.push(newRow);
+    }
   });
 
   return csvData;

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -50,7 +50,7 @@ export function SpineChartTable({
     areaNames.length > 1 ? StyledTableMultipleAreas : StyledTableOneArea;
 
   const csvData = useMemo(() => {
-    return convertSpineChartTableToCsv(sortedData);
+    return convertSpineChartTableToCsv(sortedData, benchmarkToUse);
   }, [sortedData]);
 
   const groupName = sortedData[0].groupData?.areaName;


### PR DESCRIPTION

# Description

Bugfix jira ticket: [DHSCFT-873](https://bjss-enterprise.atlassian.net/browse/DHSCFT-873)
Original ticket: [DHSCFT-826](https://bjss-enterprise.atlassian.net/browse/DHSCFT-826)

## Changes

- Use englandData from data object supplied to chart component
- Use groupData from data object supplied to chart component
- Omit englandData if it's the same areaCode as the groupData
