### PR TITLE
DHSCFT-939 successful deployment sending a slack message

### DIFF
--- a/.github/workflows/e2e-and-api-tests.yml
+++ b/.github/workflows/e2e-and-api-tests.yml
@@ -99,6 +99,17 @@ jobs:
         if: ${{ !inputs.update_screenshots && always() }}
         run: npm run test-e2e-ci
 
+      - name: Send slack notification based on test results
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            npx slack-ctrf results ctrf/ctrf-report.json --title "PR deployment successful to Fingertips Instance: ${{ vars.FINGERTIPS_FRONTEND_URL }}"
+          else
+            npx slack-ctrf results ctrf/ctrf-report.json --title "E2E Test Failure Against Deployed Fingertips Instance"
+          fi
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
+
       - name: Run Playwright tests and update baseline screenshot
         if: ${{ inputs.update_screenshots }}
         run: npm run test-e2e-ci -- --update-snapshots
@@ -195,9 +206,13 @@ jobs:
             ${{ env.frontend-directory }}/test-results/*/*.png
           retention-days: 5
 
-      - name: Send slack message if e2e tests fail - for CD test execution
-        if: failure()
+      - name: Send slack notification based on test results
+        if: always()
         run: |
-          npx slack-ctrf results ctrf/ctrf-report.json --title "E2E Test Failure Against Deployed Fingertips Instance"
+          if [ "${{ job.status }}" == "success" ]; then
+            npx slack-ctrf results ctrf/ctrf-report.json --title "PR deployment successful to Fingertips Instance: ${{ vars.FINGERTIPS_FRONTEND_URL }}"
+          else
+            npx slack-ctrf results ctrf/ctrf-report.json --title "E2E Test Failure Against Deployed Fingertips Instance"
+          fi
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/e2e-and-api-tests.yml
+++ b/.github/workflows/e2e-and-api-tests.yml
@@ -99,17 +99,6 @@ jobs:
         if: ${{ !inputs.update_screenshots && always() }}
         run: npm run test-e2e-ci
 
-      - name: Send slack notification based on test results
-        if: always()
-        run: |
-          if [ "${{ job.status }}" == "success" ]; then
-            npx slack-ctrf results ctrf/ctrf-report.json --title "PR deployment successful to Fingertips Instance: ${{ vars.FINGERTIPS_FRONTEND_URL }}"
-          else
-            npx slack-ctrf results ctrf/ctrf-report.json --title "E2E Test Failure Against Deployed Fingertips Instance"
-          fi
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
-
       - name: Run Playwright tests and update baseline screenshot
         if: ${{ inputs.update_screenshots }}
         run: npm run test-e2e-ci -- --update-snapshots

--- a/frontend/fingertips-frontend/README.md
+++ b/frontend/fingertips-frontend/README.md
@@ -143,7 +143,7 @@ To make our isolated ui testing and fully integrated e2e testing as close to rea
 
 ### Accessibility Testing
 
-Performed in the ui tests. Libraries used: @axe-core/playwright and axe-playwright. 
+Performed in the ui tests, libraries used: @axe-core/playwright and axe-playwright. 
 
 Configured to the WCAG2.2 AA standard in the following file playwright/page-objects/pageFactory.ts. Any violations of this standard cause a test failure unless the rule violated has been accepted in pageFactory.ts.
 


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-939](https://bjss-enterprise.atlassian.net/browse/DHSCFT-939)

Added if else logic to the existing send slack message to handle sending a success message.

## Validation

tested the if+else logic here - https://github.com/dhsc-govuk/FingertipsNext/actions/runs/15533395566/job/43727043984
see https://bjss.slack.com/archives/C08AZ71A98B/p1749468204490499 for discussions around the lack of access of the CI pipeline to the slack webhook secret
