### PR TITLE
DHSCFT-880: Fixing label along with some refactoring. Hide outcome te…

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -2,7 +2,6 @@
 
 import {
   BenchmarkComparisonMethod,
-  BenchmarkOutcome,
   HealthDataForArea,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
@@ -136,19 +135,19 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
     groupDataPointNamePrefix,
     englandLabel,
     groupLabel,
-    englandOutcomeLabel;
+    showLabel;
   if (benchmarkToUse === areaCodeForEngland) {
     englandDataPointNamePrefix = 'Benchmark: ';
     groupDataPointNamePrefix = 'Group: ';
     englandLabel = AreaTypeLabelEnum.Benchmark;
     groupLabel = AreaTypeLabelEnum.Group;
-    englandOutcomeLabel = englandDataPoint?.benchmarkComparison?.outcome;
+    showLabel = true;
   } else {
     englandDataPointNamePrefix = '';
     groupDataPointNamePrefix = 'Benchmark: ';
     englandLabel = AreaTypeLabelEnum.Area;
     groupLabel = AreaTypeLabelEnum.Benchmark;
-    englandOutcomeLabel = BenchmarkOutcome.NotCompared;
+    showLabel = false;
   }
 
   const id = 'barChartEmbeddedTable';
@@ -273,7 +272,9 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                     englandDataPoint.upperCi,
                   ]}
                   showConfidenceIntervalsData={showConfidenceIntervalsData}
-                  benchmarkOutcome={englandOutcomeLabel}
+                  benchmarkOutcome={
+                    englandDataPoint?.benchmarkComparison?.outcome
+                  }
                   benchmarkComparisonMethod={benchmarkComparisonMethod}
                   polarity={polarity}
                   label={englandLabel}
@@ -281,6 +282,7 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                   year={englandDataPoint.year}
                   measurementUnit={measurementUnit}
                   barColor={GovukColours.DarkGrey}
+                  showLabel={showLabel}
                 ></SparklineChart>
               </Table.Cell>
               <FormatNumberInTableCell

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -282,7 +282,7 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                   year={englandDataPoint.year}
                   measurementUnit={measurementUnit}
                   barColor={GovukColours.DarkGrey}
-                  showLabel={showComparisonLabels}
+                  showComparisonLabels={showComparisonLabels}
                 ></SparklineChart>
               </Table.Cell>
               <FormatNumberInTableCell

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -135,19 +135,19 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
     groupDataPointNamePrefix,
     englandLabel,
     groupLabel,
-    showLabel;
+    showComparisonLabels;
   if (benchmarkToUse === areaCodeForEngland) {
     englandDataPointNamePrefix = 'Benchmark: ';
     groupDataPointNamePrefix = 'Group: ';
     englandLabel = AreaTypeLabelEnum.Benchmark;
     groupLabel = AreaTypeLabelEnum.Group;
-    showLabel = true;
+    showComparisonLabels = true;
   } else {
     englandDataPointNamePrefix = '';
     groupDataPointNamePrefix = 'Benchmark: ';
     englandLabel = AreaTypeLabelEnum.Area;
     groupLabel = AreaTypeLabelEnum.Benchmark;
-    showLabel = false;
+    showComparisonLabels = false;
   }
 
   const id = 'barChartEmbeddedTable';
@@ -282,7 +282,7 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                   year={englandDataPoint.year}
                   measurementUnit={measurementUnit}
                   barColor={GovukColours.DarkGrey}
-                  showLabel={showLabel}
+                  showLabel={showComparisonLabels}
                 ></SparklineChart>
               </Table.Cell>
               <FormatNumberInTableCell

