### PR TITLE
DHSCFT-886_loosen_upload_ui_e2e_assertion

### DIFF
--- a/api/DHSC.FingertipsNext.Api.IntegrationTests/UserAuth/UserAuthenticationIntegrationTests.cs
+++ b/api/DHSC.FingertipsNext.Api.IntegrationTests/UserAuth/UserAuthenticationIntegrationTests.cs
@@ -19,7 +19,7 @@ public class UserAuthenticationIntegrationTests : IClassFixture<WebApplicationFa
     /// The entra group ID for the dev database for indicator 41101.
     /// If this value in the db changes, then this needs to be updated accordingly.
     /// </summary>
-    private const string Indicator41101GroupRoleId = "6a953232-afad-4406-a457-9960eec316ac";
+    private const string Indicator41101GroupRoleId = "90ac52f4-8513-4050-873a-24340bc89bd3";
 
     private readonly WebApplicationFactory<Program> _appFactory;
 

--- a/frontend/fingertips-frontend/playwright/page-objects/pages/uploadPage.ts
+++ b/frontend/fingertips-frontend/playwright/page-objects/pages/uploadPage.ts
@@ -90,10 +90,12 @@ export default class UploadPage extends BasePage {
       this.page.getByTestId(this.batchListTableTestId)
     ).toBeVisible();
     await expect(
-      this.page.getByRole('button', { name: this.deleteSubmissionButtonText })
+      this.page
+        .getByRole('button', { name: this.deleteSubmissionButtonText })
+        .first()
     ).toHaveCount(1);
-    await expect(this.page.getByRole('cell', { name: fileName })).toHaveCount(
-      2
-    );
+    await expect(
+      this.page.getByRole('cell', { name: fileName }).first()
+    ).toHaveCount(1);
   }
 }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-886](https://bjss-enterprise.atlassian.net/browse/DHSCFT-886)

1.  loosen the upload e2e test so that it isnt looking for a specific number of rows in the table (as this will change) - just that there is at least 1 row in the table

2. address the API Integration tests failure

## Validation

For 1 i have run the e2e CD tests locally against the deployed env and seen them pass with the fix/
