### PR TITLE
DHSCFT-854: Keep items focused after selection triggers a reload

### DIFF
--- a/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.test.tsx
+++ b/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FocusOnFragment } from './FocusOnFragment';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/context/LoaderContext', () => ({
+  useLoadingState: jest.fn(),
+}));
+
+import { useSearchParams } from 'next/navigation';
+import { useLoadingState } from '@/context/LoaderContext';
+
+describe('FocusOnFragment', () => {
+  let focusMock: jest.Mock;
+
+  beforeEach(() => {
+    focusMock = jest.fn();
+
+    // Set window.location.hash
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#test-element',
+      },
+      writable: true,
+    });
+
+    // Mock getElementById
+    jest.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'test-element') {
+        return { focus: focusMock } as unknown as HTMLElement;
+      }
+      return null;
+    });
+
+    // Provide return values for mocks
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams());
+    (useLoadingState as jest.Mock).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('focuses element matching the hash', () => {
+    render(<FocusOnFragment />);
+    expect(focusMock).toHaveBeenCalled();
+  });
+
+  it('does nothing if no element matches', () => {
+    (document.getElementById as jest.Mock).mockReturnValue(null);
+    render(<FocusOnFragment />);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if no hash', () => {
+    window.location.hash = '';
+    render(<FocusOnFragment />);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
+++ b/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { FC, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { useLoadingState } from '@/context/LoaderContext';
+import { useSearchParams } from 'next/navigation';
 
 export const FocusOnFragment: FC = () => {
-  const query = useSearchParams();
   const loadingState = useLoadingState();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (!window) return;
@@ -17,7 +17,7 @@ export const FocusOnFragment: FC = () => {
     if (!element) return;
 
     element.focus();
-  }, [query, loadingState]);
+  }, [searchParams, loadingState]);
 
   return null;
 };

--- a/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
+++ b/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
@@ -9,7 +9,6 @@ export const FocusOnFragment: FC = () => {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (!window) return;
     const hash = window.location.hash.substring(1);
     if (!hash) return;
 

--- a/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
+++ b/frontend/fingertips-frontend/components/atoms/FocusOnFragment/FocusOnFragment.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { FC, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useLoadingState } from '@/context/LoaderContext';
+
+export const FocusOnFragment: FC = () => {
+  const query = useSearchParams();
+  const loadingState = useLoadingState();
+
+  useEffect(() => {
+    if (!window) return;
+    const hash = window.location.hash.substring(1);
+    if (!hash) return;
+
+    const element = document.getElementById(hash);
+    if (!element) return;
+
+    element.focus();
+  }, [query, loadingState]);
+
+  return null;
+};

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/__snapshots__/IndicatorSearchForm.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/__snapshots__/IndicatorSearchForm.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`snapshot test - renders the form 1`] = `
       class="c3 c4 c5"
     >
       <p>
-        Search by Subject
+        Search by subject
       </p>
     </div>
     <div

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/index.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/index.tsx
@@ -57,7 +57,7 @@ export const IndicatorSearchForm = ({
         defaultValue={JSON.stringify(searchState)}
         hidden
       />
-      <StyledTitleParagraph>Search by Subject</StyledTitleParagraph>
+      <StyledTitleParagraph>Search by subject</StyledTitleParagraph>
       <StyledHintParagraph>
         For example, smoking, diabetes prevalence, or a specific indicator ID
       </StyledHintParagraph>

--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/index.tsx
@@ -201,8 +201,10 @@ export function IndicatorSelectionForm({
         indicatorId
       );
     }
-
-    replace(stateManager.generatePath(pathname), { scroll: false });
+    const newPath = stateManager.generatePath(pathname);
+    replace(`${newPath}#search-results-indicator-${indicatorId}`, {
+      scroll: false,
+    });
   };
 
   const handleSelectAll = (checked: boolean) => {
@@ -227,7 +229,10 @@ export function IndicatorSelectionForm({
       });
     }
 