--- a/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BarChartEmbeddedTable/index.tsx
@@ -2,6 +2,7 @@
 
 import {
   BenchmarkComparisonMethod,
+  BenchmarkOutcome,
   HealthDataForArea,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
@@ -131,10 +132,24 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
 
   const confidenceLimit = getConfidenceLimitNumber(benchmarkComparisonMethod);
 
-  const englandDataPointNamePrefix =
-    benchmarkToUse === areaCodeForEngland ? 'Benchmark: ' : '';
-  const groupDataPointNamePrefix =
-    benchmarkToUse === areaCodeForEngland ? 'Group: ' : 'Benchmark: ';
+  let englandDataPointNamePrefix,
+    groupDataPointNamePrefix,
+    englandLabel,
+    groupLabel,
+    englandOutcomeLabel;
+  if (benchmarkToUse === areaCodeForEngland) {
+    englandDataPointNamePrefix = 'Benchmark: ';
+    groupDataPointNamePrefix = 'Group: ';
+    englandLabel = AreaTypeLabelEnum.Benchmark;
+    groupLabel = AreaTypeLabelEnum.Group;
+    englandOutcomeLabel = englandDataPoint?.benchmarkComparison?.outcome;
+  } else {
+    englandDataPointNamePrefix = '';
+    groupDataPointNamePrefix = 'Benchmark: ';
+    englandLabel = AreaTypeLabelEnum.Area;
+    groupLabel = AreaTypeLabelEnum.Benchmark;
+    englandOutcomeLabel = BenchmarkOutcome.NotCompared;
+  }
 
   const id = 'barChartEmbeddedTable';
 
@@ -258,12 +273,10 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                     englandDataPoint.upperCi,
                   ]}
                   showConfidenceIntervalsData={showConfidenceIntervalsData}
-                  benchmarkOutcome={
-                    englandDataPoint.benchmarkComparison?.outcome
-                  }
+                  benchmarkOutcome={englandOutcomeLabel}
                   benchmarkComparisonMethod={benchmarkComparisonMethod}
                   polarity={polarity}
-                  label={AreaTypeLabelEnum.Benchmark}
+                  label={englandLabel}
                   area={englandData?.areaName}
                   year={englandDataPoint.year}
                   measurementUnit={measurementUnit}
