### PR TITLE
DHSCFT-996: Modularity oneIndicatorOneView remove searchState from props

### DIFF
--- a/frontend/fingertips-frontend/components/hooks/useSearchStateParams.test.ts
+++ b/frontend/fingertips-frontend/components/hooks/useSearchStateParams.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { SearchParams } from '@/lib/searchStateManager';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+const mockUseSearchParams = jest.requireMock('next/navigation').useSearchParams;
+
+describe('useSearchStateParams', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return correct values for both single and multi-value params', () => {
+    const mockParams = new URLSearchParams();
+    mockParams.set(SearchParams.SearchedIndicator, 'test');
+    mockParams.append(SearchParams.AreasSelected, 'a1');
+    mockParams.append(SearchParams.AreasSelected, 'a2');
+
+    mockUseSearchParams.mockReturnValue(mockParams);
+
+    const { result } = renderHook(() => useSearchStateParams());
+
+    expect(result.current[SearchParams.SearchedIndicator]).toBe('test');
+    expect(result.current[SearchParams.AreasSelected]).toEqual(['a1', 'a2']);
+  });
+
+  it('should handle missing params gracefully', () => {
+    const mockParams = new URLSearchParams();
+    mockUseSearchParams.mockReturnValue(mockParams);
+
+    const { result } = renderHook(() => useSearchStateParams());
+
+    Object.values(SearchParams).forEach((key) => {
+      if (Array.isArray(result.current[key])) {
+        expect(result.current[key]).toEqual([]);
+      } else {
+        expect(result.current[key]).toBeUndefined();
+      }
+    });
+  });
+});

--- a/frontend/fingertips-frontend/components/hooks/useSearchStateParams.ts
+++ b/frontend/fingertips-frontend/components/hooks/useSearchStateParams.ts
@@ -1,0 +1,21 @@
+import { useSearchParams } from 'next/navigation';
+import {
+  isMultiValueTypeParam,
+  SearchParams,
+  SearchStateParams,
+} from '@/lib/searchStateManager';
+
+export const useSearchStateParams = (): SearchStateParams => {
+  const search = useSearchParams() ?? new URLSearchParams();
+
+  const searchStateParams: SearchStateParams = {};
+  Object.values(SearchParams).forEach((key) => {
+    if (isMultiValueTypeParam(key)) {
+      searchStateParams[key] = search.getAll(key);
+    } else {
+      searchStateParams[key] = search.get(key) ?? undefined;
+    }
+  });
+
+  return searchStateParams;
+};

