### PR TITLE
Add endpoint to get unpublished quartile data

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -181,8 +181,15 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
         return denormalisedHealthData.OrderBy(a => a.Year);
     }
 
-    public async Task<IEnumerable<QuartileDataModel>> GetQuartileDataAsync(IEnumerable<int> indicatorIds,
-        string areaCode, string areaTypeKey, string ancestorCode, string benchmarkAreaCode)
+    public async Task<IEnumerable<QuartileDataModel>> GetQuartileDataAsync
+    (
+        IEnumerable<int> indicatorIds,
+        string areaCode,
+        string areaTypeKey,
+        string ancestorCode,
+        string benchmarkAreaCode,
+        bool includeUnpublished = false
+    )
     {
         SqlParameter requestedIndicators;
         // Convert the array parameters into DataTables for presentation to the Stored Procedure.
@@ -203,10 +210,11 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
         var areaCodeSqlParam = new SqlParameter("@RequestedArea", areaCode);
         var ancestorCodeSqlParam = new SqlParameter("@RequestedAncestorCode", ancestorCode);
         var benchmarkAreaCodeSqlParam = new SqlParameter("@RequestedBenchmarkCode", benchmarkAreaCode);
+        var includeUnpublishedData = new SqlParameter("@IncludeUnpublishedData", includeUnpublished);
 
         var retVal = await _dbContext.QuartileData.FromSql
         (@$"
-              EXEC dbo.GetIndicatorQuartileDataForLatestYear @RequestedAreaType={areaType}, @RequestedIndicatorIds={requestedIndicators}, @RequestedArea={areaCodeSqlParam}, @RequestedAncestorCode={ancestorCodeSqlParam}, @RequestedBenchmarkCode={benchmarkAreaCodeSqlParam}
+              EXEC dbo.GetIndicatorQuartileDataForLatestYear @RequestedAreaType={areaType}, @RequestedIndicatorIds={requestedIndicators}, @RequestedArea={areaCodeSqlParam}, @RequestedAncestorCode={ancestorCodeSqlParam}, @RequestedBenchmarkCode={benchmarkAreaCodeSqlParam}, @IncludeUnpublishedData={includeUnpublishedData}
               "
         ).ToListAsync();
 

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/IHealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/IHealthDataRepository.cs
@@ -22,7 +22,7 @@ public interface IHealthDataRepository
                                                                  bool includeUnpublished = false);
 
     Task<IndicatorDimensionModel?> GetIndicatorDimensionAsync(int indicatorId, string[] areaCodes, bool includeUnpublished = false);
-    Task<IEnumerable<QuartileDataModel>> GetQuartileDataAsync(IEnumerable<int> indicatorIds, string areaCode, string areaTypeKey, string ancestorCode, string benchmarkAreaCode);
+    Task<IEnumerable<QuartileDataModel>> GetQuartileDataAsync(IEnumerable<int> indicatorIds, string areaCode, string areaTypeKey, string ancestorCode, string benchmarkAreaCode, bool includeUnpublished = false);
 
     Task<IEnumerable<AreaDimensionModel>> GetAreasAsync(string[] areaCodes);
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/IIndicatorsService.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/IIndicatorsService.cs
@@ -54,6 +54,7 @@ public interface IIndicatorsService
         string areaCode,
         string areaType,
         string ancestorCode,
-        string benchmarkAreaCode
+        string benchmarkAreaCode,
+        bool includeUnpublished = false
         );
 }

--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/IndicatorService.cs
@@ -245,10 +245,19 @@ public class IndicatorService(IHealthDataRepository healthDataRepository, IHealt
         string areaCode,
         string areaType,
         string ancestorCode,
-        string benchmarkAreaCode
+        string benchmarkAreaCode,
+        bool includeUnpublished = false
         )
     {
-        var quartileData = await healthDataRepository.GetQuartileDataAsync(indicatorIds, areaCode, areaType, ancestorCode, benchmarkAreaCode);
+        var quartileData = await healthDataRepository.GetQuartileDataAsync
+        (
+            indicatorIds,
+            areaCode,
+            areaType,
+            ancestorCode,
+            benchmarkAreaCode,
+            includeUnpublished
+        );
 
         return quartileData == null ? null : healthDataMapper.Map(quartileData.ToList());
     }

--- a/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/Controllers/V1/IndicatorsController.cs
@@ -118,7 +118,7 @@ public class IndicatorsController(IIndicatorsService indicatorsService) : Contro
             true);
 
     /// <summary>
