### PR TITLE
DHSCFT-1121: work around Next's quirks with useSearchParams

### DIFF
--- a/frontend/fingertips-frontend/app/chart/page.tsx
+++ b/frontend/fingertips-frontend/app/chart/page.tsx
@@ -33,6 +33,9 @@ export default async function ChartPage(
     searchParams?: Promise<SearchStateParams>;
   }>
 ) {
+  // We don't want to render this page statically
+  await connection();
+
   try {
     const searchParams = await props.searchParams;
     const stateManager = SearchStateManager.initialise(searchParams);
@@ -44,9 +47,6 @@ export default async function ChartPage(
     } = searchState;
 
     const areasSelected = areaCodes ?? [];
-
-    // We don't want to render this page statically
-    await connection();
 
     const selectedIndicatorsData =
       indicatorsSelected && indicatorsSelected.length > 0

--- a/frontend/fingertips-frontend/app/layout.tsx
+++ b/frontend/fingertips-frontend/app/layout.tsx
@@ -1,10 +1,10 @@
 import { FTContainer } from '@/components/layouts/container';
 import StyledComponentsRegistry from '@/lib/registry';
 import type { Metadata } from 'next';
-import { ReactNode, Suspense } from 'react';
+import { ReactNode } from 'react';
 import '../global.css';
-import { HeaderFooterWrapper } from '@/components/molecules/HeaderFooterWrapper';
 import { siteDescription, siteTitle } from '@/lib/constants';
+import { HeaderFooterWrapper } from '@/components/molecules/HeaderFooterWrapper';
 
 export const metadata: Metadata = {
   title: siteTitle,
@@ -23,13 +23,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body style={{ margin: 0 }}>
-        <Suspense>
-          <StyledComponentsRegistry>
-            <HeaderFooterWrapper tag={tag} hash={hash}>
-              <FTContainer>{children}</FTContainer>
-            </HeaderFooterWrapper>
-          </StyledComponentsRegistry>
-        </Suspense>
+        <StyledComponentsRegistry>
+          <HeaderFooterWrapper tag={tag} hash={hash}>
+            <FTContainer>{children}</FTContainer>
+          </HeaderFooterWrapper>
+        </StyledComponentsRegistry>
       </body>
     </html>
   );


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1121](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1121)

Enable some server side rendering

## Changes

- remove suspense wrapper
- alter loader context to useSearchStateParams via a suspended component
- moved placement of await connection() 

## Validation

Tried without javascript and got the home screen to render albeit with permanent loader
Tried with JS and everything seems to work