### PR TITLE
Bugfix/dhscft tech remove token from session

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,18 +10,23 @@ DB_PASSWORD=
 #UPLOAD_STORAGE_ACCOUNT_CONNECTION_STRING=""
 UPLOAD_STORAGE_CONTAINER_NAME=fingertips-upload-container
 
+### Authentication ###
+
+# bare minimum for the compose to run is: 
+# API authentication env vars populated - placeholder values below are fine
+# and AUTH_SECRET to be populated
+
+# api authentication integration - values provided by OIDC provider
+AZUREAD__INSTANCE="https://foobar.example.com/"
+AZUREAD__TENANTID="tenant-id"
+AZUREAD__CLIENTID="client-id"
+
 # local authentication secret for the frontend - mandatory
 # can be populated locally with npm exec auth secret
 AUTH_SECRET=""
 
-
 # frontend authentication integration - values provided by OIDC provider
-AUTH_CLIENT_ID=""
-AUTH_CLIENT_SECRET=""
-AUTH_ISSUER=""
-AUTH_WELLKNOWN=""
-
-# api authentication integration - values provided by OIDC provider
-AZUREAD__INSTANCE=""
-AZUREAD__TENANTID=""
-AZUREAD__CLIENTID=""
+AUTH_CLIENT_ID="client-id"
+AUTH_CLIENT_SECRET="client-secret"
+AUTH_ISSUER="https://tenant-id.example.com/tenant-id/v2.0"
+AUTH_WELLKNOWN="https://login.example.com/tenant-id/v2.0/.well-known/openid-configuration"

--- a/frontend/fingertips-frontend/app/layout.tsx
+++ b/frontend/fingertips-frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import '../global.css';
 import { siteDescription, siteTitle } from '@/lib/constants';
 import { HeaderFooterWrapper } from '@/components/molecules/HeaderFooterWrapper';
 import { auth } from '@/lib/auth';