-    /// Get data for a public health indicator. Returns all data for all
+    /// Get published data for a public health indicator. Returns all published data for all
     /// areas and all years for the indicators. Optionally filter the results by
     /// supplying one or more area codes and one or more years in the query string.
     /// </summary>
@@ -136,12 +136,60 @@ public class IndicatorsController(IIndicatorsService indicatorsService) : Contro
     [ProducesResponseType(typeof(List<Schemas.IndicatorQuartileData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(SimpleError), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetQuartileDataAsync(
+    public async Task<IActionResult> GetPublishedQuartileDataAsync(
         [FromQuery(Name = "indicator_ids")] int[]? indicatorIds = null,
         [FromQuery(Name = "area_code")] string areaCode = "",
         [FromQuery(Name = "area_type")] string? areaType = null,
         [FromQuery(Name = "ancestor_code")] string ancestorCode = "",
         [FromQuery(Name = "benchmark_ref_type")] BenchmarkReferenceType benchmarkRefType = BenchmarkReferenceType.England
+        ) => await GetQuartileDataInternalAsync(
+            indicatorIds,
+            areaCode,
+            areaType,
+            ancestorCode,
+            benchmarkRefType,
+            false);
+
+    /// <summary>
+    /// Get published and unpublished data for a public health indicator. Returns all published and unpublished data for all
+    /// areas and all years for the indicators. Optionally filter the results by
+    /// supplying one or more area codes and one or more years in the query string.
+    /// </summary>
+    /// <param name="areaCode">A list of area codes.</param>
+    /// <param name="areaType">The area type the area codes belong to.</param>
+    /// <param name="ancestorCode">The area group for calculating quartiles within.</param>
+    /// <param name="benchmarkRefType">Whether to benchmark against England or SubNational.</param>
+    /// <param name="indicatorIds">The unique identifier of the indicator.</param>
+    /// <returns></returns>
+    /// <remarks>
+    /// If more than 50 indicators are supplied the request will fail.
+    /// </remarks>
+    [HttpGet]
+    [Route("quartiles/all")]
+    [ProducesResponseType(typeof(List<Schemas.IndicatorQuartileData>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(SimpleError), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPublishedAndUnpublishedQuartileDataAsync(
+        [FromQuery(Name = "indicator_ids")] int[]? indicatorIds = null,
+        [FromQuery(Name = "area_code")] string areaCode = "",
+        [FromQuery(Name = "area_type")] string? areaType = null,
+        [FromQuery(Name = "ancestor_code")] string ancestorCode = "",
+        [FromQuery(Name = "benchmark_ref_type")] BenchmarkReferenceType benchmarkRefType = BenchmarkReferenceType.England
+        ) => await GetQuartileDataInternalAsync(
+            indicatorIds,
+            areaCode,
+            areaType,
+            ancestorCode,
+            benchmarkRefType,
+            true);
+
+    private async Task<IActionResult> GetQuartileDataInternalAsync(
+        int[]? indicatorIds = null,
+        string areaCode = "",
+        string? areaType = null,
+        string ancestorCode = "",
+        BenchmarkReferenceType benchmarkRefType = BenchmarkReferenceType.England,
+        bool includeUnpublished = false
         )
     {
         if (indicatorIds is null)
@@ -161,7 +209,8 @@ public class IndicatorsController(IIndicatorsService indicatorsService) : Contro
             areaCode,
             areaType,
             ancestorCode,
-            benchmarkRefType == BenchmarkReferenceType.SubNational ? ancestorCode : "E92000001"
+            benchmarkRefType == BenchmarkReferenceType.SubNational ? ancestorCode : "E92000001",
+            includeUnpublished
         );
 
         return quartileData == null ? NotFound() : Ok(quartileData);

--- a/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quartile.http
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-benchmark-quartile.http
@@ -677,3 +677,30 @@ GET http://localhost:5144/indicators/quartiles?indicator_ids=90453&area_code=K84
         client.assert(JSON.stringify(response.body) === JSON.stringify(expected), "Response body does not match");
     });
 %}
+
+### Ensure published data is returned
+GET http://localhost:5144/indicators/quartiles/all?indicator_ids=90453&area_code=K84031&area_type=gps&ancestor_code=E38000136
+> {%
+    client.test("Ensure published data is returned", function (callbackfn, thisArg) {
+        const expected = [  {
+            "indicatorId": 90453,
+            "polarity": "NoJudgement",
+            "year": 2025,
+            "datePeriod": {
+                "type": "Calendar",
+                "from": "2025-01-01",
+                "to": "2025-12-31"
+            },
+            "q0Value": 3.07953,
+            "q1Value": 24.36787,
+            "q2Value": 29.14221,
+            "q3Value": 33.38074,
+            "q4Value": 50.264,
+            "areaValue": 25.01118,
+            "ancestorValue": null,
+            "englandValue": 27.15399
+        }]
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(JSON.stringify(response.body) === JSON.stringify(expected), "Response body does not match");
+    });
+%}

--- a/api/definition/fingertipsAPI.yaml
+++ b/api/definition/fingertipsAPI.yaml
@@ -325,7 +325,63 @@ paths:
       tags:
         - indicators
       summary: Get quartile values for indicators
-      description: Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately.
+      description: Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
+      parameters:
+        - name: ancestor_code
+          in: query
+          style: simple
+          schema:
+            type: string
+            example: E12000001
+          explode: false
+          description: The area code of an ancestor area
+        - name: area_code
+          in: query
+          style: simple
+          schema:
+            type: string
+            example: G82109
+          explode: false
+          description: The area code of the area/ geography
+        - name: area_type
+          in: query
+          description: The area type which the areas belong to
+          schema:
+            type: string
+        - name: indicator_ids
+          in: query
+          description: A list of indicator_ids, up to 10 can be requested
+          style: form
+          schema:
+            type: array
+            items:
+              type: integer
+              example: 1234
+            maxItems: 10
+        - name: benchmark_ref_type
+          in: query
+          description: The benchmark reference type
+          schema:
+            $ref: '#/components/schemas/BenchmarkReferenceType'
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuartileData'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /indicators/quartiles/all:
+    get:
+      tags:
+        - indicators
+      summary: Get quartile values for indicators
+      description: Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
       parameters:
         - name: ancestor_code
           in: query

--- a/api/definition/indicators/paths.yaml
+++ b/api/definition/indicators/paths.yaml
@@ -173,7 +173,7 @@ quartiles:
       benchmark_ref_type parameter. It will use the latest data available
       for the area group requested. If the indicator has data for
       more than one time period type then the API will return data for each
-      data period type separately.
+      data period type separately. The /all endpoint can return unpublished data, otherwise the data is published. 
     parameters:
       - name: ancestor_code
         in: query

--- a/api/definition/swagger.yaml
+++ b/api/definition/swagger.yaml
@@ -51,6 +51,8 @@ paths:
     $ref: "./indicators/paths.yaml#/indicators_by_indicator_id_all_data"
   /indicators/quartiles:
     $ref: "./indicators/paths.yaml#/quartiles"
+  /indicators/quartiles/all:
+    $ref: "./indicators/paths.yaml#/quartiles"
   /user/info:
     $ref: "./user/paths.yaml#/user_info"
   /user/indicator/{indicator_id}:

--- a/database/fingertips-db/PostDeployment/PopulateFingertips.sql
+++ b/database/fingertips-db/PostDeployment/PopulateFingertips.sql
@@ -653,9 +653,9 @@ JOIN
 JOIN
 	[dbo].[DeprivationDimension] depdim  ON depdim.[Name] = LTRIM(RTRIM(temp.Category)) AND depdim.[Type]=LTRIM(RTRIM(temp.CategoryType))
 JOIN
-	[dbo].[DateDimension] datedim_from ON datedim_from.[Date] = (CONVERT(DATETIME, temp.FromDate, 103)) 
+	[dbo].[DateDimension] datedim_from ON datedim_from.[Date] = DATEADD(year, 1, (CONVERT(DATETIME, temp.FromDate, 103))) 
 JOIN
-    [dbo].[DateDimension] datedim_to ON datedim_to.[Date] = (CONVERT(DATETIME, temp.ToDate, 103))
+    [dbo].[DateDimension] datedim_to ON datedim_to.[Date] = DATEADD(year, 1, (CONVERT(DATETIME, temp.ToDate, 103)))
 JOIN   
     [dbo].[PeriodDimension] perioddim ON perioddim.[Period] = temp.Period
 WHERE 
@@ -718,9 +718,9 @@ JOIN
 JOIN
 	[dbo].[DeprivationDimension] depdim  ON depdim.[Name] = LTRIM(RTRIM(temp.Category)) AND depdim.[Type]=LTRIM(RTRIM(temp.CategoryType))
 JOIN
-	[dbo].[DateDimension] datedim_from ON datedim_from.[Date] = (CONVERT(DATETIME, temp.FromDate, 103)) 
+	[dbo].[DateDimension] datedim_from ON datedim_from.[Date] = DATEADD(year, 1, (CONVERT(DATETIME, temp.FromDate, 103)))
 JOIN
-    [dbo].[DateDimension] datedim_to ON datedim_to.[Date] = (CONVERT(DATETIME, temp.ToDate, 103))
+    [dbo].[DateDimension] datedim_to ON datedim_to.[Date] = DATEADD(year, 1, (CONVERT(DATETIME, temp.ToDate, 103)))
 JOIN   
     [dbo].[PeriodDimension] perioddim ON perioddim.[Period] = temp.Period
 WHERE 

--- a/database/fingertips-db/StoredProcedures/GetIndicatorQuartileDataForLatestYear.sql
+++ b/database/fingertips-db/StoredProcedures/GetIndicatorQuartileDataForLatestYear.sql
@@ -3,11 +3,17 @@ CREATE PROCEDURE [dbo].[GetIndicatorQuartileDataForLatestYear] @RequestedAreaTyp
 @RequestedIndicatorIds IndicatorList READONLY,
 @RequestedArea varchar(50),
 @RequestedAncestorCode varchar(20),
-@RequestedBenchmarkCode varchar(20) --- The area used for benchmarking
+@RequestedBenchmarkCode varchar(20), --- The area used for benchmarking
+@IncludeUnpublishedData BIT
 AS BEGIN
-DECLARE @NOW AS DATETIME2;
+DECLARE @DateBefore AS DATETIME2;
 
-SET @NOW = GETUTCDATE();
+--IF we don't want to include unpblished data we want data that has a published date in the past
+--IF we do want unpublished data we want data older than 10 years in the future - same as all dates
+IF @IncludeUnpublishedData = 0
+	SET @DateBefore = GETUTCDATE();
+ELSE
+	SET @DateBefore = DateAdd(yy, 10, GETDATE());
 
 WITH --- Get the Benchmark Areas - these are areas of a specific type which are descendants of the benchmark areaGroup
 BenchmarkAreas AS (
@@ -38,7 +44,7 @@ LatestDatePerIndicatorSegment AS (
     FROM indicatorSegments AS indSeg
         JOIN dbo.HealthMeasure hm ON hm.IndicatorKey = indSeg.IndicatorKey
         AND hm.PeriodKey = indSeg.PeriodKey
-    WHERE hm.PublishedAt <= @NOW
+    WHERE hm.PublishedAt <= @DateBefore
     GROUP BY hm.IndicatorKey,
         hm.PeriodKey
 ),
@@ -58,7 +64,7 @@ ComparisonAreaValue AS (
             AND hm.IsAgeAggregatedOrSingle = 1
             AND hm.IsDeprivationAggregatedOrSingle = 1
         )
-        AND hm.PublishedAt <= @NOW
+        AND hm.PublishedAt <= @DateBefore
 ),
 ComparisonAncestor AS (
     SELECT latestDatePerSegment.IndicatorKey,
@@ -76,7 +82,7 @@ ComparisonAncestor AS (
             AND hm.IsAgeAggregatedOrSingle = 1
             AND hm.IsDeprivationAggregatedOrSingle = 1
         )
-        AND hm.PublishedAt <= @NOW
+        AND hm.PublishedAt <= @DateBefore
 ),
 EnglandValue AS (
     SELECT latestDatePerSegment.IndicatorKey,
@@ -94,7 +100,7 @@ EnglandValue AS (
             AND hm.IsAgeAggregatedOrSingle = 1
             AND hm.IsDeprivationAggregatedOrSingle = 1
         )
-        AND hm.PublishedAt <= @NOW
+        AND hm.PublishedAt <= @DateBefore
 ),
 --- This finds ALL data points in England of the same areaType which are aggregated (not inequalities) data points
 HealthData AS (
@@ -125,7 +131,7 @@ HealthData AS (
             AND hm.IsAgeAggregatedOrSingle = 1
             AND hm.IsDeprivationAggregatedOrSingle = 1
         )
-        AND hm.PublishedAt <= @NOW
+        AND hm.PublishedAt <= @DateBefore
 ),
 --- Calculate Quartiles
 QuartileData AS (

--- a/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
+++ b/frontend/fingertips-frontend/generated-sources/ft-api-client/apis/IndicatorsApi.ts
@@ -80,6 +80,14 @@ export interface IndicatorsIndicatorIdDataPostRequest {
     file?: Blob;
 }
 
+export interface IndicatorsQuartilesAllGetRequest {
+    ancestorCode?: string;
+    areaCode?: string;
+    areaType?: string;
+    indicatorIds?: Array<number>;
+    benchmarkRefType?: BenchmarkReferenceType;
+}
+
 export interface IndicatorsQuartilesGetRequest {
     ancestorCode?: string;
     areaCode?: string;
@@ -211,7 +219,27 @@ export interface IndicatorsApiInterface {
     indicatorsIndicatorIdDataPost(requestParameters: IndicatorsIndicatorIdDataPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<string>;
 
     /**
-     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately.
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
+     * @summary Get quartile values for indicators
+     * @param {string} [ancestorCode] The area code of an ancestor area
+     * @param {string} [areaCode] The area code of the area/ geography
+     * @param {string} [areaType] The area type which the areas belong to
+     * @param {Array<number>} [indicatorIds] A list of indicator_ids, up to 10 can be requested
+     * @param {BenchmarkReferenceType} [benchmarkRefType] The benchmark reference type
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof IndicatorsApiInterface
+     */
+    indicatorsQuartilesAllGetRaw(requestParameters: IndicatorsQuartilesAllGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<QuartileData>>>;
+
+    /**
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
+     * Get quartile values for indicators
+     */
+    indicatorsQuartilesAllGet(requestParameters: IndicatorsQuartilesAllGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<QuartileData>>;
+
+    /**
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
      * @summary Get quartile values for indicators
      * @param {string} [ancestorCode] The area code of an ancestor area
      * @param {string} [areaCode] The area code of the area/ geography
@@ -225,7 +253,7 @@ export interface IndicatorsApiInterface {
     indicatorsQuartilesGetRaw(requestParameters: IndicatorsQuartilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<QuartileData>>>;
 
     /**
-     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately.
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
      * Get quartile values for indicators
      */
     indicatorsQuartilesGet(requestParameters: IndicatorsQuartilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<QuartileData>>;
@@ -541,7 +569,55 @@ export class IndicatorsApi extends runtime.BaseAPI implements IndicatorsApiInter
     }
 
     /**
-     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately.
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
+     * Get quartile values for indicators
+     */
+    async indicatorsQuartilesAllGetRaw(requestParameters: IndicatorsQuartilesAllGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<QuartileData>>> {
+        const queryParameters: any = {};
+
+        if (requestParameters['ancestorCode'] != null) {
+            queryParameters['ancestor_code'] = requestParameters['ancestorCode'];
+        }
+
+        if (requestParameters['areaCode'] != null) {
+            queryParameters['area_code'] = requestParameters['areaCode'];
+        }
+
+        if (requestParameters['areaType'] != null) {
+            queryParameters['area_type'] = requestParameters['areaType'];
+        }
+
+        if (requestParameters['indicatorIds'] != null) {
+            queryParameters['indicator_ids'] = requestParameters['indicatorIds'];
+        }
+
+        if (requestParameters['benchmarkRefType'] != null) {
+            queryParameters['benchmark_ref_type'] = requestParameters['benchmarkRefType'];
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/indicators/quartiles/all`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(QuartileDataFromJSON));
+    }
+
+    /**
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
+     * Get quartile values for indicators
+     */
+    async indicatorsQuartilesAllGet(requestParameters: IndicatorsQuartilesAllGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<QuartileData>> {
+        const response = await this.indicatorsQuartilesAllGetRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
      * Get quartile values for indicators
      */
     async indicatorsQuartilesGetRaw(requestParameters: IndicatorsQuartilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<QuartileData>>> {
@@ -580,7 +656,7 @@ export class IndicatorsApi extends runtime.BaseAPI implements IndicatorsApiInter
     }
 
     /**
-     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately.
+     * Get quartile information for many indicators for one area. This will calculate the quartile based on all areas of the specified type within either England or a sub-national area, depending on the benchmark_ref_type parameter. It will use the latest data available for the area group requested. If the indicator has data for more than one time period type then the API will return data for each data period type separately. The /all endpoint can return unpublished data, otherwise the data is published.
      * Get quartile values for indicators
      */
     async indicatorsQuartilesGet(requestParameters: IndicatorsQuartilesGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<QuartileData>> {


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1090](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1090)

Add a new endpoint to the IndicatorsController to get get unpublished quartile data. This will require authorisation, this will be added in a later PR.

## Changes

- New endpoint
- Update the GetIndicatorQuartileDataForLatestYear stored procedure to return unpublished data if present
- Update service and repository code to pass in a flag to allow the return of unpublished data
- Update PopulateFingertips.sql to ensure the test unpublished data dates are correctly set

## Validation

Add http test to test that unpublished data is correctly returned
