### PR TITLE
DHSCFT-1001-Remove searchState prop drilling for chart

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
@@ -40,23 +40,12 @@ describe('SpineChartLegend', () => {
   });
 
   it('renders the group legend when selectedGroupCode is not England', () => {
-    render(
-      <SpineChartLegend
-        {...defaultProps}
-        // searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
-      />
-    );
+    render(<SpineChartLegend {...defaultProps} />);
     expect(screen.getByText('Group: Test Group')).toBeInTheDocument();
   });
 
   it('should not render alternative benchmark legend as England when group is benchmark', () => {
-    render(
-      <SpineChartLegend
-        {...defaultProps}
-        benchmarkToUse="GROUP_CODE"
-        // searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
-      />
-    );
+    render(<SpineChartLegend {...defaultProps} benchmarkToUse="GROUP_CODE" />);
     expect(screen.getByText(`Benchmark: Test Group`)).toBeInTheDocument();
     expect(screen.queryByText(englandAreaString)).not.toBeInTheDocument();
   });

--- a/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.test.tsx
@@ -43,7 +43,7 @@ describe('SpineChartLegend', () => {
     render(
       <SpineChartLegend
         {...defaultProps}
-        searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
+        // searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
       />
     );
     expect(screen.getByText('Group: Test Group')).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe('SpineChartLegend', () => {
       <SpineChartLegend
         {...defaultProps}
         benchmarkToUse="GROUP_CODE"
-        searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
+        // searchState={{ [SearchParams.GroupSelected]: 'GROUP_CODE' }}
       />
     );
     expect(screen.getByText(`Benchmark: Test Group`)).toBeInTheDocument();

--- a/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartLegend/SpineChartLegend.tsx
@@ -8,8 +8,9 @@ import {
   areaCodeForEngland,
   englandAreaString,
 } from '@/lib/chartHelpers/constants';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
 import { BenchmarkLegends } from '@/components/organisms/BenchmarkLegend/BenchmarkLegends';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 const DivContainer = styled.div({
   fontFamily: 'nta, Arial, sans-serif',
@@ -24,7 +25,6 @@ const FlexDiv = styled.div({
 interface SpineChartLegendProps {
   legendsToShow: BenchmarkLegendsToShow;
   benchmarkToUse: string;
-  searchState: SearchStateParams;
   groupName?: string;
   areaNames?: string[];
 }
@@ -32,10 +32,10 @@ interface SpineChartLegendProps {
 export const SpineChartLegend: FC<SpineChartLegendProps> = ({
   legendsToShow,
   benchmarkToUse,
-  searchState,
   groupName = '',
   areaNames = ['Area'],
 }) => {
+  const searchState = useSearchStateParams();
   const { [SearchParams.GroupSelected]: selectedGroupCode } = searchState;
 
   const benchmarkName =

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTable.test.tsx
@@ -13,7 +13,6 @@ import {
   areaCodeForEngland,
   englandAreaString,
 } from '@/lib/chartHelpers/constants';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 
 describe('Spine chart table suite', () => {
   // Greater Manchester ICB - 00T
@@ -123,17 +122,12 @@ describe('Spine chart table suite', () => {
     },
   ];
 
-  const mockSearchState: SearchStateParams = {
-    [SearchParams.SearchedIndicator]: 'some search',
-  };
-
   describe('Spine chart table', () => {
     it('should render the SpineChartTable component with title', () => {
       render(
         <SpineChartTable
           indicatorData={mockIndicatorData}
           benchmarkToUse={areaCodeForEngland}
-          searchState={mockSearchState}
         />
       );
       const spineChart = screen.getByTestId('spineChartTable-component');
@@ -151,7 +145,6 @@ describe('Spine chart table suite', () => {
         <SpineChartTable
           indicatorData={mockIndicatorData}
           benchmarkToUse={areaCodeForEngland}
-          searchState={mockSearchState}
         />
       );
 
@@ -198,7 +191,6 @@ describe('Spine chart table suite', () => {
         <SpineChartTable
           indicatorData={mockTwoAreasIndicatorData}
           benchmarkToUse={areaCodeForEngland}
-          searchState={mockSearchState}
         />
       );
 
@@ -240,7 +232,6 @@ describe('Spine chart table suite', () => {
         <SpineChartTable
           indicatorData={mockDataPeriodMismatch}
           benchmarkToUse={areaCodeForEngland}
-          searchState={mockSearchState}
         />
       );
 

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableHeader.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableHeader.test.tsx
@@ -5,13 +5,17 @@ import { GovukColours } from '@/lib/styleHelpers/colours';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams } from '@/lib/searchStateManager';
 
+const mockSearchState = { [SearchParams.GroupSelected]: 'A001' };
+
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => mockSearchState,
+}));
+
 describe('Spine chart table header', () => {
   const mockHeaderData = {
     area: 'testArea',
     group: 'testGroup',
   };
-
-  const mockSearchState = { [SearchParams.GroupSelected]: 'A001' };
 
   it('should contain the expected elements', () => {
     render(
@@ -21,7 +25,6 @@ describe('Spine chart table header', () => {
             areaNames={[mockHeaderData.area]}
             groupName={mockHeaderData.group}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </thead>
       </table>
@@ -52,7 +55,6 @@ describe('Spine chart table header', () => {
             areaNames={[mockHeaderData.area]}
             groupName={mockHeaderData.group}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </thead>
       </table>
@@ -81,7 +83,6 @@ describe('Spine chart table header', () => {
             areaNames={[mockHeaderData.area]}
             groupName={mockHeaderData.group}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </thead>
       </table>
@@ -104,7 +105,6 @@ describe('Spine chart table header', () => {
             areaNames={['East of England Region', 'East Midlands Region']}
             groupName={mockHeaderData.group}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </thead>
       </table>
@@ -132,6 +132,8 @@ describe('Spine chart table header', () => {
   });
 
   it('should not render the group header value if group is England', () => {
+    mockSearchState[SearchParams.GroupSelected] = areaCodeForEngland;
+
     render(
       <table>
         <thead>
@@ -139,9 +141,6 @@ describe('Spine chart table header', () => {
             areaNames={['East of England Region']}
             groupName={'England'}
             benchmarkToUse={areaCodeForEngland}
-            searchState={{
-              [SearchParams.GroupSelected]: areaCodeForEngland,
-            }}
           />
         </thead>
       </table>

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableHeader.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableHeader.tsx
@@ -17,13 +17,13 @@ import {
   areaCodeForEngland,
   englandAreaString,
 } from '@/lib/chartHelpers/constants';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 export interface TableHeaderProps {
   areaNames: string[];
   groupName: string;
   benchmarkToUse: string;
-  searchState: SearchStateParams;
 }
 
 interface HeaderData {
@@ -159,8 +159,8 @@ export function SpineChartTableHeader({
   areaNames,
   groupName,
   benchmarkToUse,
-  searchState,
 }: Readonly<TableHeaderProps>) {
+  const searchState = useSearchStateParams();
   const twoAreasRequested = areaNames.length === 2;
   const showGroupData = groupName !== englandAreaString;
   const benchmarkSubHeaderData = getBenchmarkSubHeaderData(

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -149,7 +149,7 @@ describe('Spine chart table row', () => {
   });
 
   it('should not render a cell for group if the group is England', () => {
-    mockSearchState[SearchParams.GroupSelected] = areaCodeForEngland
+    mockSearchState[SearchParams.GroupSelected] = areaCodeForEngland;
 
     const indicatorDataGroupEngland = {
       ...mockSpineIndicatorData,

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.test.tsx
@@ -16,6 +16,10 @@ const mockSearchState: SearchStateParams = {
   [SearchParams.SearchedIndicator]: 'some search',
 };
 
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => mockSearchState,
+}));
+
 describe('Spine chart table row', () => {
   it('should have dark grey cell color for benchmark column', () => {
     render(
@@ -24,7 +28,6 @@ describe('Spine chart table row', () => {
           <SpineChartTableRow
             indicatorData={mockSpineIndicatorData}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </tbody>
       </table>
@@ -48,7 +51,6 @@ describe('Spine chart table row', () => {
           <SpineChartTableRow
             indicatorData={mockSpineIndicatorData}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </tbody>
       </table>
@@ -85,7 +87,6 @@ describe('Spine chart table row', () => {
           <SpineChartTableRow
             indicatorData={indicatorWithMissingData}
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </tbody>
       </table>
@@ -133,7 +134,6 @@ describe('Spine chart table row', () => {
             indicatorData={indicatorDataWithTwoAreas}
             twoAreasRequested
             benchmarkToUse={areaCodeForEngland}
-            searchState={mockSearchState}
           />
         </tbody>
       </table>
@@ -149,6 +149,8 @@ describe('Spine chart table row', () => {
   });
 
   it('should not render a cell for group if the group is England', () => {
+    mockSearchState[SearchParams.GroupSelected] = areaCodeForEngland
+
     const indicatorDataGroupEngland = {
       ...mockSpineIndicatorData,
       groupData: {
@@ -176,7 +178,6 @@ describe('Spine chart table row', () => {
           <SpineChartTableRow
             indicatorData={indicatorDataGroupEngland}
             benchmarkToUse={areaCodeForEngland}
-            searchState={{ [SearchParams.GroupSelected]: areaCodeForEngland }}
           />
         </tbody>
       </table>

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/SpineChartTableRow.tsx
@@ -24,12 +24,12 @@ import {
   englandAreaString,
 } from '@/lib/chartHelpers/constants';
 import { StyledAlignRightTableCellPaddingRight } from '@/lib/tableHelpers';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 export interface SpineChartTableRowProps {
   indicatorData: SpineChartIndicatorData;
   benchmarkToUse: string;
-  searchState: SearchStateParams;
   twoAreasRequested?: boolean;
 }
 
@@ -37,8 +37,8 @@ export const SpineChartTableRow: FC<SpineChartTableRowProps> = ({
   indicatorData,
   twoAreasRequested = false,
   benchmarkToUse,
-  searchState,
 }) => {
+  const searchState = useSearchStateParams();
   const { [SearchParams.GroupSelected]: selectedGroupCode } = searchState;
 
   const {

--- a/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SpineChartTable/index.tsx
@@ -15,7 +15,6 @@ import { ExportOptionsButton } from '@/components/molecules/Export/ExportOptions
 import { convertSpineChartTableToCsv } from '@/components/organisms/SpineChartTable/convertSpineChartTableToCsv';
 import { ExportOnlyWrapper } from '@/components/molecules/Export/ExportOnlyWrapper';
 import { ExportCopyright } from '@/components/molecules/Export/ExportCopyright';
-import { SearchStateParams } from '@/lib/searchStateManager';
 import { ChartTitle } from '@/components/atoms/ChartTitle/ChartTitle';
 import { SubTitle } from '@/components/atoms/SubTitle/SubTitle';
 import { ContainerWithOutline } from '@/components/atoms/ContainerWithOutline/ContainerWithOutline';
@@ -23,7 +22,6 @@ import { ContainerWithOutline } from '@/components/atoms/ContainerWithOutline/Co
 export interface SpineChartTableProps {
   indicatorData: SpineChartIndicatorData[];
   benchmarkToUse: string;
-  searchState: SearchStateParams;
 }
 
 const sortByIndicator = (indicatorData: SpineChartIndicatorData[]) =>
@@ -36,7 +34,6 @@ const sortByIndicator = (indicatorData: SpineChartIndicatorData[]) =>
 export function SpineChartTable({
   indicatorData,
   benchmarkToUse,
-  searchState,
 }: Readonly<SpineChartTableProps>) {
   const sortedData = sortByIndicator(indicatorData);
   const methods = getMethodsAndOutcomes(indicatorData);
@@ -64,7 +61,6 @@ export function SpineChartTable({
             benchmarkToUse={benchmarkToUse}
             groupName={groupName}
             areaNames={areaNames}
-            searchState={searchState}
           />
 
           <StyledDivTableContainer>
@@ -73,7 +69,6 @@ export function SpineChartTable({
                 areaNames={areaNames}
                 groupName={sortedData[0].groupData?.areaName ?? 'Group'}
                 benchmarkToUse={benchmarkToUse}
-                searchState={searchState}
               />
               {sortedData.map((indicatorData) => (
                 <React.Fragment key={indicatorData.indicatorId}>
@@ -81,7 +76,6 @@ export function SpineChartTable({
                     indicatorData={indicatorData}
                     twoAreasRequested={areaNames.length > 1}
                     benchmarkToUse={benchmarkToUse}
-                    searchState={searchState}
                   />
                 </React.Fragment>
               ))}

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/TwoOrMoreIndicatorsAreasViewPlots.test.tsx
@@ -42,6 +42,9 @@ const mockAreas = ['A001', 'A002', 'A003'];
 const mockGroupArea = 'G001';
 
 let mockSearchParams: SearchStateParams;
+jest.mock('@/components/hooks/useSearchStateParams', () => ({
+  useSearchStateParams: () => mockSearchParams,
+}));
 
 const mockGroupHealthData: HealthDataForArea = {
   areaCode: mockGroupArea,
@@ -217,7 +220,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
   it('should render the benchmark select area drop down for the view', async () => {
     render(
       <TwoOrMoreIndicatorsAreasViewPlot
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockMetaData}
         benchmarkStatistics={mockBenchmarkStatistics}
@@ -243,7 +245,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
 
     render(
       <TwoOrMoreIndicatorsAreasViewPlot
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockMetaData}
         benchmarkStatistics={mockBenchmarkStatistics}
@@ -260,7 +261,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
 
     render(
       <TwoOrMoreIndicatorsAreasViewPlot
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockMetaData}
         benchmarkStatistics={mockBenchmarkStatistics}
@@ -279,7 +279,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
 
     render(
       <TwoOrMoreIndicatorsAreasViewPlot
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockMetaData}
         benchmarkStatistics={mockBenchmarkStatistics}
@@ -304,7 +303,6 @@ describe('TwoOrMoreIndicatorsAreasViewPlots', () => {
 
     render(
       <TwoOrMoreIndicatorsAreasViewPlot
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockMetaData}
         benchmarkStatistics={mockBenchmarkStatistics}

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsAreasViewPlots/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/generated-sources/ft-api-client';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { SpineChartTable } from '@/components/organisms/SpineChartTable';
-import { SearchParams, SearchStateManager } from '@/lib/searchStateManager';
+import { SearchParams } from '@/lib/searchStateManager';
 import { HeatmapIndicatorData } from '@/components/organisms/Heatmap/heatmapUtil';
 import {
   buildSpineChartIndicatorData,
@@ -24,6 +24,7 @@ import { ALL_AREAS_SELECTED } from '@/lib/areaFilterHelpers/constants';
 import { StyleChartWrapper } from '@/components/styles/viewPlotStyles/styleChartWrapper';
 import { BenchmarkSelectArea } from '@/components/molecules/BenchmarkSelectArea';
 import { englandAreaString } from '@/lib/chartHelpers/constants';
+import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
 
 function shouldShowHeatmap(
   areaCodes: string[],
@@ -64,19 +65,19 @@ export function extractHeatmapIndicatorData(
 }
 
 export function TwoOrMoreIndicatorsAreasViewPlot({
-  searchState,
   indicatorData,
   indicatorMetadata,
   benchmarkStatistics,
   availableAreas,
 }: Readonly<TwoOrMoreIndicatorsViewPlotProps>) {
-  const stateManager = SearchStateManager.initialise(searchState);
+  const searchState = useSearchStateParams();
+
   const {
     [SearchParams.AreasSelected]: areasSelected,
     [SearchParams.GroupSelected]: selectedGroupCode,
     [SearchParams.GroupAreaSelected]: groupAreaSelected,
     [SearchParams.BenchmarkAreaSelected]: benchmarkAreaSelected,
-  } = stateManager.getSearchState();
+  } = searchState;
 
   const areaCodes = determineAreaCodes(
     areasSelected,
@@ -139,7 +140,6 @@ export function TwoOrMoreIndicatorsAreasViewPlot({
           <SpineChartTable
             indicatorData={spineChartIndicatorData}
             benchmarkToUse={benchmarkToUse}
-            searchState={searchState}
           />
         </StyleChartWrapper>
       ) : null}

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsEnglandViewPlots/TwoOrMoreIndicatorsEnglandViewPlots.test.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsEnglandViewPlots/TwoOrMoreIndicatorsEnglandViewPlots.test.tsx
@@ -3,7 +3,6 @@ import {
   getLatestPeriodHealthDataPoint,
   TwoOrMoreIndicatorsEnglandViewPlots,
 } from '@/components/viewPlots/TwoOrMoreIndicatorsEnglandViewPlots/index';
-import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import {
   BenchmarkComparisonMethod,
@@ -14,10 +13,6 @@ import {
 import { render, screen } from '@testing-library/react';
 import { healthDataPoint } from '@/lib/mocks';
 
-const mockSearchParams: SearchStateParams = {
-  [SearchParams.IndicatorsSelected]: ['1', '2'],
-  [SearchParams.AreasSelected]: [areaCodeForEngland],
-};
 const mockEnglandHealthData: HealthDataForArea = {
   areaCode: areaCodeForEngland,
   areaName: 'England',
@@ -75,7 +70,6 @@ describe('TwoOrMoreIndicatorsEnglandView', () => {
   it('should render the EnglandAreaTypeTable component', () => {
     render(
       <TwoOrMoreIndicatorsEnglandViewPlots
-        searchState={mockSearchParams}
         indicatorData={mockIndicatorData}
         indicatorMetadata={mockIndicatorMetaData}
       />

--- a/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsEnglandViewPlots/index.tsx
+++ b/frontend/fingertips-frontend/components/viewPlots/TwoOrMoreIndicatorsEnglandViewPlots/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { SearchStateParams } from '@/lib/searchStateManager';
 import {
   HealthDataPoint,
   IndicatorWithHealthDataForArea,
@@ -12,7 +11,6 @@ import { StyleChartWrapper } from '@/components/styles/viewPlotStyles/styleChart
 
 type TwoOrMoreIndicatorsEnglandViewPlotProps = {
   indicatorData: IndicatorWithHealthDataForArea[];
-  searchState: SearchStateParams;
   indicatorMetadata: IndicatorDocument[];
 };
 

--- a/frontend/fingertips-frontend/components/viewPlots/ViewPlot.types.ts
+++ b/frontend/fingertips-frontend/components/viewPlots/ViewPlot.types.ts
@@ -4,7 +4,6 @@ import {
   QuartileData,
 } from '@/generated-sources/ft-api-client';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
-import { SearchStateParams } from '@/lib/searchStateManager';
 
 export type OneIndicatorViewPlotProps = {
   indicatorData: IndicatorWithHealthDataForArea;
@@ -13,7 +12,6 @@ export type OneIndicatorViewPlotProps = {
 };
 
 export type TwoOrMoreIndicatorsViewPlotProps = {
-  searchState: SearchStateParams;
   indicatorData: IndicatorWithHealthDataForArea[];
   indicatorMetadata: IndicatorDocument[];
   benchmarkStatistics: QuartileData[];

--- a/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsAreasView/TwoOrMoreIndicatorsAreasView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsAreasView/TwoOrMoreIndicatorsAreasView.test.tsx
@@ -185,7 +185,6 @@ describe('TwoOrMoreIndicatorsAreasView', () => {
       selectedIndicatorsData: fullSelectedIndicatorsData,
     });
 
-    expect(page.props.children.props.searchState).toEqual(fullSearchParams);
     expect(page.props.children.props.indicatorData).toEqual([
       mockIndicator,
       mockIndicator,

--- a/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsAreasView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsAreasView/index.tsx
@@ -125,7 +125,6 @@ export default async function TwoOrMoreIndicatorsAreasView({
         indicatorData={combinedIndicatorData}
         indicatorMetadata={selectedIndicatorsData}
         benchmarkStatistics={benchmarkQuartiles}
-        searchState={searchState}
         availableAreas={availableAreas}
       />
     </ViewsWrapper>

--- a/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsEnglandView/TwoOrMoreIndicatorsEnglandView.test.tsx
+++ b/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsEnglandView/TwoOrMoreIndicatorsEnglandView.test.tsx
@@ -108,7 +108,6 @@ describe('TwoOrMoreIndicatorsEnglandView', () => {
         selectedIndicatorsData: fullSelectedIndicatorsData,
       });
 
-      expect(page.props.children.props.searchState).toEqual(mockSearchParams);
       expect(page.props.children.props.indicatorData).toEqual([
         mockIndicator,
         mockIndicatorWithHealthData,

--- a/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsEnglandView/index.tsx
+++ b/frontend/fingertips-frontend/components/views/TwoOrMoreIndicatorsEnglandView/index.tsx
@@ -62,7 +62,6 @@ export default async function TwoOrMoreIndicatorsEnglandView({
     >
       <TwoOrMoreIndicatorsEnglandViewPlots
         indicatorData={combinedIndicatorData}
-        searchState={searchState}
         indicatorMetadata={selectedIndicatorsData}
       />
     </ViewsWrapper>


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1001](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1001)

Removes the prop drilling for chart two indicator views.

## Validation

All tests passing. Tested manually.