+import { LoaderProvider } from '@/context/LoaderContext';
 
 export const metadata: Metadata = {
   title: siteTitle,
@@ -27,13 +28,15 @@ export default async function RootLayout({
     <html lang="en">
       <body style={{ margin: 0 }}>
         <StyledComponentsRegistry>
-          <HeaderFooterWrapper
-            tag={tag}
-            hash={hash}
-            session={session ?? undefined}
-          >
-            <FTContainer>{children}</FTContainer>
-          </HeaderFooterWrapper>
+          <LoaderProvider>
+            <HeaderFooterWrapper
+              tag={tag}
+              hash={hash}
+              session={session ?? undefined}
+            >
+              <FTContainer>{children}</FTContainer>
+            </HeaderFooterWrapper>
+          </LoaderProvider>
         </StyledComponentsRegistry>
       </body>
     </html>

--- a/frontend/fingertips-frontend/components/atoms/AuthButton/AuthButton.test.tsx
+++ b/frontend/fingertips-frontend/components/atoms/AuthButton/AuthButton.test.tsx
@@ -1,8 +1,10 @@
+// MUST BE AT THE TOP DUE TO HOISTING OF MOCKED MODULES
+import { mockSetIsLoading } from '@/mock/utils/mockUseLoadingState';
+//
 import { render } from '@testing-library/react';
 import { AuthButton } from '.';
 import userEvent from '@testing-library/user-event';
 import { signInHandler, signOutHandler } from '@/lib/auth/handlers';
-import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
@@ -11,17 +13,7 @@ vi.mock('@/lib/auth/handlers', () => {
   };
 });
 
-const mockSetIsLoading = vi.fn();
-const mockLoaderContext: LoaderContext = {
-  getIsLoading: vi.fn(),
-  setIsLoading: mockSetIsLoading,
-};
-
-vi.mock('@/context/LoaderContext', () => {
-  return {
-    useLoadingState: () => mockLoaderContext,
-  };
-});
+mockSetIsLoading.mockReturnValue(false);
 
 describe('auth button', () => {
   beforeEach(vi.clearAllMocks);

--- a/frontend/fingertips-frontend/components/atoms/AuthButton/AuthButton.test.tsx
+++ b/frontend/fingertips-frontend/components/atoms/AuthButton/AuthButton.test.tsx
@@ -2,11 +2,24 @@ import { render } from '@testing-library/react';
 import { AuthButton } from '.';
 import userEvent from '@testing-library/user-event';
 import { signInHandler, signOutHandler } from '@/lib/auth/handlers';
+import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
     signInHandler: vi.fn(),
     signOutHandler: vi.fn(),
+  };
+});
+
+const mockSetIsLoading = vi.fn();
+const mockLoaderContext: LoaderContext = {
+  getIsLoading: vi.fn(),
+  setIsLoading: mockSetIsLoading,
+};
+
+vi.mock('@/context/LoaderContext', () => {
+  return {
+    useLoadingState: () => mockLoaderContext,
   };
 });
 

--- a/frontend/fingertips-frontend/components/atoms/AuthButton/index.tsx
+++ b/frontend/fingertips-frontend/components/atoms/AuthButton/index.tsx
@@ -1,6 +1,8 @@
 import { Session } from 'next-auth';
 import { signOutHandler, signInHandler } from '@/lib/auth/handlers';
 import { StyledAuthButton } from './AuthButton.styles';
+import { useLoadingState } from '@/context/LoaderContext';
+import { useEffect } from 'react';
 
 interface AuthButtonProps {
   session?: Session;
@@ -11,16 +13,38 @@ export function AuthButton({ session }: Readonly<AuthButtonProps>) {
 }
 
 function SignInButton() {
+  const { setIsLoading } = useLoadingState();
+  useEffect(() => {
+    setIsLoading(false);
+  });
+
   return (
-    <StyledAuthButton data-testid="sign-in-button" onClick={signInHandler}>
+    <StyledAuthButton
+      data-testid="sign-in-button"
+      onClick={() => {
+        setIsLoading(true);
+        signInHandler();
+      }}
+    >
       Sign in
     </StyledAuthButton>
   );
 }
 
 function SignOutButton() {
+  const { setIsLoading } = useLoadingState();
+  useEffect(() => {
+    setIsLoading(false);
+  });
+
   return (
-    <StyledAuthButton data-testid="sign-out-button" onClick={signOutHandler}>
+    <StyledAuthButton
+      data-testid="sign-out-button"
+      onClick={() => {
+        setIsLoading(true);
+        signOutHandler();
+      }}
+    >
       Sign out
     </StyledAuthButton>
   );

--- a/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
+++ b/frontend/fingertips-frontend/components/forms/IndicatorSearchForm/IndicatorSearchForm.test.tsx
@@ -30,6 +30,7 @@ const mockLoaderContext: LoaderContext = {
   getIsLoading: vi.fn(),
   setIsLoading: mockSetIsLoading,
 };
+
 vi.mock('@/context/LoaderContext', () => {
   return {
     useLoadingState: () => mockLoaderContext,

--- a/frontend/fingertips-frontend/components/layouts/container/index.tsx
+++ b/frontend/fingertips-frontend/components/layouts/container/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { LoaderProvider } from '@/context/LoaderContext';
 import { Main } from 'govuk-react';
 import styled from 'styled-components';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -20,14 +19,12 @@ export function FTContainer({
   return (
     <QueryClientProvider client={reactQueryClient}>
       <ModalProvider>
-        <LoaderProvider>
-          <main>
-            <StyledMain>{children}</StyledMain>
-          </main>
-          <Suspense>
-            <FocusOnFragment />
-          </Suspense>
-        </LoaderProvider>
+        <main>
+          <StyledMain>{children}</StyledMain>
+        </main>
+        <Suspense>
+          <FocusOnFragment />
+        </Suspense>
       </ModalProvider>
       {process.env.NODE_ENV === 'development' ? (
         <ReactQueryDevtools initialIsOpen={false} />

--- a/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.test.tsx
@@ -2,11 +2,24 @@ import { render } from '@testing-library/react';
 import { AuthHeader } from '.';
 import { signInHandler, signOutHandler } from '@/lib/auth/handlers';
 import userEvent from '@testing-library/user-event';
+import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
     signInHandler: vi.fn(),
     signOutHandler: vi.fn(),
+  };
+});
+
+const mockSetIsLoading = vi.fn();
+const mockLoaderContext: LoaderContext = {
+  getIsLoading: vi.fn(),
+  setIsLoading: mockSetIsLoading,
+};
+
+vi.mock('@/context/LoaderContext', () => {
+  return {
+    useLoadingState: () => mockLoaderContext,
   };
 });
 

--- a/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/AuthHeader/AuthHeader.test.tsx
@@ -1,8 +1,10 @@
+// MUST BE AT THE TOP DUE TO HOISTING OF MOCKED MODULES
+import { mockSetIsLoading } from '@/mock/utils/mockUseLoadingState';
+//
 import { render } from '@testing-library/react';
 import { AuthHeader } from '.';
 import { signInHandler, signOutHandler } from '@/lib/auth/handlers';
 import userEvent from '@testing-library/user-event';
-import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
@@ -11,17 +13,7 @@ vi.mock('@/lib/auth/handlers', () => {
   };
 });
 
-const mockSetIsLoading = vi.fn();
-const mockLoaderContext: LoaderContext = {
-  getIsLoading: vi.fn(),
-  setIsLoading: mockSetIsLoading,
-};
-
-vi.mock('@/context/LoaderContext', () => {
-  return {
-    useLoadingState: () => mockLoaderContext,
-  };
-});
+mockSetIsLoading.mockReturnValue(false);
 
 describe('auth header', () => {
   it('should render a sign in button if session is undefined', () => {

--- a/frontend/fingertips-frontend/components/molecules/Header/Header.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Header/Header.test.tsx
@@ -1,10 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import { FTHeader } from '.';
+import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
     signInHandler: vi.fn(),
     signOutHandler: vi.fn(),
+  };
+});
+
+const mockSetIsLoading = vi.fn();
+const mockLoaderContext: LoaderContext = {
+  getIsLoading: vi.fn(),
+  setIsLoading: mockSetIsLoading,
+};
+
+vi.mock('@/context/LoaderContext', () => {
+  return {
+    useLoadingState: () => mockLoaderContext,
   };
 });
 

--- a/frontend/fingertips-frontend/components/molecules/Header/Header.test.tsx
+++ b/frontend/fingertips-frontend/components/molecules/Header/Header.test.tsx
@@ -1,6 +1,8 @@
+// MUST BE AT THE TOP DUE TO HOISTING OF MOCKED MODULES
+import { mockSetIsLoading } from '@/mock/utils/mockUseLoadingState';
+//
 import { render, screen } from '@testing-library/react';
 import { FTHeader } from '.';
-import { LoaderContext } from '@/context/LoaderContext';
 
 vi.mock('@/lib/auth/handlers', () => {
   return {
@@ -9,17 +11,7 @@ vi.mock('@/lib/auth/handlers', () => {
   };
 });
 
-const mockSetIsLoading = vi.fn();
-const mockLoaderContext: LoaderContext = {
-  getIsLoading: vi.fn(),
-  setIsLoading: mockSetIsLoading,
-};
-
-vi.mock('@/context/LoaderContext', () => {
-  return {
-    useLoadingState: () => mockLoaderContext,
-  };
-});
+mockSetIsLoading.mockReturnValue(false);
 
 describe('Header', () => {
   it('should match snapshot', () => {

--- a/frontend/fingertips-frontend/lib/auth/accessToken.ts
+++ b/frontend/fingertips-frontend/lib/auth/accessToken.ts
@@ -4,20 +4,26 @@ import { auth } from '@/lib/auth';
 import { getToken } from 'next-auth/jwt';
 import { cookies, headers } from 'next/headers';
 
-export const addTokenToHeaders = async (
-  headers: HeadersInit = {}
-): Promise<HeadersInit> => {
-  const session = await auth();
-  if (!session) {
-    return headers;
-  }
+export const getAuthHeader = async (): Promise<HeadersInit | undefined> => {
+  const accessToken = await getAccessToken();
 
-  const jwt = await getJwt();
+  if (!accessToken) return undefined;
 
-  return { ...headers, Authorization: `bearer ${jwt?.accessToken}` };
+  return { Authorization: `bearer ${accessToken}` };
 };
 
-const getJwt = async () => {
+const getAccessToken = async () => {
+  const session = await auth();
+  if (!session) {
+    return undefined;
+  }
+
+  const jwt = await getJWT();
+
+  return jwt?.accessToken;
+};
+
+const getJWT = async () => {
   const req = {
     headers: Object.fromEntries(await headers()),
     cookies: Object.fromEntries(

--- a/frontend/fingertips-frontend/lib/auth/config.ts
+++ b/frontend/fingertips-frontend/lib/auth/config.ts
@@ -34,7 +34,7 @@ export class AuthConfigFactory {
           // nextjs still complains that the user api code isn't built for the edge runtime
           // even if it will never be called
           if (process.env.NEXT_RUNTIME === 'nodejs') {
-            const { validateAccessToken } = await import(
+            const { validateUser: validateAccessToken } = await import(
               '@/lib/auth/validation'
             );
 
@@ -48,5 +48,11 @@ export class AuthConfigFactory {
     };
 
     return config;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accessToken?: string;
   }
 }

--- a/frontend/fingertips-frontend/lib/auth/headers.ts
+++ b/frontend/fingertips-frontend/lib/auth/headers.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { getToken } from 'next-auth/jwt';
+import { cookies, headers } from 'next/headers';
+
+export const addTokenToHeaders = async (
+  headers: HeadersInit = {}
+): Promise<HeadersInit> => {
+  const session = await auth();
+  if (!session) {
+    return headers;
+  }
+
+  const jwt = await getJwt();
+
+  return { ...headers, Authorization: `bearer ${jwt?.accessToken}` };
+};
+
+const getJwt = async () => {
+  const req = {
+    headers: Object.fromEntries(await headers()),
+    cookies: Object.fromEntries(
+      (await cookies()).getAll().map((c) => [c.name, c.value])
+    ),
+  };
+
+  const token = await getToken({ req, secret: process.env.AUTH_SECRET });
+
+  return token;
+};

--- a/frontend/fingertips-frontend/lib/auth/validation.ts
+++ b/frontend/fingertips-frontend/lib/auth/validation.ts
@@ -1,8 +1,8 @@
 import { UserInfoType } from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
-import { addTokenToHeaders } from '@/lib/auth/headers';
+import { getAccessToken } from '@/lib/auth/accessToken';
 
-export const validateAccessToken = async (): Promise<boolean> => {
+export const validateUser = async (): Promise<boolean> => {
   const userResponse = await getUser();
   if (userResponse) {
     return true;
@@ -14,9 +14,14 @@ async function getUser() {
   const userApi = ApiClientFactory.getUserApiClient();
   let userInfoResponse: UserInfoType;
 
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    return undefined;
+  }
+
   try {
     userInfoResponse = await userApi.getUserInfo({
-      headers: await addTokenToHeaders(),
+      headers: { Authorization: `bearer ${accessToken}` },
     });
   } catch {
     console.log('unable to validate user');

--- a/frontend/fingertips-frontend/lib/auth/validation.ts
+++ b/frontend/fingertips-frontend/lib/auth/validation.ts
@@ -1,23 +1,22 @@
 import { UserInfoType } from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import { addTokenToHeaders } from '@/lib/auth/headers';
 
-export const validateAccessToken = async (
-  accessToken: string
-): Promise<boolean> => {
-  const userResponse = await getUser(accessToken);
+export const validateAccessToken = async (): Promise<boolean> => {
+  const userResponse = await getUser();
   if (userResponse) {
     return true;
   }
   return false;
 };
 
-async function getUser(accessToken: string) {
+async function getUser() {
   const userApi = ApiClientFactory.getUserApiClient();
   let userInfoResponse: UserInfoType;
 
   try {
     userInfoResponse = await userApi.getUserInfo({
-      headers: { Authorization: `bearer ${accessToken}` },
+      headers: await addTokenToHeaders(),
     });
   } catch {
     console.log('unable to validate user');

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -147,26 +147,24 @@ test.describe('Home Page Tests', () => {
     });
   });
 
-  // fails due to loading screen notyet implemented on auth flow
-  test.fixme(
-    'should display Sign out after successful mock sign in',
-    async ({ homePage }) => {
-      await test.step('Navigate to home page', async () => {
-        await homePage.navigateToHomePage();
-        await homePage.checkOnHomePage();
-      });
+  test('should display Sign out after successful mock sign in', async ({
+    homePage,
+  }) => {
+    await test.step('Navigate to home page', async () => {
+      await homePage.navigateToHomePage();
+      await homePage.checkOnHomePage();
+    });
 
-      await test.step('Click Sign in button', async () => {
-        await homePage.clickSignIn();
-      });
+    await test.step('Click Sign in button', async () => {
+      await homePage.clickSignIn();
+    });
 
-      await test.step('Enter correct email but incorrect password and verify correct message is displayed', async () => {
-        await homePage.signInToMock(password);
+    await test.step('Enter correct password and verify message is displayed', async () => {
+      await homePage.signInToMock(password);
 
-        await homePage.checkSignOutDisplayed();
-      });
-    }
-  );
+      await homePage.checkSignOutDisplayed();
+    });
+  });
 
   test('header nav link should return user to home page', async ({
     homePage,


### PR DESCRIPTION
Previously we were attaching the access token to the user session, but this leaks it to the client when it doesn't need to be through the session callback

this keeps it inside the server and reads the req cookie directly to access it

added some helper functions


manually tested
unit tests WIP - we won't be able to unit test the root getJWT function unless I crack header/cookies context in unit tests