### PR TITLE
Bugfix/dhscft 1116 header home link covered

### DIFF
--- a/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.styles.tsx
+++ b/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.styles.tsx
@@ -4,6 +4,7 @@ export const PositionWrapper = styled.div({
   position: 'absolute',
   width: '50%',
   left: '25%',
+  pointerEvents: 'none',
 });
 
 export const Content = styled.div({
@@ -12,4 +13,5 @@ export const Content = styled.div({
   height: '100%',
   margin: '0 0 0 auto',
   padding: '8px 0 8px 8px',
+  pointerEvents: 'auto',
 });

--- a/frontend/fingertips-frontend/components/molecules/Header/__snapshots__/Header.test.tsx.snap
+++ b/frontend/fingertips-frontend/components/molecules/Header/__snapshots__/Header.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`Header > should match snapshot 1`] = `
   <header>
     <div>
       <div
-        class="sc-gEvEer EJneB"
+        class="sc-gEvEer BCeNE"
       >
         <div
-          class="sc-eqUAAy kOTYac"
+          class="sc-eqUAAy hgRCKa"
         >
           <button
             class="sc-aXZVg kBvuNF"
@@ -72,6 +72,7 @@ exports[`Header > should match snapshot 1`] = `
             >
               <a
                 class="top-nav-anchor__TopNavAnchor-sc-lt39h5-0 nav-link-anchor__NavLinkAnchor-sc-1pr115z-0 dlfbAW eawaIf"
+                data-testid="header-home-nav"
                 href="/"
               >
                 <span

--- a/frontend/fingertips-frontend/components/molecules/Header/index.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Header/index.tsx
@@ -30,7 +30,7 @@ export function FTHeader({
         <AuthHeader session={session} />
         <TopNav
           serviceTitle={
-            <TopNav.NavLink href="/">
+            <TopNav.NavLink href="/" data-testid="header-home-nav">
               <ServiceTitle>{siteTitle}</ServiceTitle>
             </TopNav.NavLink>
           }

--- a/frontend/fingertips-frontend/playwright/page-objects/basePage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/basePage.ts
@@ -6,6 +6,7 @@ import { spaceSeparatedPattern } from '@/lib/constants';
 
 export default class BasePage {
   readonly errorPageTitleHeaderId = 'error-page-title';
+  readonly headerHomeLinkId = 'header-home-nav';
 
   constructor(public readonly page: PlaywrightPage) {}
 
@@ -176,6 +177,12 @@ export default class BasePage {
   async verifyUrlUpdatedAfterDeselection(deselectedIndicator: string) {
     await expect(this.page).not.toHaveURL(
       new RegExp(`&is=${deselectedIndicator}`)
+    );
+  }
+
+  async clickHeaderHomeNavigation() {
+    await this.clickAndAwaitLoadingComplete(
+      this.page.getByTestId(this.headerHomeLinkId)
     );
   }
 }

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -167,6 +167,20 @@ test.describe('Home Page Tests', () => {
       });
     }
   );
+
+  test('header nav link should return user to home page', async ({
+    homePage,
+    resultsPage,
+  }) => {
+    await test.step('Navigate directly to results page', async () => {
+      await resultsPage.navigateToResults(subjectSearchTerm, []);
+    });
+
+    await test.step('Navigate to home page', async () => {
+      await resultsPage.clickHeaderHomeNavigation();
+      await homePage.checkOnHomePage();
+    });
+  });
 });
 
 test.describe('Results Page Tests', () => {


### PR DESCRIPTION
stops the auth header from occluding the real header

couldn't do it as a unit test because JSDOM isn't clever enough in the right ways so extended the UI tests