### PR TITLE
DHSCFT-1110_re_enable_a11y_check

### DIFF
--- a/frontend/fingertips-frontend/lib/search/indicatorMapper.test.ts
+++ b/frontend/fingertips-frontend/lib/search/indicatorMapper.test.ts
@@ -128,7 +128,7 @@ describe('indicatorMapper tests', () => {
     });
 
     // DHSCFT-198 - AC1 - if no area specified but England chosen as group, then return the trend for England
-    it('retrieves the trend for England when no area has been specificed but England chosen as group', () => {
+    it('retrieves the trend for England when no area has been specified but England chosen as group', () => {
       const mockRawIndicators = [
         {
           ...baseMockRawIndicators[0],

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/errorpage.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/errorpage.spec.ts
@@ -19,15 +19,14 @@ test.describe('Error page tests', () => {
 
   test('Chart page displays ErrorPage when API returns unexpected error', async ({
     chartPage,
-    // axeBuilder,
+    axeBuilder,
   }) => {
     await chartPage.page.goto(`/chart?is=`);
 
     await test
       .expect(chartPage.errorPageTitle())
       .toContainText('Sorry, there is a problem with the service');
-    // readd once DHSCFT-495 is actioned as the next error overlay is current causing the test to fail
-    // await chartPage.expectNoAccessibilityViolations(axeBuilder);
+    await chartPage.expectNoAccessibilityViolations(axeBuilder);
   });
 
   test('Indicator page displays ErrorPage when API returns unexpected error', async ({


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1110](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1110)

The isolated ui test 'Chart page displays ErrorPage when API returns unexpected error' in:

frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/errorpage.spec.ts

had a commented out a11y check in it due to DHSCFT-495 - however that ticket was Done a while back

This a11y check can be uncommented out so that it executes as expected now.

## Validation

test suite continues to pass locally and in CI