@@ -319,7 +332,7 @@ export const BarChartEmbeddedTable: FC<BarChartEmbeddedTableProps> = ({
                   benchmarkOutcome={groupDataPoint.benchmarkComparison?.outcome}
                   benchmarkComparisonMethod={benchmarkComparisonMethod}
                   polarity={polarity}
-                  label={AreaTypeLabelEnum.Group}
+                  label={groupLabel}
                   area={groupIndicatorData?.areaName}
                   year={groupDataPoint.year}
                   measurementUnit={measurementUnit}

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
@@ -33,6 +33,7 @@ interface SparklineChartProps {
   measurementUnit: string | undefined;
   barColor?: string;
   benchmarkArea?: string;
+  showLabel?: boolean;
 }
 
 export function SparklineChart({
@@ -49,6 +50,7 @@ export function SparklineChart({
   measurementUnit,
   barColor,
   benchmarkArea,
+  showLabel = true,
 }: Readonly<SparklineChartProps>) {
   const benchmarkColor = getBenchmarkColour(
     benchmarkComparisonMethod,
@@ -65,7 +67,8 @@ export function SparklineChart({
       benchmarkOutcome,
       label,
       benchmarkComparisonMethod,
-      benchmarkArea
+      benchmarkArea,
+      showLabel
     );
 
     const symbolStyles = [

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
@@ -33,7 +33,7 @@ interface SparklineChartProps {
   measurementUnit: string | undefined;
   barColor?: string;
   benchmarkArea?: string;
-  showLabel?: boolean;
+  showComparisonLabels?: boolean;
 }
 
 export function SparklineChart({
@@ -50,7 +50,7 @@ export function SparklineChart({
   measurementUnit,
   barColor,
   benchmarkArea,
-  showLabel = true,
+  showComparisonLabels = true,
 }: Readonly<SparklineChartProps>) {
   const benchmarkColor = getBenchmarkColour(
     benchmarkComparisonMethod,
@@ -68,7 +68,7 @@ export function SparklineChart({
       label,
       benchmarkComparisonMethod,
       benchmarkArea,
-      showLabel
+      showComparisonLabels
     );
 
     const symbolStyles = [

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -1191,7 +1191,7 @@ describe('getTooltipContent', () => {
     });
   });
 
-  it('should not return a comparison, category or benchmark label when showLabel = false is passed in', () => {
+  it('should return an empty string for benchmarkLabel, category and comparisonLabel when showComparisonLabels = false is passed in', () => {
     const benchmarkOutcome = BenchmarkOutcome.Similar;
     const benchmarkComparisonMethod =
       BenchmarkComparisonMethod.CIOverlappingReferenceValue95;

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -1172,6 +1172,45 @@ describe('getTooltipContent', () => {
     });
   });
 
+  it('should return a comparisonLabel, category and benchmarkLabel when areaName is passed in', () => {
+    const benchmarkOutcome = BenchmarkOutcome.Similar;
+    const benchmarkComparisonMethod =
+      BenchmarkComparisonMethod.CIOverlappingReferenceValue95;
+
+    const result = getTooltipContent(
+      benchmarkOutcome,
+      AreaTypeLabelEnum.Area,
+      benchmarkComparisonMethod,
+      'London'
+    );
+
+    expect(result).toEqual({
+      benchmarkLabel: 'Similar to London',
+      category: '',
+      comparisonLabel: '(95%)',
+    });
+  });
+
+  it('should not return a comparison, category or benchmark label when showLabel = false is passed in', () => {
+    const benchmarkOutcome = BenchmarkOutcome.Similar;
+    const benchmarkComparisonMethod =
+      BenchmarkComparisonMethod.CIOverlappingReferenceValue95;
+
+    const result = getTooltipContent(
+      benchmarkOutcome,
+      AreaTypeLabelEnum.Area,
+      benchmarkComparisonMethod,
+      'London',
+      false
+    );
+
+    expect(result).toEqual({
+      benchmarkLabel: '',
+      category: '',
+      comparisonLabel: '',
+    });
+  });
+
   it('should return tooltip for quintiles with no CI% shown', () => {
     const benchmarkOutcome = BenchmarkOutcome.Worse;
     const benchmarkComparisonMethod = BenchmarkComparisonMethod.Quintiles;

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -337,14 +337,15 @@ export const getTooltipContent = (
   benchmarkOutcome: BenchmarkOutcome,
   label: string,
   benchmarkComparisonMethod: BenchmarkComparisonMethod,
-  areaName?: string
+  areaName?: string,
+  showLabel = true
 ) => {
   const category = getCategory(benchmarkOutcome, label);
 
   if (
     label === AreaTypeLabelEnum.Benchmark ||
     label === AreaTypeLabelEnum.Group ||
-    (label === AreaTypeLabelEnum.Area && areaName === undefined)
+    !showLabel
   ) {
     return { category, benchmarkLabel: '', comparisonLabel: '' };
   }

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -343,7 +343,8 @@ export const getTooltipContent = (
 
   if (
     label === AreaTypeLabelEnum.Benchmark ||
-    label === AreaTypeLabelEnum.Group
+    label === AreaTypeLabelEnum.Group ||
+    (label === AreaTypeLabelEnum.Area && areaName === undefined)
   ) {
     return { category, benchmarkLabel: '', comparisonLabel: '' };
   }

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -338,14 +338,14 @@ export const getTooltipContent = (
   label: string,
   benchmarkComparisonMethod: BenchmarkComparisonMethod,
   areaName?: string,
-  showLabel = true
+  showComparisonLabels = true
 ) => {
   const category = getCategory(benchmarkOutcome, label);
 
   if (
     label === AreaTypeLabelEnum.Benchmark ||
     label === AreaTypeLabelEnum.Group ||
-    !showLabel
+    !showComparisonLabels
   ) {
     return { category, benchmarkLabel: '', comparisonLabel: '' };
   }


### PR DESCRIPTION

# Description

Jira ticket: https://bjss-enterprise.atlassian.net/browse/DHSCFT-880

Correcting the bar chart hover labels when England isn't the selected benchmark

## Changes
- Added tests for getTooltipContent
- Added optional parameter that decides whether to show the label
- Fixing label along with some refactoring


## Validation
<img width="388" alt="image" src="https://github.com/user-attachments/assets/e64dc81f-3fb8-494d-af17-f3f4e6fda754" />

<img width="391" alt="image" src="https://github.com/user-attachments/assets/7d85e9c5-0843-4303-9134-8999720d55b6" />

