### PR TITLE
DHSCFT-903: Add benchmark legends in the svg exports

### DIFF
--- a/frontend/fingertips-frontend/components/atoms/DomContainer/DomContainer.tsx
+++ b/frontend/fingertips-frontend/components/atoms/DomContainer/DomContainer.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef } from 'react';
 
 interface DomContainerProps {
-  data?: HTMLElement | HTMLCanvasElement;
+  data?: HTMLElement | HTMLCanvasElement | SVGSVGElement;
 }
 
 export const DomContainer: FC<DomContainerProps> = ({ data }) => {

--- a/frontend/fingertips-frontend/components/molecules/Export/ExportPreviewOptions.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Export/ExportPreviewOptions.test.tsx
@@ -5,7 +5,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { Options } from 'highcharts';
 import userEvent from '@testing-library/user-event';
 import { CsvData } from '@/lib/downloadHelpers/convertToCsv';
-import { getSvgFromOptions } from '@/components/molecules/Export/exportHelpers';
+
+import { svgStringFromChartOptions } from '@/components/molecules/Export/helpers/svgStringFromChartOptions';
 
 jest.mock('html2canvas', () => ({
   __esModule: true,
@@ -13,9 +14,15 @@ jest.mock('html2canvas', () => ({
 }));
 
 jest.mock('@/components/molecules/Export/exportHelpers', () => ({
-  getSvgFromOptions: jest.fn(() => '<svg></svg>'),
   getHtmlToImageCanvas: () => Promise.resolve(document.createElement('canvas')),
 }));
+
+jest.mock(
+  '@/components/molecules/Export/helpers/svgStringFromChartOptions',
+  () => ({
+    svgStringFromChartOptions: jest.fn(() => '<svg></svg>'),
+  })
+);
 
 const testRender = (chartOptions?: Options, csvData?: CsvData) => {
   render(
@@ -59,6 +66,9 @@ describe('ExportPreviewOptions', () => {
 
   it('should show svg if the chart object is supplied', async () => {
     const mockChartOptions: Options = {
+      accessibility: {
+        enabled: false,
+      },
       series: [
         {
           type: 'line',
@@ -78,7 +88,7 @@ describe('ExportPreviewOptions', () => {
     await userEvent.click(svg);
 
     await waitFor(() => {
-      expect(getSvgFromOptions).toHaveBeenCalled();
+      expect(svgStringFromChartOptions).toHaveBeenCalled();
     });
   });
 

--- a/frontend/fingertips-frontend/components/molecules/Export/export.types.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/export.types.ts
@@ -7,9 +7,10 @@ export enum ExportType {
   CSV = 'csv',
 }
 
-export interface ExportDownload {
-  canvas?: HTMLCanvasElement;
-  svg?: string;
+export interface ElementInfo {
+  element?: HTMLElement | SVGSVGElement;
+  width: number;
+  height: number;
 }
 
 export enum CsvHeader {

--- a/frontend/fingertips-frontend/components/molecules/Export/exportHelpers.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/exportHelpers.ts
@@ -1,16 +1,4 @@
 import html2canvas from 'html2canvas';
-import Highcharts from 'highcharts';
-import {
-  exportAccessedDate,
-  exportCopyrightText,
-} from '@/components/molecules/Export/ExportCopyright';
-import { CustomOptions } from '@/components/molecules/Export/export.types';
-import {
-  mapCopyright,
-  mapLicense,
-  mapSourceForType,
-} from '@/components/organisms/ThematicMap/thematicMapHelpers';
-import { GovukColours } from '@/lib/styleHelpers/colours';
 
 export const ExcludeFromExport = 'excludeFromExport';
 
@@ -55,13 +43,6 @@ export const preCanvasConversion = (
   });
 };
 
-export const svgStringToDomElement = (svgString: string) => {
-  const parser = new DOMParser();
-  const svgDoc = parser.parseFromString(svgString, 'image/svg+xml');
-  const element = svgDoc.documentElement;
-  return element.nodeName === 'svg' ? element : undefined;
-};
-
 export const canvasToBlob = (canvas: HTMLCanvasElement) => {
   return new Promise<Blob | null>((resolve) => {
     canvas.toBlob((blob: Blob | null) => {
@@ -82,55 +63,4 @@ export const triggerBlobDownload = (fileName: string, blob: Blob) => {
   document.body.removeChild(link);
 
   URL.revokeObjectURL(url);
-};
-
-export const getSvgFromOptions = (options: Highcharts.Options): string => {
-  const container = document.createElement('div');
-  container.style.display = 'none';
-  document.body.appendChild(container);
-
-  const optionsWithFooter = addCopyrightFooterToChartOptions(options);
-
-  // type issue with mapChart existing (or not) on the Highcharts object - it does
-  // maybe because the loading of highcharts modules is done before this code is executed
-  const constructor = optionsWithFooter.mapView
-    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      Highcharts.mapChart
-    : Highcharts.chart;
-
-  const chart = constructor(container, optionsWithFooter);
-  const svg = chart.getSVG();
-
-  chart.destroy();
-  document.body.removeChild(container);
-
-  return svg;
-};
-
-export const addCopyrightFooterToChartOptions = (options: CustomOptions) => {
-  const modifiedEvents = { ...options.chart?.events };
-  const modifiedChart = { ...options.chart, events: modifiedEvents };
-  const modifiedOptions = { ...options, chart: modifiedChart };
-
-  const captionLines = [exportCopyrightText(), exportAccessedDate()];
-
-  if (modifiedOptions.custom?.mapAreaType) {
-    const mapSource = mapSourceForType(modifiedOptions.custom?.mapAreaType);
-    captionLines.push('');
-    captionLines.push(mapSource);
-    captionLines.push(mapLicense);
-    captionLines.push(mapCopyright);
-  }
-
-  modifiedOptions.caption = {
-    margin: 20,
-    text: captionLines.join('<br />'),
-    style: {
-      color: GovukColours.Black,
-      fontSize: '14px',
-    },
-  };
-  modifiedOptions.chart.spacingBottom = 25;
-  return modifiedOptions;
 };

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/chartOptionsAddFooter.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/chartOptionsAddFooter.test.ts
@@ -1,0 +1,44 @@
+import { chartOptionsAddFooter } from '@/components/molecules/Export/helpers/chartOptionsAddFooter';
+import { GovukColours } from '@/lib/styleHelpers/colours';
+import {
+  exportAccessedDate,
+  exportCopyrightText,
+} from '@/components/molecules/Export/ExportCopyright';
+import { CustomOptions } from '@/components/molecules/Export/export.types';
+import { mapSourceForType } from '@/components/organisms/ThematicMap/thematicMapHelpers';
+
+describe('chartOptionsAddFooter', () => {
+  it('modifies chart options and attaches a load event', () => {
+    const inputOptions = {
+      chart: {
+        events: {},
+      },
+    };
+
+    const modified = chartOptionsAddFooter(inputOptions);
+
+    expect(modified.chart.spacingBottom).toBe(25);
+    expect(modified.caption).toEqual({
+      margin: 20,
+      style: {
+        color: GovukColours.Black,
+        fontSize: '14px',
+      },
+      text: `${exportCopyrightText()}<br />${exportAccessedDate()}`,
+    });
+  });
+
+  it('includes map metadata when custom.mapAreaType is set', () => {
+    const inputOptions = {
+      chart: {
+        events: {},
+      },
+      custom: {
+        mapAreaType: 'regions',
+      },
+    } as CustomOptions;
+
+    const modified = chartOptionsAddFooter(inputOptions);
+    expect(modified.caption?.text).toContain(mapSourceForType('regions'));
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/chartOptionsAddFooter.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/chartOptionsAddFooter.ts
@@ -1,0 +1,38 @@
+import { CustomOptions } from '@/components/molecules/Export/export.types';
+import {
+  exportAccessedDate,
+  exportCopyrightText,
+} from '@/components/molecules/Export/ExportCopyright';
+import {
+  mapCopyright,
+  mapLicense,
+  mapSourceForType,
+} from '@/components/organisms/ThematicMap/thematicMapHelpers';
+import { GovukColours } from '@/lib/styleHelpers/colours';
+
+export const chartOptionsAddFooter = (options: CustomOptions) => {
+  const modifiedEvents = { ...options.chart?.events };
+  const modifiedChart = { ...options.chart, events: modifiedEvents };
+  const modifiedOptions = { ...options, chart: modifiedChart };
+
+  const captionLines = [exportCopyrightText(), exportAccessedDate()];
+
+  if (modifiedOptions.custom?.mapAreaType) {
+    const mapSource = mapSourceForType(modifiedOptions.custom?.mapAreaType);
+    captionLines.push('');
+    captionLines.push(mapSource);
+    captionLines.push(mapLicense);
+    captionLines.push(mapCopyright);
+  }
+
+  modifiedOptions.caption = {
+    margin: 20,
+    text: captionLines.join('<br />'),
+    style: {
+      color: GovukColours.Black,
+      fontSize: '14px',
+    },
+  };
+  modifiedOptions.chart.spacingBottom = 25;
+  return modifiedOptions;
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.test.ts
@@ -1,0 +1,44 @@
+import { svgClone } from '@/components/molecules/Export/helpers/svgClone';
+import { ElementInfo } from '@/components/molecules/Export/export.types'; // adjust import path
+
+describe('svgClone', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''; // Clear DOM before each test
+  });
+
+  it('should clone the element and return correct width and height', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('id', 'test-svg');
+    svg.setAttribute('width', '200');
+    svg.setAttribute('height', '100');
+
+    document.body.appendChild(svg);
+
+    const result: ElementInfo = svgClone('#test-svg');
+
+    expect(result.element).toBeDefined();
+    expect(result.width).toBe(200);
+    expect(result.height).toBe(100);
+  });
+
+  it('should return undefined element and 0 dimensions if element not found', () => {
+    const result: ElementInfo = svgClone('#non-existent');
+
+    expect(result.element).toBeUndefined();
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+
+  it('should return 0 dimensions if width/height attributes are missing', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('id', 'svg-no-dimensions');
+
+    document.body.appendChild(svg);
+
+    const result = svgClone('#svg-no-dimensions');
+
+    expect(result.element).toBeDefined();
+    expect(result.width).toBe(0);
+    expect(result.height).toBe(0);
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.test.ts
@@ -1,9 +1,9 @@
 import { svgClone } from '@/components/molecules/Export/helpers/svgClone';
-import { ElementInfo } from '@/components/molecules/Export/export.types'; // adjust import path
+import { ElementInfo } from '@/components/molecules/Export/export.types';
 
 describe('svgClone', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''; // Clear DOM before each test
+    document.body.innerHTML = '';
   });
 
   it('should clone the element and return correct width and height', () => {

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgClone.ts
@@ -1,0 +1,14 @@
+import { ElementInfo } from '@/components/molecules/Export/export.types';
+
+export const svgClone = (selector: string): ElementInfo => {
+  const originalElement = document.querySelector(selector);
+  const clonedElement = originalElement?.cloneNode(true);
+  if (!clonedElement) {
+    return { element: undefined, width: 0, height: 0 };
+  }
+  const element = clonedElement as HTMLElement;
+  const width = element ? Number(element.getAttribute('width')) : 0;
+  const height = element ? Number(element.getAttribute('height')) : 0;
+
+  return { element, width, height };
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgFromString.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgFromString.test.ts
@@ -1,0 +1,22 @@
+import { svgFromString } from '@/components/molecules/Export/helpers/svgFromString';
+
+describe('svgFromString', () => {
+  it('parses a valid SVG string into an SVGElement', () => {
+    const svgString = `<svg width="600" height="400" xmlns="http://www.w3.org/2000/svg">
+                         <circle cx="50" cy="50" r="40" stroke="black" fill="red" />
+                       </svg>`;
+
+    const { element, width, height } = svgFromString(svgString);
+
+    expect(element).toBeInstanceOf(SVGElement);
+    expect(element?.nodeName).toBe('svg');
+    expect(width).toBe(600);
+    expect(height).toBe(400);
+  });
+
+  it('returns a undefined for invalid SVG', () => {
+    const badSvg = `<svg><g><circle r="1"></svg>`; // malformed
+    const { element } = svgFromString(badSvg);
+    expect(element).toBeUndefined();
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgFromString.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgFromString.ts
@@ -1,0 +1,26 @@
+import { ElementInfo } from '@/components/molecules/Export/export.types';
+
+export const svgFromString = (svgString: string): ElementInfo => {
+  let svgDoc: Document;
+  try {
+    const parser = new DOMParser();
+    svgDoc = parser.parseFromString(svgString, 'image/svg+xml');
+  } catch (e) {
+    console.error('Failed to parse SVG:', e);
+    return { element: undefined, width: 0, height: 0 };
+  }
+
+  const parserError = svgDoc.querySelector('parsererror');
+  if (parserError) {
+    return { element: undefined, width: 0, height: 0 };
+  }
+
+  const element = svgDoc.documentElement;
+  if (!element) {
+    return { element: undefined, width: 0, height: 0 };
+  }
+
+  const width = Number(element.getAttribute('width'));
+  const height = Number(element.getAttribute('height'));
+  return { element, width, height };
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromChartOptions.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromChartOptions.test.ts
@@ -1,0 +1,42 @@
+import { svgStringFromChartOptions } from '@/components/molecules/Export/helpers/svgStringFromChartOptions';
+import Highcharts from 'highcharts';
+import { Chart } from 'highcharts';
+
+jest.mock('highcharts', () => {
+  return {
+    chart: jest.fn(),
+  };
+});
+
+describe('svgStringFromChartOptions', () => {
+  let mockChart: Chart;
+
+  beforeEach(() => {
+    mockChart = {
+      getSVG: jest.fn().mockReturnValue('<svg>mocked</svg>'),
+      destroy: jest.fn(),
+    } as unknown as Chart;
+    (Highcharts.chart as jest.Mock).mockReturnValue(mockChart);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a chart, get its SVG, destroy the chart, and remove the container', () => {
+    const options = { title: { text: 'Test Chart' } };
+
+    const svg = svgStringFromChartOptions(options);
+
+    expect(Highcharts.chart).toHaveBeenCalled();
+    expect(mockChart.getSVG).toHaveBeenCalled();
+    expect(mockChart.destroy).toHaveBeenCalled();
+    expect(svg).toBe('<svg>mocked</svg>');
+
+    // Ensure the container is removed from the DOM
+    const containerInDom = Array.from(document.body.children).find(
+      (child) => child.tagName === 'DIV'
+    );
+    expect(containerInDom).toBeUndefined();
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromChartOptions.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromChartOptions.ts
@@ -1,0 +1,25 @@
+import Highcharts from 'highcharts';
+
+export const svgStringFromChartOptions = (
+  options: Highcharts.Options
+): string => {
+  const container = document.createElement('div');
+  container.style.display = 'none';
+  document.body.appendChild(container);
+
+  // type issue with mapChart existing (or not) on the Highcharts object - it does
+  // maybe because the loading of highcharts modules is done before this code is executed
+  const constructor = options.mapView
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      Highcharts.mapChart
+    : Highcharts.chart;
+
+  const chart = constructor(container, options);
+  const svg = chart.getSVG();
+
+  chart.destroy();
+  document.body.removeChild(container);
+
+  return svg;
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromElement.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromElement.test.ts
@@ -1,0 +1,22 @@
+import { svgStringFromElement } from '@/components/molecules/Export/helpers/svgStringFromElement';
+
+describe('svgStringFromElement', () => {
+  it('serializes an SVG element to a string', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '100');
+    svg.setAttribute('height', '50');
+    svg.innerHTML = '<rect x="10" y="10" width="30" height="20" fill="blue"/>';
+
+    const result = svgStringFromElement(svg);
+    expect(result).toEqual(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect x="10" y="10" width="30" height="20" fill="blue"/></svg>`
+    );
+  });
+
+  it('returns a non-empty string', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const result = svgStringFromElement(svg);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromElement.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgStringFromElement.ts
@@ -1,0 +1,4 @@
+export const svgStringFromElement = (element: SVGSVGElement): string => {
+  const serializer = new XMLSerializer();
+  return serializer.serializeToString(element);
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgWithChartAndLegend.test.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgWithChartAndLegend.test.ts
@@ -1,0 +1,73 @@
+import { svgWithChartAndLegend } from '@/components/molecules/Export/helpers/svgWithChartAndLegend';
+import { ElementInfo } from '@/components/molecules/Export/export.types';
+
+describe('svgWithChartAndLegend', () => {
+  const createSvgElement = (
+    id: string,
+    width: number,
+    height: number,
+    style?: string
+  ): SVGSVGElement => {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    el.setAttribute('id', id);
+    el.setAttribute('width', `${width}`);
+    el.setAttribute('height', `${height}`);
+    if (style) el.setAttribute('style', style);
+    return el;
+  };
+
+  it('returns a composed SVG with chart and legend', () => {
+    const chartEl = createSvgElement('chart', 200, 150, 'background: #fff');
+    const legendEl = createSvgElement('legend', 180, 50);
+
+    const chartInfo: ElementInfo = {
+      element: chartEl,
+      width: 200,
+      height: 150,
+    };
+
+    const legendInfo: ElementInfo = {
+      element: legendEl,
+      width: 180,
+      height: 50,
+    };
+
+    const svg = svgWithChartAndLegend(chartInfo, legendInfo);
+    expect(svg).toBeInstanceOf(SVGSVGElement);
+    expect(svg?.getAttribute('width')).toBe('200px');
+    expect(svg?.getAttribute('height')).toBe('200px'); // 150 + 50
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 200 200');
+    expect(svg?.getAttribute('style')).toBe('background: #fff');
+
+    const groups = svg?.querySelectorAll('g');
+    expect(groups?.length).toBe(2);
+    expect(groups?.[0]?.getAttribute('transform')).toBe('translate(10, 0)');
+    expect(groups?.[1]?.getAttribute('transform')).toBe('translate(0, 50)');
+  });
+
+  it('returns null if chart or legend is missing', () => {
+    const result1 = svgWithChartAndLegend(
+      { element: undefined, width: 100, height: 100 },
+      {
+        element: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        width: 100,
+        height: 100,
+      }
+    );
+    expect(result1).toBeNull();
+
+    const result2 = svgWithChartAndLegend(
+      {
+        element: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        width: 100,
+        height: 0,
+      },
+      {
+        element: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        width: 100,
+        height: 100,
+      }
+    );
+    expect(result2).toBeNull();
+  });
+});

--- a/frontend/fingertips-frontend/components/molecules/Export/helpers/svgWithChartAndLegend.ts
+++ b/frontend/fingertips-frontend/components/molecules/Export/helpers/svgWithChartAndLegend.ts
@@ -1,0 +1,39 @@
+import { ElementInfo } from '@/components/molecules/Export/export.types';
+
+export const svgWithChartAndLegend = (
+  chartInfo: ElementInfo,
+  legendInfo: ElementInfo
+) => {
+  const { element: chart, width: chartW, height: chartH } = chartInfo;
+  const { element: legend, width: legendW, height: legendH } = legendInfo;
+
+  if (!chart || !legend) return null;
+  if (!chartW || !chartH || !legendW || !legendH) return null;
+
+  const overallWidth = Math.ceil(Math.max(legendW, chartW));
+  const overallHeight = Math.ceil(legendH + chartH);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', `${overallWidth}px`);
+  svg.setAttribute('height', `${overallHeight}px`);
+  svg.setAttribute('viewBox', `0 0 ${overallWidth} ${overallHeight}`);
+  svg.setAttribute('style', chart.getAttribute('style') ?? '');
+
+  const legendGroup = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'g'
+  );
+  legendGroup.setAttribute('transform', `translate(10, 0)`);
+  svg.appendChild(legendGroup);
+  legendGroup.appendChild(legend);
+
+  const chartGroup = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'g'
+  );
+  chartGroup.setAttribute('transform', `translate(0, ${legendH})`);
+  svg.appendChild(chartGroup);
+  chartGroup.appendChild(chart);
+
+  return svg;
+};

--- a/frontend/fingertips-frontend/components/molecules/Export/usePreviewPrep.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Export/usePreviewPrep.test.tsx
@@ -10,9 +10,15 @@ jest.mock('@/components/molecules/Export/exportHelpers', () => ({
   getHtmlToImageCanvas: jest.fn(() => {
     return Promise.resolve({ nodeName: 'CANVAS' });
   }),
-  getSvgFromOptions: jest.fn(() => '<svg></svg>'),
   svgStringToDomElement: jest.fn(() => document.createElement('svg')),
 }));
+
+jest.mock(
+  '@/components/molecules/Export/helpers/svgStringFromChartOptions',
+  () => ({
+    svgStringFromChartOptions: jest.fn(() => '<svg></svg>'),
+  })
+);
 
 const createWrapper = () => {
   const client = new QueryClient({
@@ -63,7 +69,7 @@ describe('usePreviewPrep', () => {
     );
 
     await waitFor(() => result.current.isSuccess);
-    expect(result.current.element?.nodeName).toBe('SVG');
+    expect(result.current.element?.nodeName).toBe('svg');
     expect(result.current.text).toBe('<svg></svg>');
   });
 

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '@/components/organisms/Inequalities/inequalitiesHelpers';
 import { getBarChartOptions } from '@/components/molecules/Inequalities/BarChart/barChartHelpers';
 import { pointFormatterHelper } from '@/lib/chartHelpers/pointFormatterHelper';
-import { BenchmarkLegend } from '@/components/organisms/BenchmarkLegend';
 import { ConfidenceIntervalCheckbox } from '../../ConfidenceIntervalCheckbox';
 import { useState } from 'react';
 import {
@@ -26,12 +25,8 @@ import { ExportOptionsButton } from '../../Export/ExportOptionsButton';
 import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapper';
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
 import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
-import {
-  allLegendItems,
-  getMethodsAndOutcomes,
-} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+import { getMethodsAndOutcomes } from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
 import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
-import { BenchmarkLegendsSvg } from '@/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg';
 
 interface InequalitiesBarChartProps {
   title: string;

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
@@ -201,7 +201,7 @@ export function InequalitiesBarChart({
         <BenchmarkLegends
           legendsToShow={legendsToShow}
           title={'Compared to persons'}
-          // svg
+          svg
         />
         <HighChartsWrapper
           chartOptions={barChartOptions}

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/index.tsx
@@ -26,6 +26,12 @@ import { ExportOptionsButton } from '../../Export/ExportOptionsButton';
 import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapper';
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
 import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
+import {
+  allLegendItems,
+  getMethodsAndOutcomes,
+} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
+import { BenchmarkLegendsSvg } from '@/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg';
 
 interface InequalitiesBarChartProps {
   title: string;
@@ -162,7 +168,7 @@ export function InequalitiesBarChart({
 
   const barChartOptions = getBarChartOptions({
     // The deprivation chart needs more height
-    height: type === InequalitiesTypes.Deprivation ? '800' : '400',
+    height: type === InequalitiesTypes.Deprivation ? 800 : 400,
     xAxisTitleText: `${xAxisTitlePrefix} ${mapToXAxisTitle[type]}`,
     xAxisCategories: barChartFields,
     yAxisTitleText: `${yAxisLabel}${measurementUnit ? ': ' + measurementUnit : ''}`,
@@ -180,6 +186,9 @@ export function InequalitiesBarChart({
   });
 
   const id = 'inequalitiesBarChart-component';
+  const legendsToShow = getMethodsAndOutcomes([
+    { benchmarkComparisonMethod, polarity },
+  ]);
   return (
     <>
       <div id={id} data-testid={id}>
@@ -189,10 +198,10 @@ export function InequalitiesBarChart({
           showConfidenceIntervalsData={showConfidenceIntervalsData}
           setShowConfidenceIntervalsData={setShowConfidenceIntervalsData}
         />
-        <BenchmarkLegend
+        <BenchmarkLegends
+          legendsToShow={legendsToShow}
           title={'Compared to persons'}
-          benchmarkComparisonMethod={benchmarkComparisonMethod}
-          polarity={polarity}
+          // svg
         />
         <HighChartsWrapper
           chartOptions={barChartOptions}

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/inequalitiesBarChart.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/BarChart/inequalitiesBarChart.test.tsx
@@ -1,5 +1,5 @@
 import { InequalitiesBarChart } from '.';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { getTestData } from './mocks';
 import { InequalitiesTypes } from '@/components/organisms/Inequalities/inequalitiesHelpers';
 import {
@@ -40,9 +40,12 @@ describe('Inequalities BarChart suite', () => {
     expect(
       screen.getByText('inequalities for South FooBar, 2008')
     ).toBeInTheDocument();
-    expect(screen.getByText('Lower')).toBeInTheDocument();
-    expect(screen.getByText('Higher')).toBeInTheDocument();
-    expect(screen.getByText('Similar')).toBeInTheDocument();
+
+    const benchmarkLegend = screen.getByTestId('benchmarkLegend-component');
+    expect(within(benchmarkLegend).getByText('Lower')).toBeInTheDocument();
+    expect(within(benchmarkLegend).getByText('Higher')).toBeInTheDocument();
+    expect(within(benchmarkLegend).getByText('Similar')).toBeInTheDocument();
+
     expect(screen.getByRole('button')).toHaveTextContent('Export options');
   });
 

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLabel/index.tsx
@@ -17,10 +17,10 @@ interface BenchmarkLabelProps {
 
 export const BenchmarkTagStyle = styled(Tag)<{
   outcome: BenchmarkOutcome;
-  group: BenchmarkComparisonMethod;
+  comparisonMethod: BenchmarkComparisonMethod;
   polarity: IndicatorPolarity;
-}>(({ outcome, group, polarity }) => {
-  const theme = getBenchmarkTagStyle(group, outcome, polarity);
+}>(({ outcome, comparisonMethod, polarity }) => {
+  const theme = getBenchmarkTagStyle(comparisonMethod, outcome, polarity);
 
   return {
     padding: '5px 8px 4px 8px',
@@ -56,7 +56,7 @@ export const BenchmarkLabel: React.FC<BenchmarkLabelProps> = ({
   return (
     <BenchmarkTagStyle
       outcome={outcomeParsed}
-      group={methodParsed}
+      comparisonMethod={methodParsed}
       polarity={polarityParsed}
     >
       {labelText}

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegend.styles.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegend.styles.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+export const LegendContainerWithMargin = styled.div({
+  marginBottom: '2em',
+});
+export const LegendContainerNoMargin = styled.div({});
+
+export const BenchmarkLegendHeader = styled('h4')({
+  alignSelf: 'stretch',
+  margin: '16px 0 8px 0',
+  fontFamily: 'nta,Arial,sans-serif',
+  fontWeight: 300,
+  fontSize: '19px',
+});
+
+export const LegendGroup = styled('div')({
+  position: 'relative',
+  left: '-5px',
+});
+
+export const StyledLegendLabel = styled('span')({
+  display: 'block',
+  margin: '4px 0 0 0',
+  fontFamily: 'nta,Arial,sans-serif',
+  fontWeight: 300,
+  fontSize: '16px', //16px
+});

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegend.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegend.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { BenchmarkLegend, BenchmarkLegends } from '.';
+import { BenchmarkLegend } from '.';
 import '@testing-library/jest-dom';
 import {
   BenchmarkComparisonMethod,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
 import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
 
 describe('Testing the benchmark component', () => {
   it('Snapshot testing of the UI RAG 95', () => {

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegendGroup.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegendGroup.tsx
@@ -4,22 +4,12 @@ import {
   BenchmarkOutcome,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
-import styled from 'styled-components';
 import { FC } from 'react';
 import { getConfidenceLimitNumber } from '@/lib/chartHelpers/chartHelpers';
-
-const LegendGroup = styled('div')({
-  position: 'relative',
-  left: '-5px',
-});
-
-const StyledLegendLabel = styled('span')({
-  display: 'block',
-  margin: '4px 0 0 0',
-  fontFamily: 'nta,Arial,sans-serif',
-  fontWeight: 300,
-  fontSize: '16px', //16px
-});
+import {
+  LegendGroup,
+  StyledLegendLabel,
+} from '@/components/organisms/BenchmarkLegend/BenchmarkLegend.styles';
 
 interface BenchmarkLegendProps {
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
@@ -28,7 +18,7 @@ interface BenchmarkLegendProps {
   subTitle?: string;
 }
 
-const BenchmarkLegendGroup: FC<BenchmarkLegendProps> = ({
+export const BenchmarkLegendGroup: FC<BenchmarkLegendProps> = ({
   outcomes,
   benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown,
   polarity,
@@ -59,5 +49,3 @@ const BenchmarkLegendGroup: FC<BenchmarkLegendProps> = ({
     </>
   );
 };
-
-export default BenchmarkLegendGroup;

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegends.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/BenchmarkLegends.tsx
@@ -1,0 +1,95 @@
+import { FC } from 'react';
+import {
+  BenchmarkComparisonMethod,
+  IndicatorPolarity,
+} from '@/generated-sources/ft-api-client';
+import {
+  quintilesOutcomes,
+  quintilesOutcomesWithJudgement,
+} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+
+import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import {
+  BenchmarkLegendHeader,
+  LegendContainerNoMargin,
+  LegendContainerWithMargin,
+} from '@/components/organisms/BenchmarkLegend/BenchmarkLegend.styles';
+import { BenchmarkLegendGroup } from '@/components/organisms/BenchmarkLegend/BenchmarkLegendGroup';
+import { BenchmarkLegendsSvg } from '@/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg';
+import { legendsRenderConfig } from '@/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig';
+
+interface BenchmarkLegendsProps {
+  title?: string;
+  legendsToShow: BenchmarkLegendsToShow;
+  bottomMargin?: boolean;
+  svg?: boolean;
+}
+
+export const BenchmarkLegends: FC<BenchmarkLegendsProps> = ({
+  title = 'Compared to England',
+  legendsToShow,
+  bottomMargin = true,
+  svg = false,
+}) => {
+  const {
+    show95,
+    outcomes95,
+    show99,
+    outcomes99,
+    showQ,
+    showQnoJudgement,
+    hideDuplicateQuintileSubheading,
+  } = legendsRenderConfig(legendsToShow);
+
+  const LegendContainer = bottomMargin
+    ? LegendContainerWithMargin
+    : LegendContainerNoMargin;
+  return (
+    <>
+      <LegendContainer data-testid="benchmarkLegend-component">
+        <BenchmarkLegendHeader>{title}</BenchmarkLegendHeader>
+        {show95 ? (
+          <BenchmarkLegendGroup
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={
+              BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+            }
+            outcomes={outcomes95}
+          />
+        ) : null}
+
+        {show99 ? (
+          <BenchmarkLegendGroup
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={
+              BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8
+            }
+            outcomes={outcomes99}
+          />
+        ) : null}
+
+        {showQnoJudgement ? (
+          <BenchmarkLegendGroup
+            polarity={IndicatorPolarity.NoJudgement}
+            benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
+            outcomes={quintilesOutcomes}
+          />
+        ) : null}
+
+        {showQ ? (
+          <BenchmarkLegendGroup
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
+            outcomes={quintilesOutcomesWithJudgement}
+            subTitle={hideDuplicateQuintileSubheading ? '' : undefined}
+          />
+        ) : null}
+      </LegendContainer>
+      {svg ? (
+        <div style={{ position: 'absolute', visibility: 'hidden' }}>
+          <BenchmarkLegendsSvg legendsToShow={legendsToShow} title={title} />
+        </div>
+      ) : null}
+    </>
+  );
+};

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/__snapshots__/BenchmarkLegend.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/__snapshots__/BenchmarkLegend.test.tsx.snap
@@ -79,19 +79,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB 95 1`] =
   border: 1px solid #0B0C0C;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -104,6 +91,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB 95 1`] =
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -243,19 +243,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB 99.8 1`]
   border: 1px solid #0B0C0C;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -268,6 +255,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB 99.8 1`]
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -419,19 +419,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB quintile
   tint: SOLID;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -444,6 +431,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI BOB quintile
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -588,19 +588,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG 95 1`] =
   border: 1px solid #0B0C0C;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -613,6 +600,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG 95 1`] =
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -752,19 +752,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG 99.8 1`]
   border: 1px solid #0B0C0C;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -777,6 +764,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG 99.8 1`]
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -928,19 +928,6 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG quintile
   tint: SOLID;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -953,6 +940,19 @@ exports[`Testing the benchmark component Snapshot testing of the UI RAG quintile
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {
@@ -1304,19 +1304,6 @@ exports[`Testing the benchmark component Snapshot testing of the legend with all
   tint: SOLID;
 }
 
-.c3 {
-  position: relative;
-  left: -5px;
-}
-
-.c2 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
 .c0 {
   margin-bottom: 2em;
 }
@@ -1329,6 +1316,19 @@ exports[`Testing the benchmark component Snapshot testing of the legend with all
   font-family: nta,Arial,sans-serif;
   font-weight: 300;
   font-size: 19px;
+}
+
+.c3 {
+  position: relative;
+  left: -5px;
+}
+
+.c2 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/benchmarkLegendHelpers.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/benchmarkLegendHelpers.ts
@@ -80,6 +80,17 @@ export const quintilesOutcomesWithJudgement = [
   BenchmarkOutcome.Best,
 ];
 
+const both = {
+  judgement: true,
+  noJudgement: true,
+};
+
+export const allLegendItems: BenchmarkLegendsToShow = {
+  [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: both,
+  [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: both,
+  [BenchmarkComparisonMethod.Quintiles]: both,
+};
+
 export const isJudgemental = (polarity: IndicatorPolarity) =>
   polarity === IndicatorPolarity.HighIsGood ||
   polarity === IndicatorPolarity.LowIsGood;

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BenchmarkLegendGroupSvg } from './BenchmarkLegendGroupSvg';
+import {
+  BenchmarkComparisonMethod,
+  IndicatorPolarity,
+} from '@/generated-sources/ft-api-client';
+import { ragOutcomes } from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+
+describe('BenchmarkLegendGroupSvg', () => {
+  it('renders subtitle and legend items', () => {
+    const { container } = render(
+      <svg>
+        <BenchmarkLegendGroupSvg
+          y={50}
+          outcomes={ragOutcomes}
+          benchmarkComparisonMethod={
+            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+          }
+          polarity={IndicatorPolarity.HighIsGood}
+        />
+      </svg>
+    );
+
+    // Subtitle text
+    expect(screen.getByText('95% confidence')).toBeInTheDocument();
+
+    // Each outcome label
+    expect(screen.getByText('Better')).toBeInTheDocument();
+    expect(screen.getByText('Worse')).toBeInTheDocument();
+
+    // Correct number of rects
+    const rects = container.querySelectorAll('rect');
+    expect(rects).toHaveLength(ragOutcomes.length);
+
+    // Correct number of texts
+    const texts = container.querySelectorAll('text');
+    expect(texts).toHaveLength(ragOutcomes.length + 1);
+  });
+
+  it('uses custom subTitle when provided', () => {
+    render(
+      <svg>
+        <BenchmarkLegendGroupSvg
+          y={0}
+          outcomes={ragOutcomes}
+          benchmarkComparisonMethod={
+            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+          }
+          polarity={IndicatorPolarity.NoJudgement}
+          subTitle="Custom Subtitle"
+        />
+      </svg>
+    );
+
+    expect(screen.getByText('Custom Subtitle')).toBeInTheDocument();
+  });
+
+  it('renders without subtitle if none is provided and method has no confidence limit', () => {
+    const { container } = render(
+      <svg>
+        <BenchmarkLegendGroupSvg
+          outcomes={ragOutcomes}
+          benchmarkComparisonMethod={
+            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+          }
+          polarity={IndicatorPolarity.HighIsGood}
+        />
+      </svg>
+    );
+
+    expect(container).toHaveTextContent(
+      '95% confidenceBetterSimilarWorseNot compared'
+    );
+  });
+});

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg.tsx
@@ -1,0 +1,87 @@
+import { getBenchmarkLabelText } from '@/components/organisms/BenchmarkLabel';
+import {
+  BenchmarkComparisonMethod,
+  BenchmarkOutcome,
+  IndicatorPolarity,
+} from '@/generated-sources/ft-api-client';
+import { FC } from 'react';
+import { getConfidenceLimitNumber } from '@/lib/chartHelpers/chartHelpers';
+import { getBenchmarkTagStyle } from '@/components/organisms/BenchmarkLabel/BenchmarkLabelConfig';
+import { GovukColours } from '@/lib/styleHelpers/colours';
+
+interface BenchmarkLegendProps {
+  y?: number;
+  benchmarkComparisonMethod?: BenchmarkComparisonMethod;
+  outcomes: BenchmarkOutcome[];
+  polarity: IndicatorPolarity;
+  subTitle?: string;
+}
+
+export const BenchmarkLegendGroupSvg: FC<BenchmarkLegendProps> = ({
+  y = 0,
+  outcomes,
+  benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown,
+  polarity,
+  subTitle,
+}) => {
+  const confidenceLimit = getConfidenceLimitNumber(benchmarkComparisonMethod);
+  const prefix = confidenceLimit
+    ? `${confidenceLimit}% confidence`
+    : 'Quintiles';
+
+  const subTitleText = subTitle ?? prefix;
+
+  const gap = 10;
+  let xPointer = 0;
+  const items = outcomes.map((outcome) => {
+    const x = xPointer;
+    const txt = getBenchmarkLabelText(outcome);
+    const width = 16 + txt.length * 8;
+    xPointer += width + gap;
+    const theme = getBenchmarkTagStyle(
+      benchmarkComparisonMethod,
+      outcome,
+      polarity
+    );
+    return {
+      key: `${benchmarkComparisonMethod}_${outcome}`,
+      x,
+      width,
+      txt,
+      color: theme?.color ?? GovukColours.White,
+      backgroundColor: theme?.backgroundColor,
+      stroke: theme?.border ? theme.color : 'none',
+    };
+  });
+
+  return (
+    <g transform={`translate(0,${y})`}>
+      {subTitleText ? (
+        <text y={12} fontSize={16}>
+          {subTitleText}
+        </text>
+      ) : null}
+      {items.map(({ key, txt, x, width, color, backgroundColor, stroke }) => (
+        <g transform={`translate(${x},${subTitleText ? 20 : 6})`} key={key}>
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={26}
+            fill={backgroundColor}
+            stroke={stroke}
+          />
+          <text
+            fontSize={16}
+            x={width / 2}
+            y={19}
+            textAnchor={'middle'}
+            fill={color}
+          >
+            {txt}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+};

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { BenchmarkLegendsSvg } from './BenchmarkLegendsSvg';
+import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client';
+
+// Mocking BenchmarkLegendGroupSvg to focus only on render logic
+jest.mock(
+  '@/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg',
+  () => ({
+    BenchmarkLegendGroupSvg: jest.fn(({ y, benchmarkComparisonMethod }) => (
+      <g data-testid={`legend-${benchmarkComparisonMethod}`} data-y={y}></g>
+    )),
+  })
+);
+
+describe('BenchmarkLegendsSvg', () => {
+  it('renders correct SVG structure with all legend types shown', () => {
+    const legendsToShow: BenchmarkLegendsToShow = {
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: true,
+      },
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: {
+        judgement: true,
+        noJudgement: false,
+      },
+      [BenchmarkComparisonMethod.Quintiles]: {
+        judgement: true,
+        noJudgement: true,
+      },
+    };
+
+    render(
+      <BenchmarkLegendsSvg legendsToShow={legendsToShow} title="Test Title" />
+    );
+
+    expect(
+      screen.getByTestId('benchmarkLegend-component-svg')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId(
+        `legend-${BenchmarkComparisonMethod.CIOverlappingReferenceValue95}`
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        `legend-${BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8}`
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId(`legend-${BenchmarkComparisonMethod.Quintiles}`)
+    ).toHaveLength(2); // one for noJudgement, one for judgement
+  });
+
+  it('renders only 95 legend when others are absent', () => {
+    const legendsToShow: BenchmarkLegendsToShow = {
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: false,
+      },
+    };
+
+    render(<BenchmarkLegendsSvg legendsToShow={legendsToShow} />);
+
+    expect(
+      screen.getByTestId(
+        `legend-${BenchmarkComparisonMethod.CIOverlappingReferenceValue95}`
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        `legend-${BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8}`
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryAllByTestId(`legend-${BenchmarkComparisonMethod.Quintiles}`)
+    ).toHaveLength(0);
+  });
+
+  it('does not render any groups if no flags are set', () => {
+    render(<BenchmarkLegendsSvg legendsToShow={{}} />);
+    expect(screen.queryAllByTestId(/legend-/)).toHaveLength(0);
+  });
+});

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendsSvg.tsx
@@ -1,0 +1,87 @@
+import { FC } from 'react';
+import {
+  BenchmarkComparisonMethod,
+  IndicatorPolarity,
+} from '@/generated-sources/ft-api-client';
+import {
+  quintilesOutcomes,
+  quintilesOutcomesWithJudgement,
+} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import { BenchmarkLegendGroupSvg } from '@/components/organisms/BenchmarkLegend/components/svg/BenchmarkLegendGroupSvg';
+import { legendsSvgRenderConfig } from '@/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig';
+
+interface BenchmarkLegendsProps {
+  title?: string;
+  legendsToShow: BenchmarkLegendsToShow;
+}
+
+export const BenchmarkLegendsSvg: FC<BenchmarkLegendsProps> = ({
+  title = 'Compared to England',
+  legendsToShow,
+}) => {
+  const {
+    show95,
+    outcomes95,
+    show99,
+    outcomes99,
+    showQ,
+    showQnoJudgement,
+    hideDuplicateQuintileSubheading,
+    cumulativeY,
+    yValues,
+  } = legendsSvgRenderConfig(legendsToShow);
+
+  return (
+    <svg
+      data-testid="benchmarkLegend-component-svg"
+      width={500}
+      height={cumulativeY}
+      className={'svgBenchmarkLegend'}
+    >
+      <g>
+        <text y={16}>{title}</text>
+        {show95 ? (
+          <BenchmarkLegendGroupSvg
+            y={yValues.y95}
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={
+              BenchmarkComparisonMethod.CIOverlappingReferenceValue95
+            }
+            outcomes={outcomes95}
+          />
+        ) : null}
+
+        {show99 ? (
+          <BenchmarkLegendGroupSvg
+            y={yValues.y99}
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={
+              BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8
+            }
+            outcomes={outcomes99}
+          />
+        ) : null}
+
+        {showQnoJudgement ? (
+          <BenchmarkLegendGroupSvg
+            y={yValues.yQnoJudgement}
+            polarity={IndicatorPolarity.NoJudgement}
+            benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
+            outcomes={quintilesOutcomes}
+          />
+        ) : null}
+
+        {showQ ? (
+          <BenchmarkLegendGroupSvg
+            y={yValues.yQJudgement}
+            polarity={IndicatorPolarity.HighIsGood}
+            benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
+            outcomes={quintilesOutcomesWithJudgement}
+            subTitle={hideDuplicateQuintileSubheading ? '' : undefined}
+          />
+        ) : null}
+      </g>
+    </svg>
+  );
+};

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig.test.ts
@@ -1,0 +1,72 @@
+import { legendsRenderConfig } from './legendsRenderConfig';
+import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client';
+import {
+  bobOutcomes,
+  ragOutcomes,
+} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+
+describe('legendsRenderConfig', () => {
+  it('returns correct config when all types are enabled', () => {
+    const config = legendsRenderConfig({
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: true,
+      },
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: {
+        judgement: true,
+        noJudgement: false,
+      },
+      [BenchmarkComparisonMethod.Quintiles]: {
+        judgement: true,
+        noJudgement: true,
+      },
+    });
+
+    const expectedOutcomes95 = [...new Set([...ragOutcomes, ...bobOutcomes])];
+    const expectedOutcomes99 = [...new Set([...ragOutcomes])];
+
+    expect(config.show95).toBe(true);
+    expect(config.outcomes95).toEqual(expectedOutcomes95);
+    expect(config.show99).toBe(true);
+    expect(config.outcomes99).toEqual(expectedOutcomes99);
+    expect(config.showQ).toBe(true);
+    expect(config.showQnoJudgement).toBe(true);
+    expect(config.hideDuplicateQuintileSubheading).toBe(true);
+  });
+
+  it('handles missing methods safely', () => {
+    const config = legendsRenderConfig({}); // empty input
+
+    expect(config.show95).toBe(false);
+    expect(config.outcomes95).toEqual([]);
+    expect(config.show99).toBe(false);
+    expect(config.outcomes99).toEqual([]);
+    expect(config.showQ).toBe(false);
+    expect(config.showQnoJudgement).toBe(false);
+    expect(config.hideDuplicateQuintileSubheading).toBe(false);
+  });
+
+  it('avoids duplicating rag outcomes in outcomes95', () => {
+    const config = legendsRenderConfig({
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: false,
+      },
+    });
+
+    expect(config.outcomes95).toEqual([...new Set(ragOutcomes)]);
+    expect(config.show95).toBe(true);
+  });
+
+  it('avoids duplicating bob outcomes in outcomes99', () => {
+    const config = legendsRenderConfig({
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: {
+        judgement: false,
+        noJudgement: true,
+      },
+    });
+
+    expect(config.outcomes99).toEqual([...new Set(bobOutcomes)]);
+    expect(config.show99).toBe(true);
+  });
+});

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig.ts
@@ -1,0 +1,47 @@
+import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client';
+import {
+  bobOutcomes,
+  ragOutcomes,
+} from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
+
+export const legendsRenderConfig = (legendsToShow: BenchmarkLegendsToShow) => {
+  const { judgement: judgement95 = false, noJudgement: noJudgement95 = false } =
+    legendsToShow[BenchmarkComparisonMethod.CIOverlappingReferenceValue95] ??
+    {};
+
+  const outcomes95 = [
+    ...new Set([
+      ...(judgement95 ? ragOutcomes : []),
+      ...(noJudgement95 ? bobOutcomes : []),
+    ]),
+  ];
+
+  const { judgement: judgement99 = false, noJudgement: noJudgement99 = false } =
+    legendsToShow[BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8] ??
+    {};
+
+  const outcomes99 = [
+    ...new Set([
+      ...(judgement99 ? ragOutcomes : []),
+      ...(noJudgement99 ? bobOutcomes : []),
+    ]),
+  ];
+
+  const { judgement: showQ = false, noJudgement: showQnoJudgement = false } =
+    legendsToShow[BenchmarkComparisonMethod.Quintiles] ?? {};
+
+  const show95 = outcomes95.length > 0;
+  const show99 = outcomes99.length > 0;
+  const hideDuplicateQuintileSubheading = showQ && showQnoJudgement;
+
+  return {
+    show95,
+    outcomes95,
+    show99,
+    outcomes99,
+    showQ,
+    showQnoJudgement,
+    hideDuplicateQuintileSubheading,
+  };
+};

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig.test.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig.test.ts
@@ -1,0 +1,80 @@
+import { legendsSvgRenderConfig } from '@/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig';
+import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client';
+
+describe('legendsSvgRenderConfig', () => {
+  it('renders all legend types with correct spacing and cumulativeY', () => {
+    const config = legendsSvgRenderConfig({
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: true,
+      },
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: {
+        judgement: true,
+        noJudgement: false,
+      },
+      [BenchmarkComparisonMethod.Quintiles]: {
+        judgement: true,
+        noJudgement: true,
+      },
+    });
+
+    expect(config.show95).toBe(true);
+    expect(config.show99).toBe(true);
+    expect(config.showQ).toBe(true);
+    expect(config.showQnoJudgement).toBe(true);
+    expect(config.hideDuplicateQuintileSubheading).toBe(true);
+
+    // y positioning checks
+    expect(config.yValues.y95).toBe(35);
+    expect(config.yValues.y99).toBe(95); // 35 + 60
+    expect(config.yValues.yQnoJudgement).toBe(155); // 95 + 60
+    expect(config.yValues.yQJudgement).toBe(205); // 155 + 50 (reduced spacing)
+
+    expect(config.cumulativeY).toBe(245); // last + 40
+  });
+
+  it('renders only 95 and quintile judgement with standard spacing', () => {
+    const config = legendsSvgRenderConfig({
+      [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: {
+        judgement: true,
+        noJudgement: false,
+      },
+      [BenchmarkComparisonMethod.Quintiles]: {
+        judgement: true,
+        noJudgement: false,
+      },
+    });
+
+    expect(config.show95).toBe(true);
+    expect(config.show99).toBe(false);
+    expect(config.showQ).toBe(true);
+    expect(config.showQnoJudgement).toBe(false);
+    expect(config.hideDuplicateQuintileSubheading).toBe(false);
+
+    expect(config.yValues.y95).toBe(35);
+    expect(config.yValues.y99).toBe(0);
+    expect(config.yValues.yQnoJudgement).toBe(0);
+    expect(config.yValues.yQJudgement).toBe(95); // 35 + 60
+
+    expect(config.cumulativeY).toBe(135);
+  });
+
+  it('returns zero y-values when no legends are shown', () => {
+    const config = legendsSvgRenderConfig({});
+
+    expect(config.show95).toBe(false);
+    expect(config.show99).toBe(false);
+    expect(config.showQ).toBe(false);
+    expect(config.showQnoJudgement).toBe(false);
+    expect(config.hideDuplicateQuintileSubheading).toBe(false);
+
+    expect(config.yValues).toEqual({
+      y95: 0,
+      y99: 0,
+      yQnoJudgement: 0,
+      yQJudgement: 0,
+    });
+
+    expect(config.cumulativeY).toBe(35); // unchanged from initial
+  });
+});

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig.ts
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/helpers/legendsSvgRenderConfig.ts
@@ -1,0 +1,42 @@
+import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
+import { legendsRenderConfig } from '@/components/organisms/BenchmarkLegend/helpers/legendsRenderConfig';
+
+export const legendsSvgRenderConfig = (
+  legendsToShow: BenchmarkLegendsToShow
+) => {
+  const renderConfig = legendsRenderConfig(legendsToShow);
+  const {
+    show95,
+    show99,
+    showQnoJudgement,
+    hideDuplicateQuintileSubheading,
+    showQ,
+  } = renderConfig;
+
+  let cumulativeY = 35;
+  const yValues = { y95: 0, y99: 0, yQnoJudgement: 0, yQJudgement: 0 };
+  const ySpacing = 60;
+  const ySpacingWithoutSubheading = 50;
+  if (show95) {
+    yValues.y95 = cumulativeY;
+    cumulativeY += ySpacing;
+  }
+  if (show99) {
+    yValues.y99 = cumulativeY;
+    cumulativeY += ySpacing;
+  }
+
+  if (showQnoJudgement) {
+    yValues.yQnoJudgement = cumulativeY;
+    cumulativeY += hideDuplicateQuintileSubheading
+      ? ySpacingWithoutSubheading
+      : ySpacing;
+  }
+
+  if (showQ) {
+    yValues.yQJudgement = cumulativeY;
+    cumulativeY += ySpacing - 20;
+  }
+
+  return { ...renderConfig, cumulativeY, yValues };
+};

--- a/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/BenchmarkLegend/index.tsx
@@ -1,34 +1,20 @@
 'use client';
 
-import styled from 'styled-components';
 import { FC } from 'react';
 import {
   BenchmarkComparisonMethod,
   IndicatorPolarity,
 } from '@/generated-sources/ft-api-client';
-import BenchmarkLegendGroup from '@/components/organisms/BenchmarkLegend/BenchmarkLegendGroup';
+import { BenchmarkLegendGroup } from '@/components/organisms/BenchmarkLegend/BenchmarkLegendGroup';
 import {
-  bobOutcomes,
+  allLegendItems,
   getOutcomes,
-  quintilesOutcomes,
-  quintilesOutcomesWithJudgement,
-  ragOutcomes,
 } from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
-import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
-
-const LegendContainerWithMargin = styled.div({
-  marginBottom: '2em',
-});
-
-const LegendContainerNoMargin = styled.div({});
-
-const BenchmarkLegendHeader = styled('h4')({
-  alignSelf: 'stretch',
-  margin: '16px 0 8px 0',
-  fontFamily: 'nta,Arial,sans-serif',
-  fontWeight: 300,
-  fontSize: '19px',
-});
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
+import {
+  BenchmarkLegendHeader,
+  LegendContainerWithMargin,
+} from '@/components/organisms/BenchmarkLegend/BenchmarkLegend.styles';
 
 interface BenchmarkLegendProps {
   title?: string;
@@ -63,97 +49,5 @@ interface BenchmarkLegendAllProps {
 }
 
 const BenchmarkLegendAll: FC<BenchmarkLegendAllProps> = ({ title }) => {
-  const both = {
-    judgement: true,
-    noJudgement: true,
-  };
-  const all: BenchmarkLegendsToShow = {
-    [BenchmarkComparisonMethod.CIOverlappingReferenceValue95]: both,
-    [BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8]: both,
-    [BenchmarkComparisonMethod.Quintiles]: both,
-  };
-
-  return <BenchmarkLegends title={title} legendsToShow={all} />;
-};
-
-interface BenchmarkLegendsProps {
-  title?: string;
-  legendsToShow: BenchmarkLegendsToShow;
-  bottomMargin?: boolean;
-}
-
-export const BenchmarkLegends: FC<BenchmarkLegendsProps> = ({
-  title = 'Compared to England',
-  legendsToShow,
-  bottomMargin = true,
-}) => {
-  const { judgement: judgement95 = false, noJudgement: noJudgement95 = false } =
-    legendsToShow[BenchmarkComparisonMethod.CIOverlappingReferenceValue95] ??
-    {};
-  const outcomes95 = [
-    ...new Set([
-      ...(judgement95 ? ragOutcomes : []),
-      ...(noJudgement95 ? bobOutcomes : []),
-    ]),
-  ];
-
-  const { judgement: judgement99 = false, noJudgement: noJudgement99 = false } =
-    legendsToShow[BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8] ??
-    {};
-  const outcomes99 = [
-    ...new Set([
-      ...(judgement99 ? ragOutcomes : []),
-      ...(noJudgement99 ? bobOutcomes : []),
-    ]),
-  ];
-  const { judgement: showQ = false, noJudgement: showQnoJudgement = false } =
-    legendsToShow[BenchmarkComparisonMethod.Quintiles] ?? {};
-
-  const show95 = outcomes95.length > 0;
-  const show99 = outcomes99.length > 0;
-  const hideDuplicateQuintileSubheading = showQ && showQnoJudgement;
-  const LegendContainer = bottomMargin
-    ? LegendContainerWithMargin
-    : LegendContainerNoMargin;
-  return (
-    <LegendContainer data-testid="benchmarkLegend-component">
-      <BenchmarkLegendHeader>{title}</BenchmarkLegendHeader>
-      {show95 ? (
-        <BenchmarkLegendGroup
-          polarity={IndicatorPolarity.HighIsGood}
-          benchmarkComparisonMethod={
-            BenchmarkComparisonMethod.CIOverlappingReferenceValue95
-          }
-          outcomes={outcomes95}
-        />
-      ) : null}
-
-      {show99 ? (
-        <BenchmarkLegendGroup
-          polarity={IndicatorPolarity.HighIsGood}
-          benchmarkComparisonMethod={
-            BenchmarkComparisonMethod.CIOverlappingReferenceValue99_8
-          }
-          outcomes={outcomes99}
-        />
-      ) : null}
-
-      {showQnoJudgement ? (
-        <BenchmarkLegendGroup
-          polarity={IndicatorPolarity.NoJudgement}
-          benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
-          outcomes={quintilesOutcomes}
-        />
-      ) : null}
-
-      {showQ ? (
-        <BenchmarkLegendGroup
-          polarity={IndicatorPolarity.HighIsGood}
-          benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
-          outcomes={quintilesOutcomesWithJudgement}
-          subTitle={hideDuplicateQuintileSubheading ? '' : undefined}
-        />
-      ) : null}
-    </LegendContainer>
-  );
+  return <BenchmarkLegends title={title} legendsToShow={allLegendItems} />;
 };

--- a/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/Heatmap.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/Heatmap.test.tsx.snap
@@ -311,33 +311,6 @@ exports[`heatmap snapshot test - england benchmark 1`] = `
   tint: SOLID;
 }
 
-.c6 {
-  position: relative;
-  left: -5px;
-}
-
-.c5 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
-.c3 {
-  margin-bottom: 2em;
-}
-
-.c4 {
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  margin: 16px 0 8px 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 19px;
-}
-
 .c25 {
   height: 50px;
   margin: 0;
@@ -524,6 +497,33 @@ exports[`heatmap snapshot test - england benchmark 1`] = `
 .c2 {
   font-size: 19px;
   margin: 0 0 30px 0;
+}
+
+.c3 {
+  margin-bottom: 2em;
+}
+
+.c4 {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  margin: 16px 0 8px 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 19px;
+}
+
+.c6 {
+  position: relative;
+  left: -5px;
+}
+
+.c5 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {

--- a/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/Heatmap.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/organisms/Heatmap/__snapshots__/Heatmap.test.tsx.snap
@@ -1413,33 +1413,6 @@ exports[`heatmap snapshot test - group area benchmark 1`] = `
   tint: SOLID;
 }
 
-.c6 {
-  position: relative;
-  left: -5px;
-}
-
-.c5 {
-  display: block;
-  margin: 4px 0 0 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-}
-
-.c3 {
-  margin-bottom: 2em;
-}
-
-.c4 {
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  margin: 16px 0 8px 0;
-  font-family: nta,Arial,sans-serif;
-  font-weight: 300;
-  font-size: 19px;
-}
-
 .c25 {
   height: 50px;
   margin: 0;
@@ -1631,6 +1604,33 @@ exports[`heatmap snapshot test - group area benchmark 1`] = `
 .c2 {
   font-size: 19px;
   margin: 0 0 30px 0;
+}
+
+.c3 {
+  margin-bottom: 2em;
+}
+
+.c4 {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  margin: 16px 0 8px 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 19px;
+}
+
+.c6 {
+  position: relative;
+  left: -5px;
+}
+
+.c5 {
+  display: block;
+  margin: 4px 0 0 0;
+  font-family: nta,Arial,sans-serif;
+  font-weight: 300;
+  font-size: 16px;
 }
 
 @media print {

--- a/frontend/fingertips-frontend/components/organisms/Heatmap/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/Heatmap/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { HeatmapIndicatorData } from './heatmapUtil';
-import { BenchmarkLegends } from '../BenchmarkLegend';
 import { HeatmapHover } from './components/hover';
 import React, { FC } from 'react';
 import HeatmapTable from '@/components/organisms/Heatmap/components/HeatmapTable';
@@ -12,6 +11,7 @@ import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapp
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
 import { ContainerWithOutline } from '@/components/atoms/ContainerWithOutline/ContainerWithOutline';
 import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
 
 export interface HeatmapProps {
   indicatorData: HeatmapIndicatorData[];

--- a/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
@@ -69,7 +69,7 @@ describe('SpineChartLegend', () => {
 
   it('renders BenchmarkLegends and SpineChartQuartilesInfoContainer', () => {
     render(<SpineChartLegend {...defaultProps} />);
-    expect(screen.getByTestId('benchmark-legends')).toBeInTheDocument();
+    expect(screen.getByTestId('benchmarkLegend-component')).toBeInTheDocument();
     expect(screen.getByTestId('quartiles-info')).toBeInTheDocument();
   });
 });

--- a/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { SpineChartLegendItem } from '@/components/organisms/SpineChartLegend/SpineChartLegendItem';
 import { SpineChartLegendTypes } from '@/components/organisms/SpineChartLegend/SpineChartLegend.types';
 import React, { FC } from 'react';
-import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend';
 import { BenchmarkLegendsToShow } from '@/components/organisms/BenchmarkLegend/benchmarkLegend.types';
 import { SpineChartQuartilesInfoContainer } from '@/components/organisms/SpineChart/SpineChartQuartilesInfo';
 import {
@@ -10,6 +9,7 @@ import {
   englandAreaString,
 } from '@/lib/chartHelpers/constants';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
 
 const DivContainer = styled.div({
   fontFamily: 'nta, Arial, sans-serif',

--- a/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
@@ -21,6 +21,8 @@ import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapp
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
 import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
 import { ContainerWithOutline } from '@/components/atoms/ContainerWithOutline/ContainerWithOutline';
+import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
+import { getMethodsAndOutcomes } from '@/components/organisms/BenchmarkLegend/benchmarkLegendHelpers';
 
 interface ThematicMapProps {
   healthIndicatorData: HealthDataForArea[];
@@ -88,6 +90,10 @@ export function ThematicMap({
     healthIndicatorData
   );
 
+  const legendsToShow = getMethodsAndOutcomes([
+    { benchmarkComparisonMethod, polarity },
+  ]);
+
   return (
     <>
       <H3>Compare an indicator by areas</H3>
@@ -111,10 +117,10 @@ export function ThematicMap({
               />
             </div>
           ))}
-          <BenchmarkLegend
+          <BenchmarkLegends
+            legendsToShow={legendsToShow}
             title={`Compared to ${healthIndicatorData[0].healthData[0].benchmarkComparison?.benchmarkAreaName}`}
-            benchmarkComparisonMethod={benchmarkComparisonMethod}
-            polarity={polarity}
+            svg
           />
           <HighChartsWrapper
             chartOptions={chartOptions}

--- a/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/ThematicMap/index.tsx
@@ -7,7 +7,6 @@ import {
   createThematicMapChartOptions,
   thematicMapTitle,
 } from '@/components/organisms/ThematicMap/thematicMapHelpers';
-import { BenchmarkLegend } from '../BenchmarkLegend';
 import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client/models/BenchmarkComparisonMethod';
 import { IndicatorPolarity } from '@/generated-sources/ft-api-client/models/IndicatorPolarity';
 import { IndicatorDocument } from '@/lib/search/searchTypes';


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-903](https://bjss-enterprise.atlassian.net/browse/DHSCFT-903)

Add our bespoke benchmark legend into the svg export of the charts

## Changes

- Create an SVG version of the Benchmark Legend
- Modify the export function to create a new svg containing the legend and the chart's own svg
- Extracted the svg export helpers into their own files with separate tests
- Refiled benchmarkLegends

## Validation

<img width="862" alt="image" src="https://github.com/user-attachments/assets/85a2406b-3738-47db-a83c-0bf375f08cf4" />

<img width="808" alt="image" src="https://github.com/user-attachments/assets/e77b6884-81a4-494b-a3c3-d363d20070be" />


Hidden svg implementation of the legend...
<img width="742" alt="image" src="https://github.com/user-attachments/assets/a5e13c9e-5924-44f8-b932-dfb7cbaaab77" />
