### PR TITLE
DHSCFT-822: Dynamic title for spine chart

### DIFF
--- a/frontend/fingertips-frontend/components/atoms/SubTitle/SubTitle.tsx
+++ b/frontend/fingertips-frontend/components/atoms/SubTitle/SubTitle.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { H2 } from 'govuk-react';
+
+export const SubTitle = styled(H2)({
+  fontSize: '24px',
+  marginTop: '16px',
+});

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
@@ -128,7 +128,7 @@ describe('Spine chart table suite', () => {
   };
 
   describe('Spine chart table', () => {
-    it('should render the SpineChartTable component', () => {
+    it('should render the SpineChartTable component with title', () => {
       render(
         <SpineChartTable
           indicatorData={mockIndicatorData}
@@ -138,6 +138,12 @@ describe('Spine chart table suite', () => {
       );
       const spineChart = screen.getByTestId('spineChartTable-component');
       expect(spineChart).toBeInTheDocument();
+
+      const titles = screen.getAllByRole('heading', { level: 4 });
+      expect(titles[0]).toHaveTextContent(
+        'Area profile for Greater Manchester ICB - 00T'
+      );
+      expect(titles[1]).toHaveTextContent('Compared to England');
     });
 
     it('should render the SpineChartTable in ascending indicator order', () => {
@@ -194,6 +200,11 @@ describe('Spine chart table suite', () => {
           benchmarkToUse={areaCodeForEngland}
           searchState={mockSearchState}
         />
+      );
+
+      const titles = screen.getAllByRole('heading', { level: 4 });
+      expect(titles[0]).toHaveTextContent(
+        'Area profile for Greater Manchester ICB - 00T and Greater Manchester ICB - 01T'
       );
 
       expect(screen.getByTestId('area-header-1')).toHaveTextContent(

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -1,16 +1,13 @@
 'use client';
+
 import React, { useMemo } from 'react';
-
 import { SpineChartTableHeader } from './SpineChartTableHeader';
-
 import { SpineChartTableRow } from './SpineChartTableRow';
 import {
   StyledDivTableContainer,
   StyledTableMultipleAreas,
   StyledTableOneArea,
 } from './SpineChartTable.Styles';
-import { H2 } from 'govuk-react';
-import styled from 'styled-components';
 import { SpineChartLegend } from '@/components/organisms/SpineChartLegend/SpineChartLegend';
 import { getMethodsAndOutcomes } from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
 import { SpineChartIndicatorData } from './spineChartTableHelpers';
@@ -19,11 +16,9 @@ import { convertSpineChartTableToCsv } from '@/components/organisms/SpineChartTa
 import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapper';
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
 import { SearchStateParams } from '@/lib/searchStateManager';
-
-const SpineChartHeading = styled(H2)({
-  fontSize: '1.5rem',
-  marginTop: '1rem',
-});
+import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
+import { SubTitle } from '@/components/atoms/SubTitle/SubTitle';
+import { ContainerWithOutline } from '@/components/atoms/ContainerWithOutline/ContainerWithOutline';
 
 export interface SpineChartTableProps {
   indicatorData: SpineChartIndicatorData[];
@@ -56,44 +51,48 @@ export function SpineChartTable({
   }, [sortedData]);
 
   const groupName = sortedData[0].groupData?.areaName;
+  const title = `Area profile for ${areaNames.join(' and ')}`;
 
   return (
     <>
-      <div id={'spineChartTable'}>
-        <SpineChartHeading>Compare indicators by areas</SpineChartHeading>
-        <SpineChartLegend
-          legendsToShow={methods}
-          benchmarkToUse={benchmarkToUse}
-          groupName={groupName}
-          areaNames={areaNames}
-          searchState={searchState}
-        />
+      <SubTitle>Compare indicators by areas</SubTitle>
+      <ContainerWithOutline>
+        <div id={'spineChartTable'}>
+          <ChartTitle>{title}</ChartTitle>
+          <SpineChartLegend
+            legendsToShow={methods}
+            benchmarkToUse={benchmarkToUse}
+            groupName={groupName}
+            areaNames={areaNames}
+            searchState={searchState}
+          />
 
-        <StyledDivTableContainer data-testid="spineChartTable-component">
-          <StyledTable>
-            <SpineChartTableHeader
-              areaNames={areaNames}
-              groupName={sortedData[0].groupData?.areaName ?? 'Group'}
-              benchmarkToUse={benchmarkToUse}
-              searchState={searchState}
-            />
-            {sortedData.map((indicatorData) => (
-              <React.Fragment key={indicatorData.indicatorId}>
-                <SpineChartTableRow
-                  indicatorData={indicatorData}
-                  twoAreasRequested={areaNames.length > 1}
-                  benchmarkToUse={benchmarkToUse}
-                  searchState={searchState}
-                />
-              </React.Fragment>
-            ))}
-          </StyledTable>
-        </StyledDivTableContainer>
-        <ExportOnlyWrapper>
-          <ExportCopyright />
-        </ExportOnlyWrapper>
-      </div>
-      <ExportOptionsButton targetId={'spineChartTable'} csvData={csvData} />
+          <StyledDivTableContainer data-testid="spineChartTable-component">
+            <StyledTable>
+              <SpineChartTableHeader
+                areaNames={areaNames}
+                groupName={sortedData[0].groupData?.areaName ?? 'Group'}
+                benchmarkToUse={benchmarkToUse}
+                searchState={searchState}
+              />
+              {sortedData.map((indicatorData) => (
+                <React.Fragment key={indicatorData.indicatorId}>
+                  <SpineChartTableRow
+                    indicatorData={indicatorData}
+                    twoAreasRequested={areaNames.length > 1}
+                    benchmarkToUse={benchmarkToUse}
+                    searchState={searchState}
+                  />
+                </React.Fragment>
+              ))}
+            </StyledTable>
+          </StyledDivTableContainer>
+          <ExportOnlyWrapper>
+            <ExportCopyright />
+          </ExportOnlyWrapper>
+        </div>
+        <ExportOptionsButton targetId={'spineChartTable'} csvData={csvData} />
+      </ContainerWithOutline>
     </>
   );
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-822](https://bjss-enterprise.atlassian.net/browse/DHSCFT-822)

Spine chart dynamic title

## Changes

- Added spine chart title for 1 and 2 areas
- Added generic sub title component for the 'Compare indicators by areas' type title
- Added a border around the spine chart
- Etc.

## Validation

<img width="917" alt="image" src="https://github.com/user-attachments/assets/8bd7d50e-529e-42d0-8bcd-009dd031bf8b" />

<img width="820" alt="image" src="https://github.com/user-attachments/assets/d028fb44-c2b2-49b6-abd0-017cf310b38f" />