-    replace(stateManager.generatePath(pathname), { scroll: false });
+    replace(
+      `${stateManager.generatePath(pathname)}#search-results-indicator-all`,
+      { scroll: false }
+    );
   };
 
   return (
@@ -257,6 +262,7 @@ export function IndicatorSelectionForm({
               data-testid="select-all-checkbox"
               defaultChecked={areAllIndicatorsSelected}
               onChange={(e) => handleSelectAll(e.target.checked)}
+              id={'search-results-indicator-all'}
             >
               Select all
             </Checkbox>

--- a/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSelectionForm/indicatorSelectionForm.test.tsx
@@ -232,7 +232,7 @@ describe('IndicatorSelectionForm', () => {
     await user.click(screen.getByRole('checkbox', { name: /NHS/i }));
 
     expect(mockReplace).toHaveBeenCalledWith(
-      `${mockPath}?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=1`,
+      `${mockPath}?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=1#search-results-indicator-1`,
       {
         scroll: false,
       }
@@ -258,7 +258,7 @@ describe('IndicatorSelectionForm', () => {
     await user.click(screen.getByRole('checkbox', { name: /NHS/i }));
 
     expect(mockReplace).toHaveBeenCalledWith(
-      `${mockPath}?${SearchParams.SearchedIndicator}=test`,
+      `${mockPath}?${SearchParams.SearchedIndicator}=test#search-results-indicator-1`,
       {
         scroll: false,
       }
@@ -328,7 +328,7 @@ describe('IndicatorSelectionForm', () => {
     await user.click(screen.getByRole('checkbox', { name: /Select all/i }));
 
     expect(mockReplace).toHaveBeenCalledWith(
-      `${mockPath}?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=1&${SearchParams.IndicatorsSelected}=2`,
+      `${mockPath}?${SearchParams.SearchedIndicator}=test&${SearchParams.IndicatorsSelected}=1&${SearchParams.IndicatorsSelected}=2#search-results-indicator-all`,
       { scroll: false }
     );
   });
@@ -352,7 +352,7 @@ describe('IndicatorSelectionForm', () => {
     await user.click(screen.getByRole('checkbox', { name: /Select all/i }));
 
     expect(mockReplace).toHaveBeenCalledWith(
-      `${mockPath}?${SearchParams.SearchedIndicator}=test`,
+      `${mockPath}?${SearchParams.SearchedIndicator}=test#search-results-indicator-all`,
       { scroll: false }
     );
   });
@@ -601,7 +601,7 @@ describe('IndicatorSelectionForm', () => {
       ).map((index) => `${SearchParams.IndicatorsSelected}=${index}`);
 
       expect(mockReplace).toHaveBeenCalledWith(
-        `${mockPath}?${SearchParams.SearchedIndicator}=test&${expectedSelectedIndicatorsParam.join('&')}`,
+        `${mockPath}?${SearchParams.SearchedIndicator}=test&${expectedSelectedIndicatorsParam.join('&')}#search-results-indicator-all`,
         { scroll: false }
       );
     });
@@ -619,7 +619,7 @@ describe('IndicatorSelectionForm', () => {
       await user.click(screen.getByRole('checkbox', { name: /Select all/i }));
 
       expect(mockReplace).toHaveBeenCalledWith(
-        `${mockPath}?${SearchParams.SearchedIndicator}=test`,
+        `${mockPath}?${SearchParams.SearchedIndicator}=test#search-results-indicator-all`,
         { scroll: false }
       );
     });
@@ -682,14 +682,14 @@ describe('IndicatorSelectionForm', () => {
       fireEvent.click(firstCheckbox);
       expect(firstCheckbox).toBeChecked();
       expect(mockReplace).toHaveBeenCalledWith(
-        'some-mock-path?si=patient&is=93474',
+        'some-mock-path?si=patient&is=93474#search-results-indicator-93474',
         { scroll: false }
       );
       mockReplace.mockReset();
       //  select all checkbox to see what happen and check it against the uri
       await user.click(screen.getByRole('checkbox', { name: /Select all/i }));
       expect(mockReplace).toHaveBeenCalledWith(
-        'some-mock-path?si=patient&is=93474&is=94035&is=41101',
+        'some-mock-path?si=patient&is=93474&is=94035&is=41101#search-results-indicator-all',
         { scroll: false }
       );
     });

--- a/frontend/fingertips-frontend/components/layouts/container/index.tsx
+++ b/frontend/fingertips-frontend/components/layouts/container/index.tsx
@@ -8,6 +8,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { reactQueryClient } from '@/lib/reactQueryClient';
 import { ModalProvider } from '@/context/ModalContext';
 import { FocusOnFragment } from '@/components/atoms/FocusOnFragment/FocusOnFragment';
+import { Suspense } from 'react';
 
 const StyledMain = styled(Main)({
   minHeight: '80vh',
@@ -24,7 +25,9 @@ export function FTContainer({
             <main>
               <StyledMain>{children}</StyledMain>
             </main>
-            <FocusOnFragment />
+            <Suspense>
+              <FocusOnFragment />
+            </Suspense>
           </LoaderProvider>
         </SearchStateProvider>
       </ModalProvider>

--- a/frontend/fingertips-frontend/components/layouts/container/index.tsx
+++ b/frontend/fingertips-frontend/components/layouts/container/index.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { reactQueryClient } from '@/lib/reactQueryClient';
 import { ModalProvider } from '@/context/ModalContext';
+import { FocusOnFragment } from '@/components/atoms/FocusOnFragment/FocusOnFragment';
 
 const StyledMain = styled(Main)({
   minHeight: '80vh',
@@ -23,6 +24,7 @@ export function FTContainer({
             <main>
               <StyledMain>{children}</StyledMain>
             </main>
+            <FocusOnFragment />
           </LoaderProvider>
         </SearchStateProvider>
       </ModalProvider>

--- a/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/SelectAreasFilterPanel.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/SelectAreasFilterPanel.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen, within } from '@testing-library/react';
-import { SelectAreasFilterPanel } from '.';
+import {
+  selectAreaGroupId,
+  selectAreaGroupTypeId,
+  SelectAreasFilterPanel,
+  selectAreaTypeId,
+} from '.';
 import { mockAvailableAreas } from '@/mock/data/areaData';
 import {
   allAreaTypes,
@@ -157,6 +162,7 @@ describe('SelectAreasFilterPanel', () => {
       const expectedPath = [
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#${selectAreaTypeId}`,
       ].join('');
 
       const user = userEvent.setup();
@@ -201,6 +207,7 @@ describe('SelectAreasFilterPanel', () => {
       const expectedPath = [
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#${selectAreaTypeId}`,
       ].join('');
 
       const user = userEvent.setup();
@@ -326,6 +333,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
         `&${SearchParams.GroupTypeSelected}=england`,
+        `#${selectAreaGroupTypeId}`,
       ].join('');
 
       const user = userEvent.setup();
@@ -382,6 +390,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
         `&${SearchParams.GroupTypeSelected}=england`,
+        `#${selectAreaGroupTypeId}`,
       ].join('');
 
       const user = userEvent.setup();
@@ -508,6 +517,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
         `&${SearchParams.GroupSelected}=${availableGroups[1].code}`,
+        `#${selectAreaGroupId}`,
       ].join('');
 
       const user = userEvent.setup();
@@ -622,6 +632,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreasSelected}=${eastEnglandNHSRegion.code}`,
         `&${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
       const availableAreas = mockAvailableAreas['nhs-regions'];
 
@@ -661,6 +672,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreasSelected}=${eastEnglandNHSRegion.code}`,
         `&${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
       const availableAreas = mockAvailableAreas['nhs-regions'];
 
@@ -716,6 +728,7 @@ describe('SelectAreasFilterPanel', () => {
       const expectedPath = [
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
       const availableAreas = mockAvailableAreas['nhs-regions'];
 
@@ -755,6 +768,7 @@ describe('SelectAreasFilterPanel', () => {
       const expectedPath = [
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
       const availableAreas = mockAvailableAreas['nhs-regions'];
 
@@ -792,6 +806,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         `?${SearchParams.AreaTypeSelected}=nhs-regions`,
         `&${SearchParams.GroupAreaSelected}=${ALL_AREAS_SELECTED}`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
 
       render(
@@ -833,6 +848,7 @@ describe('SelectAreasFilterPanel', () => {
         `${mockPath}`,
         ...expectedAreasSelected,
         `&${SearchParams.AreaTypeSelected}=nhs-regions`,
+        `#area-select-${eastEnglandNHSRegion.code}`,
       ].join('');
 
       render(

--- a/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/SelectAreasFilterPanel/index.tsx
@@ -17,6 +17,10 @@ export type AreaFilterData = {
   availableAreas?: Area[];
 };
 
+export const selectAreaTypeId = 'select-area-type';
+export const selectAreaGroupTypeId = 'select-area-group-type';
+export const selectAreaGroupId = 'select-area-group';
+
 interface SelectAreasFilterPanelProps {
   areaFilterData?: AreaFilterData;
 }
@@ -61,7 +65,12 @@ export function SelectAreasFilterPanel({
       SearchParams.GroupTypeSelected
     );
     searchStateManager.removeParamValueFromState(SearchParams.GroupSelected);
-    replace(searchStateManager.generatePath(pathname), { scroll: false });
+    replace(
+      `${searchStateManager.generatePath(pathname)}#${selectAreaTypeId}`,
+      {
+        scroll: false,
+      }
+    );
   };
 
   const groupTypeSelected = (valueSelected: string) => {
@@ -72,7 +81,10 @@ export function SelectAreasFilterPanel({
       valueSelected
     );
     searchStateManager.removeParamValueFromState(SearchParams.GroupSelected);
-    replace(searchStateManager.generatePath(pathname), { scroll: false });
+    replace(
+      `${searchStateManager.generatePath(pathname)}#${selectAreaGroupTypeId}`,
+      { scroll: false }
+    );
   };
 
   const groupSelected = (valueSelected: string) => {
@@ -82,7 +94,12 @@ export function SelectAreasFilterPanel({
       SearchParams.GroupSelected,
       valueSelected
     );
-    replace(searchStateManager.generatePath(pathname), { scroll: false });
+    replace(
+      `${searchStateManager.generatePath(pathname)}#${selectAreaGroupId}`,
+      {
+        scroll: false,
+      }
+    );
   };
 
   const handleAreaSelected = (areaCode: string, checked: boolean) => {
@@ -142,7 +159,10 @@ export function SelectAreasFilterPanel({
       );
     }
 
-    replace(searchStateManager.generatePath(pathname), { scroll: false });
+    replace(
+      `${searchStateManager.generatePath(pathname)}#area-select-${areaCode}`,
+      { scroll: false }
+    );
   };
 
   const handleSelectAllAreasSelected = (checked: boolean) => {
@@ -179,6 +199,7 @@ export function SelectAreasFilterPanel({
           disabled: hasAreasSelected,
         }}
         style={{ marginBottom: '1em' }}
+        id={selectAreaTypeId}
       >
         {areaFilterData?.availableAreaTypes?.map((areaType) => (
           <option key={areaType.key} value={areaType.key}>
@@ -196,6 +217,7 @@ export function SelectAreasFilterPanel({
           disabled: hasAreasSelected,
         }}
         style={{ marginBottom: '1em' }}
+        id={selectAreaGroupTypeId}
       >
         {areaFilterData?.availableGroupTypes?.map((areaType) => (
           <option key={areaType.key} value={areaType.key}>
@@ -213,6 +235,7 @@ export function SelectAreasFilterPanel({
           disabled: hasAreasSelected,
         }}
         style={{ marginBottom: '1em' }}
+        id={selectAreaGroupId}
       >
         {areaFilterData?.availableGroups?.map((area) => (
           <option key={area.code} value={area.code}>
@@ -230,6 +253,7 @@ export function SelectAreasFilterPanel({
             searchState?.[SearchParams.GroupAreaSelected] === ALL_AREAS_SELECTED
           }
           onChange={(e) => handleSelectAllAreasSelected(e.target.checked)}
+          id={'area-select-all'}
         >
           Select all areas
         </StyledSelectAllCheckBox>

--- a/frontend/fingertips-frontend/components/organisms/AreaFilterPane/AreaFilterPaneCheckbox.tsx
+++ b/frontend/fingertips-frontend/components/organisms/AreaFilterPane/AreaFilterPaneCheckbox.tsx
@@ -23,6 +23,7 @@ export const AreaFilterPaneCheckbox: FC<AreaFilterPaneCheckboxProps> = ({
       onChange={(e) => {
         handleAreaSelected(code, e.target.checked);
       }}
+      id={`area-select-${code}`}
     >
       {name}
     </Checkbox>

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/resultsPage.ts
@@ -300,6 +300,11 @@ export default class ResultsPage extends AreaFilter {
     await expect(selectAllCheckbox).not.toBeChecked();
   }
 
+  async verifyCheckboxIsInFocus(locator: string) {
+    const checkboxElement = this.page.locator(locator);
+    await expect(checkboxElement).toBeFocused();
+  }
+
   async selectIndicator(indicatorId: string) {
     const indicatorCheckbox = this.page.getByTestId(
       `${this.indicatorCheckboxPrefix}-${indicatorId}`

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -161,6 +161,12 @@ test.describe('Results Page Tests', () => {
       await resultsPage.verifyUrlExcludesAllIndicators();
     });
 
+    await test.step('Verify select all checkbox is still in focus', async () => {
+      await resultsPage.verifyCheckboxIsInFocus(
+        '#search-results-indicator-all'
+      );
+    });
+
     await test.step('Verify individual selections to select all', async () => {
       await resultsPage.selectEveryIndicator(allValidIndicatorIDs);
       await resultsPage.verifySelectAllCheckboxTicked();
@@ -172,6 +178,12 @@ test.describe('Results Page Tests', () => {
       await resultsPage.verifySelectAllCheckboxUnticked();
       await resultsPage.verifyUrlUpdatedAfterDeselection(
         allValidIndicatorIDs[0]
+      );
+    });
+
+    await test.step('Verify that the previously deselected checkbox is still in focus', async () => {
+      await resultsPage.verifyCheckboxIsInFocus(
+        `#search-results-indicator-${allValidIndicatorIDs[0]}`
       );
     });
   });


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-854](https://bjss-enterprise.atlassian.net/browse/DHSCFT-854)

Add a generic hook to use url fragments to maintain element focus when the page reloads due to selection change

## Changes

- Added FocusOnFragment component
- Added id's to checkbox and select elements on results page
- Updated target paths to include a hash fragment