### PR TITLE
DHSCFT-1038: fix to show England column for quintiles indicators

### DIFF
--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -494,23 +494,6 @@ describe('Line chart table suite', () => {
     }
   };
 
-  describe('LineChartTable when given quintiles data', () => {
-    it('should not render the benchmark column', () => {
-      render(
-        <LineChartTable
-          title={'Title'}
-          healthIndicatorData={[mockHealthData[0]]}
-          englandIndicatorData={MOCK_ENGLAND_DATA}
-          indicatorMetadata={{ unitLabel: '%' } as IndicatorDocument}
-          benchmarkComparisonMethod={BenchmarkComparisonMethod.Quintiles}
-        />
-      );
-
-      expect(screen.queryByTestId(`england-subheader`)).not.toBeInTheDocument();
-      expect(screen.queryByTestId('england-header')).not.toBeInTheDocument();
-    });
-  });
-
   describe('LineChartTable when mismatched years are supplied', () => {
     it('should not render Xs but keep the correct years aligned', () => {
       const mockHealthArea1 = JSON.parse(JSON.stringify(MOCK_ENGLAND_DATA));

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -229,8 +229,7 @@ export function LineChartTable({
 
   const confidenceLimit = getConfidenceLimitNumber(benchmarkComparisonMethod);
   const showEnglandColumn =
-    healthIndicatorData[0]?.areaCode !== areaCodeForEngland &&
-    benchmarkComparisonMethod !== BenchmarkComparisonMethod.Quintiles;
+    healthIndicatorData[0]?.areaCode !== areaCodeForEngland;
 
   const showGroupColumn =
     healthIndicatorData[0]?.areaCode !== areaCodeForEngland &&


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1038](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1038)

Show's England column on line chart table for quintile indicators

![Screenshot 2025-06-25 at 13 04 41](https://github.com/user-attachments/assets/036fa461-1159-42ba-9f83-92a9f27872f3)

![Screenshot 2025-06-25 at 13 04 31](https://github.com/user-attachments/assets/211d0366-c85d-45a9-a6a9-bcf1d02ea20c)

## Validation

Tested manually