### PR TITLE
DHSCFT-1127 drop thresholds to 90 percent

### DIFF
--- a/frontend/fingertips-frontend/vitest.config.ts
+++ b/frontend/fingertips-frontend/vitest.config.ts
@@ -16,10 +16,10 @@ export default defineConfig({
       enabled: true,
       reporter: ['lcov', 'text', 'text-summary'],
       thresholds: {
-        statements: 96.8,
-        branches: 92.41,
-        functions: 93.55,
-        lines: 96.8,
+        statements: 90,
+        branches: 90,
+        functions: 90,
+        lines: 90,
       },
       include: ['**/*.ts', '**/*.tsx'],
       exclude: [


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1127](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1127)

dropped the unit test coverage thresholds to 90% across the board

## Validation
 
tests continue to pass