--- a/frontend/fingertips-frontend/components/molecules/BenchmarkSelectArea/BenchmarkSelectArea.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/BenchmarkSelectArea/BenchmarkSelectArea.test.tsx
@@ -56,7 +56,6 @@ describe('BenchmarkSelectArea', () => {
       <BenchmarkSelectArea
         availableAreas={mockAvailableAreas}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={{}}
       />
     );
 
@@ -77,7 +76,6 @@ describe('BenchmarkSelectArea', () => {
       <BenchmarkSelectArea
         availableAreas={mockAvailableAreas}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={{ [SearchParams.InequalityBarChartAreaSelected]: 'A002' }}
       />
     );
 
@@ -99,7 +97,6 @@ describe('BenchmarkSelectArea', () => {
       <BenchmarkSelectArea
         availableAreas={mockAvailableAreas}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={{}}
       />
     );
 

--- a/frontend/fingertips-frontend/components/molecules/BenchmarkSelectArea/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/BenchmarkSelectArea/index.tsx
@@ -1,25 +1,21 @@
-import {
-  SearchParamKeys,
-  SearchStateManager,
-  SearchStateParams,
-} from '@/lib/searchStateManager';
+import { SearchParamKeys, SearchStateManager } from '@/lib/searchStateManager';
 import { useLoadingState } from '@/context/LoaderContext';
 import { usePathname, useRouter } from 'next/navigation';
 import { StyledFilterSelect } from '@/components/styles/StyledFilterSelect';
 import { AreaWithoutAreaType } from '@/lib/common-types';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface BenchmarkSelectAreaProps {
   availableAreas: AreaWithoutAreaType[];
   benchmarkAreaSelectedKey: SearchParamKeys;
-  searchState: SearchStateParams;
 }
 
 export function BenchmarkSelectArea({
   availableAreas,
   benchmarkAreaSelectedKey,
-  searchState,
 }: Readonly<BenchmarkSelectAreaProps>) {
+  const searchState = useSearchStateParams();
   const pathname = usePathname();
   const { replace } = useRouter();
   const { setIsLoading } = useLoadingState();

--- a/frontend/fingertips-frontend/components/molecules/ChartSelectArea/ChartSelectArea.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ChartSelectArea/ChartSelectArea.test.tsx
@@ -56,7 +56,6 @@ describe('ChartSelectArea', () => {
       <ChartSelectArea
         availableAreas={mockAvailableAreas}
         chartAreaSelectedKey={SearchParams.InequalityBarChartAreaSelected}
-        searchState={{}}
       />
     );
 
@@ -77,7 +76,6 @@ describe('ChartSelectArea', () => {
       <ChartSelectArea
         availableAreas={mockAvailableAreas}
         chartAreaSelectedKey={SearchParams.InequalityBarChartAreaSelected}
-        searchState={{ [SearchParams.InequalityBarChartAreaSelected]: 'A002' }}
       />
     );
 
@@ -99,7 +97,6 @@ describe('ChartSelectArea', () => {
       <ChartSelectArea
         availableAreas={mockAvailableAreas}
         chartAreaSelectedKey={SearchParams.InequalityLineChartAreaSelected}
-        searchState={{}}
       />
     );
 

--- a/frontend/fingertips-frontend/components/molecules/ChartSelectArea/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/ChartSelectArea/index.tsx
@@ -1,28 +1,24 @@
-import {
-  SearchParamKeys,
-  SearchStateManager,
-  SearchStateParams,
-} from '@/lib/searchStateManager';
+import { SearchParamKeys, SearchStateManager } from '@/lib/searchStateManager';
 import { useLoadingState } from '@/context/LoaderContext';
 import { usePathname, useRouter } from 'next/navigation';
 import { StyledFilterSelect } from '@/components/styles/StyledFilterSelect';
 import { AreaWithoutAreaType } from '@/lib/common-types';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface ChartSelectAreaProps {
   availableAreas: AreaWithoutAreaType[];
   chartAreaSelectedKey: SearchParamKeys;
-  searchState: SearchStateParams;
 }
 
 export function ChartSelectArea({
   availableAreas,
   chartAreaSelectedKey,
-  searchState,
 }: Readonly<ChartSelectAreaProps>) {
   const pathname = usePathname();
   const { replace } = useRouter();
   const { setIsLoading } = useLoadingState();
 
+  const searchState = useSearchStateParams();
   const searchStateManager = SearchStateManager.initialise(searchState);
 
   const chartAreaTypeSelected = (valueSelected: string) => {

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/index.tsx
@@ -17,7 +17,7 @@ import {
   sequenceSelectorForInequality,
   valueSelectorForInequality,
 } from '@/components/organisms/Inequalities/inequalitiesHelpers';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
 import {
   BenchmarkComparisonMethod,
   HealthDataForArea,
@@ -32,10 +32,10 @@ import { InequalitiesTypesDropDown } from '../InequalitiesTypesDropDown';
 import { DataSource } from '@/components/atoms/DataSource/DataSource';
 import { StyleChartWrapper } from '@/components/styles/viewPlotStyles/styleChartWrapper';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface InequalitiesForSingleTimePeriodProps {
   healthIndicatorData: HealthDataForArea[];
-  searchState: SearchStateParams;
   indicatorMetadata?: IndicatorDocument;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   polarity?: IndicatorPolarity;
@@ -44,7 +44,6 @@ interface InequalitiesForSingleTimePeriodProps {
 
 export function InequalitiesForSingleTimePeriod({
   healthIndicatorData,
-  searchState,
   indicatorMetadata,
   benchmarkComparisonMethod,
   polarity,
@@ -56,7 +55,7 @@ export function InequalitiesForSingleTimePeriod({
     [SearchParams.InequalityBarChartTypeSelected]: inequalityTypeSelected,
     [SearchParams.InequalityBarChartAreaSelected]:
       inequalityBarChartAreaSelected,
-  } = searchState;
+  } = useSearchStateParams();
 
   const healthdataWithoutGroup = seriesDataWithoutGroup(
     healthIndicatorData,
@@ -139,19 +138,17 @@ export function InequalitiesForSingleTimePeriod({
   return (
     <StyleChartWrapper data-testid="inequalitiesForSingleTimePeriod-component">
       <H3>Inequalities data for a single time period</H3>
-      <TimePeriodDropDown years={yearsDesc} searchState={searchState} />
+      <TimePeriodDropDown years={yearsDesc} />
       <InequalitiesTypesDropDown
         inequalitiesOptions={inequalityCategories}
         inequalityTypeSelectedSearchParam={
           SearchParams.InequalityBarChartTypeSelected
         }
         testRef="bc"
-        searchState={searchState}
       />
       <ChartSelectArea
         availableAreas={availableAreasWithInequalities}
         chartAreaSelectedKey={SearchParams.InequalityBarChartAreaSelected}
-        searchState={searchState}
       />
       <TabContainer
         id="inequalitiesBarChartAndTable"

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/inequalitiesForSingleTimePeriod.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesForSingleTimePeriod/inequalitiesForSingleTimePeriod.test.tsx
@@ -2,8 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { InequalitiesForSingleTimePeriod } from '.';
 import { MOCK_HEALTH_DATA } from '@/lib/tableHelpers/mocks';
-import { SearchStateContext } from '@/context/SearchStateContext';
-import { SearchParams } from '@/lib/searchStateManager';
 import {
   HealthDataForArea,
   HealthDataPointTrendEnum,
@@ -36,20 +34,6 @@ jest.mock('@/context/LoaderContext', () => {
     useLoadingState: () => mockLoaderContext,
   };
 });
-
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
-  };
-});
-
-const mockSearchState = {
-  [SearchParams.InequalityYearSelected]: '2008',
-};
 
 describe('InequalitiesForSingleTimePeriod suite', () => {
   it('should render expected elements', async () => {
@@ -93,7 +77,6 @@ describe('InequalitiesForSingleTimePeriod suite', () => {
     render(
       <InequalitiesForSingleTimePeriod
         healthIndicatorData={[mockHealthData]}
-        searchState={mockSearchState}
         dataSource={'inequalities data source'}
       />
     );
@@ -160,10 +143,7 @@ describe('InequalitiesForSingleTimePeriod suite', () => {
     };
 
     render(
-      <InequalitiesForSingleTimePeriod
-        healthIndicatorData={[mockHealthData]}
-        searchState={mockSearchState}
-      />
+      <InequalitiesForSingleTimePeriod healthIndicatorData={[mockHealthData]} />
     );
 
     expect(

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/index.tsx
@@ -7,11 +7,7 @@ import {
   BenchmarkOutcome,
   HealthDataForArea,
 } from '@/generated-sources/ft-api-client';
-import {
-  SearchParams,
-  SearchStateManager,
-  SearchStateParams,
-} from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
 import {
   generateInequalitiesLineChartOptions,
   getDynamicKeys,
@@ -45,10 +41,10 @@ import { DataSource } from '@/components/atoms/DataSource/DataSource';
 import { StyleChartWrapper } from '@/components/styles/viewPlotStyles/styleChartWrapper';
 import { LineChartVariant } from '@/components/organisms/LineChart/helpers/generateStandardLineChartOptions';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface InequalitiesTrendProps {
   healthIndicatorData: HealthDataForArea[];
-  searchState: SearchStateParams;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   indicatorMetadata?: IndicatorDocument;
   dataSource?: string;
@@ -66,18 +62,16 @@ const getBenchmarkOutcomeForYear = (
 export function InequalitiesTrend({
   healthIndicatorData,
   indicatorMetadata,
-  searchState,
   benchmarkComparisonMethod,
   dataSource,
 }: Readonly<InequalitiesTrendProps>) {
-  const stateManager = SearchStateManager.initialise(searchState);
   const {
     [SearchParams.GroupSelected]: selectedGroupCode,
     [SearchParams.AreasSelected]: areasSelected,
     [SearchParams.InequalityLineChartTypeSelected]: inequalityTypeSelected,
     [SearchParams.InequalityLineChartAreaSelected]:
       inequalityLineChartAreaSelected,
-  } = stateManager.getSearchState();
+  } = useSearchStateParams();
 
   const areaCodes = determineAreaCodes(areasSelected);
 
@@ -215,12 +209,10 @@ export function InequalitiesTrend({
           SearchParams.InequalityLineChartTypeSelected
         }
         testRef="lc"
-        searchState={searchState}
       />
       <ChartSelectArea
         availableAreas={availableAreasWithInequalities}
         chartAreaSelectedKey={SearchParams.InequalityLineChartAreaSelected}
-        searchState={searchState}
       />
       <TabContainer
         id="inequalitiesLineChartAndTable"

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/inequalitiesTrend.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTrend/inequalitiesTrend.test.tsx
@@ -1,10 +1,8 @@
 import { render, screen, within } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { InequalitiesTrend } from '.';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { MOCK_HEALTH_DATA } from '@/lib/tableHelpers/mocks';
 import { LoaderContext } from '@/context/LoaderContext';
-import { SearchStateContext } from '@/context/SearchStateContext';
 import {
   HealthDataForArea,
   HealthDataPointTrendEnum,
@@ -35,20 +33,6 @@ jest.mock('@/context/LoaderContext', () => {
     useLoadingState: () => mockLoaderContext,
   };
 });
-
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
-  };
-});
-
-const state: SearchStateParams = {
-  [SearchParams.InequalityLineChartTypeSelected]: 'Sex',
-};
 
 describe('InequalitiesTrend suite', () => {
   it('should render expected elements', async () => {
@@ -96,7 +80,6 @@ describe('InequalitiesTrend suite', () => {
     render(
       <InequalitiesTrend
         healthIndicatorData={mockHealthData}
-        searchState={state}
         dataSource="inequalities data source"
       />
     );
@@ -151,12 +134,7 @@ describe('InequalitiesTrend suite', () => {
       healthData: MOCK_HEALTH_DATA[0].healthData.slice(0, 2),
     };
 
-    render(
-      <InequalitiesTrend
-        healthIndicatorData={[mockHealthData]}
-        searchState={state}
-      />
-    );
+    render(<InequalitiesTrend healthIndicatorData={[mockHealthData]} />);
 
     expect(
       screen.queryByTestId('inequalitiesTrend-component')
@@ -169,12 +147,7 @@ describe('InequalitiesTrend suite', () => {
       healthData: [MOCK_HEALTH_DATA[0].healthData[0]],
     };
 
-    render(
-      <InequalitiesTrend
-        healthIndicatorData={[mockHealthData]}
-        searchState={state}
-      />
-    );
+    render(<InequalitiesTrend healthIndicatorData={[mockHealthData]} />);
 
     expect(
       screen.queryByTestId('inequalitiesTrend-component')

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTypesDropDown/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTypesDropDown/index.tsx
@@ -1,27 +1,23 @@
 import { StyledFilterSelect } from '@/components/styles/StyledFilterSelect';
-import {
-  SearchParamKeys,
-  SearchStateManager,
-  SearchStateParams,
-} from '@/lib/searchStateManager';
+import { SearchParamKeys, SearchStateManager } from '@/lib/searchStateManager';
 import { usePathname, useRouter } from 'next/navigation';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface InequalitiesTypeDropDownProps {
   inequalitiesOptions: string[];
   inequalityTypeSelectedSearchParam: SearchParamKeys;
   testRef: string;
-  searchState: SearchStateParams;
 }
 
 export function InequalitiesTypesDropDown({
   inequalitiesOptions,
   inequalityTypeSelectedSearchParam,
   testRef,
-  searchState,
 }: Readonly<InequalitiesTypeDropDownProps>) {
   const pathname = usePathname();
   const { replace } = useRouter();
 
+  const searchState = useSearchStateParams();
   const searchStateManager = SearchStateManager.initialise(searchState);
 
   const setSelectedType = (selectedType: string) => {

--- a/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTypesDropDown/inequalitiesTypesDropDown.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Inequalities/InequalitiesTypesDropDown/inequalitiesTypesDropDown.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import { InequalitiesTypesDropDown } from '.';
 import { SearchParams } from '@/lib/searchStateManager';
 import userEvent from '@testing-library/user-event';
-import { SearchStateContext } from '@/context/SearchStateContext';
 
 const mockPath = 'some-mock-path';
 const mockReplace = jest.fn();
@@ -24,16 +23,9 @@ const mockSearchState = {
   [SearchParams.InequalityLineChartTypeSelected]: 'Sex',
   [SearchParams.InequalityBarChartTypeSelected]: 'Sex',
 };
-
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
-  };
-});
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => mockSearchState,
+}));
 
 describe('InequalitiesTypesDropDown suite', () => {
   const options = ['deprivation1', 'deprivation2', 'deprivation3', 'Sex'];
@@ -46,7 +38,6 @@ describe('InequalitiesTypesDropDown suite', () => {
           SearchParams.InequalityBarChartTypeSelected
         }
         testRef="bc"
-        searchState={mockSearchState}
       />
     );
     const dropDown = screen.getByRole('combobox');
@@ -74,7 +65,6 @@ describe('InequalitiesTypesDropDown suite', () => {
           SearchParams.InequalityLineChartTypeSelected
         }
         testRef="lc"
-        searchState={mockSearchState}
       />
     );
 
@@ -84,9 +74,8 @@ describe('InequalitiesTypesDropDown suite', () => {
   });
 
   it('should select option specified in searchState', async () => {
-    const mockSearchState = {
-      [SearchParams.InequalityLineChartTypeSelected]: 'deprivation3',
-    };
+    mockSearchState[SearchParams.InequalityLineChartTypeSelected] =
+      'deprivation3';
 
     render(
       <InequalitiesTypesDropDown
@@ -95,7 +84,6 @@ describe('InequalitiesTypesDropDown suite', () => {
           SearchParams.InequalityLineChartTypeSelected
         }
         testRef="bc"
-        searchState={mockSearchState}
       />
     );
 

--- a/frontend/fingertips-frontend/components/molecules/TimePeriodDropDown/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/TimePeriodDropDown/index.tsx
@@ -1,25 +1,21 @@
 import { StyledFilterSelect } from '@/components/styles/StyledFilterSelect';
 import { useLoadingState } from '@/context/LoaderContext';
-import {
-  SearchParams,
-  SearchStateManager,
-  SearchStateParams,
-} from '@/lib/searchStateManager';
+import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
 import { usePathname, useRouter } from 'next/navigation';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface TimePeriodDropDownProps {
   years: (number | string)[];
-  searchState: SearchStateParams;
 }
 
 export function TimePeriodDropDown({
   years,
-  searchState,
 }: Readonly<TimePeriodDropDownProps>) {
   const pathname = usePathname();
   const { replace } = useRouter();
   const { setIsLoading } = useLoadingState();
 
+  const searchState = useSearchStateParams();
   const searchStateManager = SearchStateManager.initialise(searchState);
 
   const setSelectedYear = (selectedYear: string) => {

--- a/frontend/fingertips-frontend/components/molecules/TimePeriodDropDown/timePeriodDropDown.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/TimePeriodDropDown/timePeriodDropDown.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import { TimePeriodDropDown } from '.';
 import { SearchParams } from '@/lib/searchStateManager';
 import userEvent from '@testing-library/user-event';
-import { SearchStateContext } from '@/context/SearchStateContext';
 import { LoaderContext } from '@/context/LoaderContext';
 
 const mockPath = 'some-mock-path';
@@ -32,25 +31,11 @@ jest.mock('@/context/LoaderContext', () => {
   };
 });
 
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
-  };
-});
-
-const mockSearchState = {
-  [SearchParams.InequalityYearSelected]: '2023',
-};
-
 const years = ['2023', '2022', '2021', '2020'];
 
 describe('TimePeriodDropDown suite', () => {
   it('should display expected elements', () => {
-    render(<TimePeriodDropDown years={years} searchState={mockSearchState} />);
+    render(<TimePeriodDropDown years={years} />);
     const dropDown = screen.getByRole('combobox');
     const yearOptions = within(dropDown).getAllByRole('option');
 
@@ -69,7 +54,7 @@ describe('TimePeriodDropDown suite', () => {
     ].join('');
 
     const user = userEvent.setup();
-    render(<TimePeriodDropDown years={years} searchState={mockSearchState} />);
+    render(<TimePeriodDropDown years={years} />);
 
     await user.selectOptions(screen.getByRole('combobox'), '2022');
 
@@ -83,16 +68,7 @@ describe('TimePeriodDropDown suite', () => {
     ].join('');
 
     const user = userEvent.setup();
-    render(
-      <TimePeriodDropDown
-        years={years}
-        searchState={{
-          ...mockSearchState,
-          [SearchParams.InequalityBarChartTypeSelected]: 'some type',
-          [SearchParams.InequalityBarChartAreaSelected]: 'A001',
-        }}
-      />
-    );
+    render(<TimePeriodDropDown years={years} />);
 
     await user.selectOptions(screen.getByRole('combobox'), '2022');
 

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/index.tsx
@@ -5,13 +5,11 @@ import {
 } from '@/generated-sources/ft-api-client';
 import { InequalitiesForSingleTimePeriod } from '@/components/molecules/Inequalities/InequalitiesForSingleTimePeriod';
 import { InequalitiesTrend } from '@/components/molecules/Inequalities/InequalitiesTrend';
-import { SearchStateParams } from '@/lib/searchStateManager';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 
 interface InequalitiesProps {
   healthIndicatorData: HealthDataForArea[];
   indicatorMetadata?: IndicatorDocument;
-  searchState: SearchStateParams;
   benchmarkComparisonMethod?: BenchmarkComparisonMethod;
   polarity?: IndicatorPolarity;
   dataSource?: string;
@@ -20,7 +18,6 @@ interface InequalitiesProps {
 export function Inequalities({
   healthIndicatorData,
   indicatorMetadata,
-  searchState,
   benchmarkComparisonMethod = BenchmarkComparisonMethod.Unknown,
   polarity = IndicatorPolarity.Unknown,
   dataSource,
@@ -29,7 +26,6 @@ export function Inequalities({
     <div data-testid="inequalities-component">
       <InequalitiesForSingleTimePeriod
         healthIndicatorData={healthIndicatorData}
-        searchState={searchState}
         indicatorMetadata={indicatorMetadata}
         benchmarkComparisonMethod={benchmarkComparisonMethod}
         polarity={polarity}
@@ -38,7 +34,6 @@ export function Inequalities({
       <InequalitiesTrend
         healthIndicatorData={healthIndicatorData}
         indicatorMetadata={indicatorMetadata}
-        searchState={searchState}
         benchmarkComparisonMethod={benchmarkComparisonMethod}
         dataSource={dataSource}
       />

--- a/frontend/fingertips-frontend/components/organisms/Inequalities/inequalities.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/Inequalities/inequalities.test.tsx
@@ -2,16 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { Inequalities } from '.';
 import { MOCK_HEALTH_DATA } from '@/lib/tableHelpers/mocks';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
-import { SearchStateContext } from '@/context/SearchStateContext';
 import { LoaderContext } from '@/context/LoaderContext';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
-
-const state: SearchStateParams = {
-  [SearchParams.SearchedIndicator]: 'testing',
-  [SearchParams.IndicatorsSelected]: ['333'],
-  [SearchParams.AreasSelected]: ['A1245'],
-};
 
 const mockLoaderContext: LoaderContext = {
   getIsLoading: jest.fn(),
@@ -20,16 +12,6 @@ const mockLoaderContext: LoaderContext = {
 jest.mock('@/context/LoaderContext', () => {
   return {
     useLoadingState: () => mockLoaderContext,
-  };
-});
-
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
   };
 });
 
@@ -51,12 +33,7 @@ jest.mock('next/navigation', () => {
 
 describe('Inequalities suite', () => {
   it('should render inequalities component', async () => {
-    render(
-      <Inequalities
-        healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
-      />
-    );
+    render(<Inequalities healthIndicatorData={MOCK_HEALTH_DATA} />);
 
     await waitFor(async () => {
       expect(screen.getByTestId('inequalities-component')).toBeInTheDocument();
@@ -82,12 +59,7 @@ describe('Inequalities suite', () => {
   });
 
   it('should render expected text', async () => {
-    render(
-      <Inequalities
-        healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
-      />
-    );
+    render(<Inequalities healthIndicatorData={MOCK_HEALTH_DATA} />);
 
     expect(
       await screen.findByText(/Inequalities data for a single time period/i)
@@ -101,7 +73,6 @@ describe('Inequalities suite', () => {
     render(
       <Inequalities
         healthIndicatorData={MOCK_HEALTH_DATA}
-        searchState={state}
         indicatorMetadata={{ unitLabel: 'kg' } as IndicatorDocument}
       />
     );

--- a/frontend/fingertips-frontend/components/organisms/PopulationPyramidWithTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/PopulationPyramidWithTable/index.tsx
@@ -117,7 +117,6 @@ export const PopulationPyramidWithTable = ({
             <ChartSelectArea
               availableAreas={availableAreas}
               chartAreaSelectedKey={SearchParams.PopulationAreaSelected}
-              searchState={searchState}
             />
             <TabContainer
               id="pyramidChartAndTableView"

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/OneIndicatorOneAreaViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/OneIndicatorOneAreaViewPlots.test.tsx
@@ -1,10 +1,8 @@
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
 import { OneIndicatorOneAreaViewPlots } from '.';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { IndicatorWithHealthDataForArea } from '@/generated-sources/ft-api-client';
-import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
-import { SearchStateContext } from '@/context/SearchStateContext';
 import { LoaderContext } from '@/context/LoaderContext';
 
 jest.mock('next/navigation', () => {
@@ -27,16 +25,6 @@ jest.mock('@/context/LoaderContext', () => {
   };
 });
 
-const mockSearchStateContext: SearchStateContext = {
-  getSearchState: jest.fn(),
-  setSearchState: jest.fn(),
-};
-jest.mock('@/context/SearchStateContext', () => {
-  return {
-    useSearchState: () => mockSearchStateContext,
-  };
-});
-
 const mockMetaData = {
   indicatorID: '108',
   indicatorName: 'pancakes eaten',
@@ -52,12 +40,13 @@ const mockMetaData = {
 const mockSearch = 'test';
 const mockIndicator = ['108'];
 const mockAreas = ['A001'];
-
-const searchState: SearchStateParams = {
-  [SearchParams.SearchedIndicator]: mockSearch,
-  [SearchParams.IndicatorsSelected]: mockIndicator,
-  [SearchParams.AreasSelected]: mockAreas,
-};
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => ({
+    [SearchParams.SearchedIndicator]: mockSearch,
+    [SearchParams.IndicatorsSelected]: mockIndicator,
+    [SearchParams.AreasSelected]: mockAreas,
+  }),
+}));
 
 const testHealthData: IndicatorWithHealthDataForArea = {
   areaHealthData: [mockHealthData['108'][0], mockHealthData['108'][1]],
@@ -73,7 +62,6 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={testHealthData}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -100,7 +88,6 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={testHealthData}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -128,21 +115,10 @@ describe('OneIndicatorOneAreaViewPlots', () => {
   });
 
   it('should render the LineChart components in the special case that England is the only area', async () => {
-    const mockSearch = 'test';
-    const mockIndicator = ['108'];
-    const mockAreas = [areaCodeForEngland];
-
-    const searchState: SearchStateParams = {
-      [SearchParams.SearchedIndicator]: mockSearch,
-      [SearchParams.IndicatorsSelected]: mockIndicator,
-      [SearchParams.AreasSelected]: mockAreas,
-    };
-
     await act(() =>
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={{ areaHealthData: [mockHealthData['108'][0]] }}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -177,7 +153,6 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={testHealthData}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -203,7 +178,6 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={MOCK_DATA}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -232,7 +206,6 @@ describe('OneIndicatorOneAreaViewPlots', () => {
       render(
         <OneIndicatorOneAreaViewPlots
           indicatorData={testHealthData}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       )

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorOneAreaViewPlots/index.tsx
@@ -28,6 +28,7 @@ import {
   LineChartVariant,
 } from '@/components/organisms/LineChart/helpers/generateStandardLineChartOptions';
 import Highcharts from 'highcharts';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 function shouldLineChartBeShown(
   dataWithoutEnglandOrGroup: HealthDataForArea[],
@@ -41,14 +42,13 @@ function shouldLineChartBeShown(
 
 export function OneIndicatorOneAreaViewPlots({
   indicatorData,
-  searchState,
   indicatorMetadata,
 }: Readonly<OneIndicatorViewPlotProps>) {
   const {
     [SearchParams.GroupSelected]: selectedGroupCode,
     [SearchParams.AreasSelected]: areasSelected,
     [SearchParams.BenchmarkAreaSelected]: benchmarkAreaSelected,
-  } = searchState;
+  } = useSearchStateParams();
 
   const areaCodes = determineAreaCodes(areasSelected);
 
@@ -116,7 +116,6 @@ export function OneIndicatorOneAreaViewPlots({
       <BenchmarkSelectArea
         availableAreas={availableAreasForBenchmarking}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={searchState}
       />
       {shouldLineChartBeShown(
         areaDataWithoutInequalities,
@@ -161,7 +160,6 @@ export function OneIndicatorOneAreaViewPlots({
       )}
       <Inequalities
         healthIndicatorData={healthIndicatorData}
-        searchState={searchState}
         indicatorMetadata={indicatorMetadata}
         benchmarkComparisonMethod={benchmarkComparisonMethod}
         polarity={polarity}

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/OneIndicatorTwoOrMoreAreasViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/OneIndicatorTwoOrMoreAreasViewPlots.test.tsx
@@ -66,10 +66,10 @@ const testHealthData: IndicatorWithHealthDataForArea = {
   areaHealthData: [mockHealthData['108'][1], mockHealthData['108'][2]],
 };
 
-const searchState: SearchStateParams = {
-  [SearchParams.SearchedIndicator]: mockSearch,
-  [SearchParams.IndicatorsSelected]: mockIndicator,
-};
+const mockSearchState: SearchStateParams = {};
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => mockSearchState,
+}));
 
 const lineChartTestId = 'standardLineChart-component';
 const lineChartTableTestId = 'lineChartTable-component';
@@ -106,6 +106,9 @@ const assertLineChartAndTableNotInDocument = async () => {
 describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchState[SearchParams.SearchedIndicator] = mockSearch;
+    mockSearchState[SearchParams.IndicatorsSelected] = mockIndicator;
+    mockSearchState[SearchParams.AreasSelected] = mockAreas;
   });
 
   afterAll(() => {
@@ -117,10 +120,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
       render(
         <OneIndicatorTwoOrMoreAreasViewPlots
           indicatorData={testHealthData}
-          searchState={{
-            ...searchState,
-            [SearchParams.AreasSelected]: mockAreas,
-          }}
           indicatorMetadata={mockMetaData}
         />
       )
@@ -147,10 +146,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
       render(
         <OneIndicatorTwoOrMoreAreasViewPlots
           indicatorData={testHealthData}
-          searchState={{
-            ...searchState,
-            [SearchParams.AreasSelected]: mockAreas,
-          }}
           indicatorMetadata={mockMetaData}
         />
       );
@@ -161,10 +156,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
       render(
         <OneIndicatorTwoOrMoreAreasViewPlots
           indicatorData={testHealthData}
-          searchState={{
-            ...searchState,
-            [SearchParams.AreasSelected]: mockAreas,
-          }}
           indicatorMetadata={mockMetaData}
         />
       );
@@ -185,32 +176,19 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
         ],
       };
 
-      const state: SearchStateParams = {
-        [SearchParams.IndicatorsSelected]: ['0'],
-        [SearchParams.AreasSelected]: ['A001'],
-      };
+      mockSearchState[SearchParams.SearchedIndicator] = undefined;
 
-      render(
-        <OneIndicatorTwoOrMoreAreasViewPlots
-          indicatorData={MOCK_DATA}
-          searchState={state}
-        />
-      );
+      render(<OneIndicatorTwoOrMoreAreasViewPlots indicatorData={MOCK_DATA} />);
 
       await waitFor(() => assertLineChartAndTableNotInDocument());
     });
 
     it('should not render the LineChart components when there are more than 2 areas', async () => {
-      const searchState: SearchStateParams = {
-        [SearchParams.SearchedIndicator]: mockSearch,
-        [SearchParams.IndicatorsSelected]: mockIndicator,
-        [SearchParams.AreasSelected]: [...mockAreas, 'A003'],
-      };
+      mockSearchState[SearchParams.AreasSelected] = [...mockAreas, 'A003'];
 
       render(
         <OneIndicatorTwoOrMoreAreasViewPlots
           indicatorData={testHealthData}
-          searchState={searchState}
           indicatorMetadata={mockMetaData}
         />
       );
@@ -221,17 +199,10 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
 
   describe('BarChartEmbeddedTable', () => {
     it('should render the BarChartEmbeddedTable component, when two or more areas are selected', async () => {
-      const searchState: SearchStateParams = {
-        [SearchParams.SearchedIndicator]: mockSearch,
-        [SearchParams.IndicatorsSelected]: mockIndicator,
-        [SearchParams.AreasSelected]: ['A1245', 'A1246', 'A1427'],
-      };
+      mockSearchState[SearchParams.AreasSelected] = ['A1245', 'A1246', 'A1427'];
 
       render(
-        <OneIndicatorTwoOrMoreAreasViewPlots
-          indicatorData={testHealthData}
-          searchState={searchState}
-        />
+        <OneIndicatorTwoOrMoreAreasViewPlots indicatorData={testHealthData} />
       );
 
       expect(
@@ -240,17 +211,9 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
     });
 
     it('should render the title for BarChartEmbeddedTable', async () => {
-      const searchState: SearchStateParams = {
-        [SearchParams.SearchedIndicator]: mockSearch,
-        [SearchParams.IndicatorsSelected]: mockIndicator,
-        [SearchParams.AreasSelected]: ['A1245', 'A1246', 'A1427'],
-      };
-
+      mockSearchState[SearchParams.AreasSelected] = ['A1245', 'A1246', 'A1427'];
       render(
-        <OneIndicatorTwoOrMoreAreasViewPlots
-          indicatorData={testHealthData}
-          searchState={searchState}
-        />
+        <OneIndicatorTwoOrMoreAreasViewPlots indicatorData={testHealthData} />
       );
 
       expect(
@@ -265,6 +228,13 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
       mockGetSearchState.mockReturnValue({
         [SearchParams.AreaTypeSelected]: 'regions',
       });
+
+      mockSearchState[SearchParams.SearchedIndicator] = mockSearch;
+      mockSearchState[SearchParams.IndicatorsSelected] = mockIndicator;
+      mockSearchState[SearchParams.AreasSelected] = mockAreas;
+      mockSearchState[SearchParams.GroupAreaSelected] = ALL_AREAS_SELECTED;
+      mockSearchState[SearchParams.AreaTypeSelected] = 'regions';
+      mockSearchState[SearchParams.GroupSelected] = 'E12000003';
     });
 
     it('should render the ThematicMap with title', async () => {
@@ -272,14 +242,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
         ok: true,
         json: async () => regionsMap,
       });
-
-      const searchState: SearchStateParams = {
-        [SearchParams.GroupAreaSelected]: ALL_AREAS_SELECTED,
-        [SearchParams.AreaTypeSelected]: 'regions',
-        [SearchParams.GroupSelected]: 'E12000003',
-      };
-
-      mockGetSearchState.mockReturnValue(searchState);
 
       render(
         <QueryClientProvider client={reactQueryClient}>
@@ -291,7 +253,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
                 mockHealthData[108][3],
               ],
             }}
-            searchState={searchState}
             areaCodes={['E12000001', 'E12000002']}
             indicatorMetadata={mockIndicatorDocument()}
           />
@@ -310,12 +271,7 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
     });
 
     it('should not render the ThematicMap when not all areas in a group are selected', async () => {
-      const searchState: SearchStateParams = {
-        [SearchParams.GroupAreaSelected]: 'not ALL',
-        [SearchParams.AreaTypeSelected]: 'regions',
-      };
-
-      mockGetSearchState.mockReturnValue(searchState);
+      mockSearchState[SearchParams.GroupAreaSelected] = 'not_all';
 
       render(
         <OneIndicatorTwoOrMoreAreasViewPlots
@@ -326,7 +282,6 @@ describe('OneIndicatorTwoOrMoreAreasViewPlots', () => {
               mockHealthData[108][3],
             ],
           }}
-          searchState={searchState}
         />
       );
 

--- a/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/OneIndicatorTwoOrMoreAreasViewPlots/index.tsx
@@ -15,8 +15,6 @@ import { H3 } from 'govuk-react';
 import { OneIndicatorViewPlotProps } from '@/components/viewPlots/ViewPlot.types';
 import { ThematicMap } from '@/components/organisms/ThematicMap';
 import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
-import { useEffect } from 'react';
-import { useSearchState } from '@/context/SearchStateContext';
 import { BenchmarkComparisonMethod } from '@/generated-sources/ft-api-client/models/BenchmarkComparisonMethod';
 import { IndicatorPolarity } from '@/generated-sources/ft-api-client';
 import { DataSource } from '@/components/atoms/DataSource/DataSource';
@@ -26,6 +24,7 @@ import {
   LineChartVariant,
 } from '@/components/organisms/LineChart/helpers/generateStandardLineChartOptions';
 import { BenchmarkSelectArea } from '@/components/molecules/BenchmarkSelectArea';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 interface OneIndicatorTwoOrMoreAreasViewPlotsProps
   extends OneIndicatorViewPlotProps {
@@ -35,14 +34,14 @@ interface OneIndicatorTwoOrMoreAreasViewPlotsProps
 export function OneIndicatorTwoOrMoreAreasViewPlots({
   indicatorData,
   indicatorMetadata,
-  searchState,
   areaCodes = [],
 }: Readonly<OneIndicatorTwoOrMoreAreasViewPlotsProps>) {
-  const { setSearchState } = useSearchState();
-
-  useEffect(() => {
-    setSearchState(searchState ?? {});
-  }, [searchState, setSearchState]);
+  const searchState = useSearchStateParams();
+  // const { setSearchState } = useSearchState();
+  //
+  // useEffect(() => {
+  //   setSearchState(searchState ?? {});
+  // }, [searchState, setSearchState]);
 
   const {
     [SearchParams.GroupSelected]: selectedGroupCode,
@@ -112,7 +111,6 @@ export function OneIndicatorTwoOrMoreAreasViewPlots({
       <BenchmarkSelectArea
         availableAreas={availableAreasForBenchmarking}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={searchState}
       />
       {shouldLineChartbeShown && (
         <StyleChartWrapper>

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
@@ -129,7 +129,6 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
       <BenchmarkSelectArea
         availableAreas={availableAreasForBenchmarking}
         benchmarkAreaSelectedKey={SearchParams.BenchmarkAreaSelected}
-        searchState={searchState}
       />
       {shouldShowSpineChart(
         areaCodes,

--- a/frontend/fingertips-frontend/components/viewPlots/ViewPlot.types.ts
+++ b/frontend/fingertips-frontend/components/viewPlots/ViewPlot.types.ts
@@ -7,7 +7,6 @@ import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { SearchStateParams } from '@/lib/searchStateManager';
 
 export type OneIndicatorViewPlotProps = {
-  searchState: SearchStateParams;
   indicatorData: IndicatorWithHealthDataForArea;
   indicatorMetadata?: IndicatorDocument;
   availableAreas?: Area[];

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/OneIndicatorOneAreaView.test.tsx
@@ -180,6 +180,5 @@ describe('OneIndicatorOneAreaView', () => {
 
     const page = await OneIndicatorOneAreaView({ searchState: searchState });
     expect(page.props.children.props.indicatorData).toEqual(mockIndicator);
-    expect(page.props.children.props.searchState).toEqual(searchState);
   });
 });

--- a/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorOneAreaView/index.tsx
@@ -86,7 +86,6 @@ export default async function OneIndicatorOneAreaView({
       <OneIndicatorOneAreaViewPlots
         key={`OneIndicatorOneAreaViewPlots-${JSON.stringify(searchState)}`}
         indicatorData={indicatorData}
-        searchState={searchState}
         indicatorMetadata={selectedIndicatorsData?.[0]}
       />
     </ViewsWrapper>

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/OneIndicatorTwoOrMoreAreasView.test.tsx
@@ -97,7 +97,6 @@ describe('OneIndicatorTwoOrMoreAreasView', () => {
     });
 
     expect(page.props.children.props.indicatorData).toEqual(mockIndicatorData);
-    expect(page.props.children.props.searchState).toEqual(searchState);
   });
 
   it('should pass the latestYear flag as true when there are more than 2 areas selected', async () => {

--- a/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/OneIndicatorTwoOrMoreAreasView/index.tsx
@@ -62,7 +62,6 @@ export default async function OneIndicatorTwoOrMoreAreasView({
       <OneIndicatorTwoOrMoreAreasViewPlots
         areaCodes={areaCodes}
         indicatorData={indicatorData}
-        searchState={searchState}
         indicatorMetadata={indicatorMetadata}
       />
     </ViewsWrapper>

--- a/frontend/fingertips-frontend/lib/searchStateManager.ts
+++ b/frontend/fingertips-frontend/lib/searchStateManager.ts
@@ -19,23 +19,6 @@ export enum SearchParams {
   BenchmarkAreaSelected = 'bas',
 }
 
-export type SearchParamKeys = `${SearchParams}`;
-
-const multiValueParams = [
-  SearchParams.IndicatorsSelected as string,
-  SearchParams.AreasSelected as string,
-];
-
-const chartStateParams = [
-  SearchParams.InequalityYearSelected,
-  SearchParams.InequalityBarChartAreaSelected,
-  SearchParams.InequalityLineChartAreaSelected,
-  SearchParams.InequalityBarChartTypeSelected,
-  SearchParams.InequalityLineChartTypeSelected,
-  SearchParams.PopulationAreaSelected,
-  SearchParams.BenchmarkAreaSelected,
-];
-
 export type SearchStateParams = {
   [SearchParams.SearchedIndicator]?: string;
   [SearchParams.IndicatorsSelected]?: string[];
@@ -55,8 +38,28 @@ export type SearchStateParams = {
   [SearchParams.BenchmarkAreaSelected]?: string;
 };
 
-const isMultiValueTypeParam = (searchParamKey: SearchParamKeys) =>
-  multiValueParams.includes(searchParamKey);
+export type SearchParamKeys = `${SearchParams}`;
+
+const multiValueParams = [
+  SearchParams.IndicatorsSelected as string,
+  SearchParams.AreasSelected as string,
+];
+
+const chartStateParams = [
+  SearchParams.InequalityYearSelected,
+  SearchParams.InequalityBarChartAreaSelected,
+  SearchParams.InequalityLineChartAreaSelected,
+  SearchParams.InequalityBarChartTypeSelected,
+  SearchParams.InequalityLineChartTypeSelected,
+  SearchParams.PopulationAreaSelected,
+  SearchParams.BenchmarkAreaSelected,
+];
+
+export const isMultiValueTypeParam = (
+  searchParamKey: SearchParamKeys
+): searchParamKey is
+  | SearchParams.IndicatorsSelected
+  | SearchParams.AreasSelected => multiValueParams.includes(searchParamKey);
 
 export class SearchStateManager {
   private searchState: SearchStateParams;


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-996](https://bjss-enterprise.atlassian.net/browse/DHSCFT-996)

Reduce prop-drilling in favour of a hook that provides searchStateParams from the url directly

## Changes

- Create hook useSearchStateParams()
- Start with OneIndicatorOneAreaView and remove from all components downwards

## Validation

e2e should work without changes