### PR TITLE
add loading provider to error page

### DIFF
--- a/frontend/fingertips-frontend/app/global-error.tsx
+++ b/frontend/fingertips-frontend/app/global-error.tsx
@@ -5,6 +5,7 @@ import { FTHeader } from '@/components/molecules/Header';
 import { FTContainer } from '@/components/layouts/container';
 import { FTFooter } from '@/components/molecules/Footer';
 import { ErrorPage } from '@/components/pages/error';
+import { LoaderProvider } from '@/context/LoaderContext';
 
 // next.js will only use this page in production builds, meaning that
 // in dev builds you will see the developer oriented unhandled exception
@@ -16,11 +17,13 @@ export default function GlobalError() {
     <html lang="en">
       <body>
         <StyledComponentsRegistry>
-          <FTHeader />
-          <FTContainer>
-            <ErrorPage />
-          </FTContainer>
-          <FTFooter />
+          <LoaderProvider>
+            <FTHeader />
+            <FTContainer>
+              <ErrorPage />
+            </FTContainer>
+            <FTFooter />
+          </LoaderProvider>
         </StyledComponentsRegistry>
       </body>
     </html>


### PR DESCRIPTION
ronseal

no test - react is unhappy if you render <html> and <body> tags inside a div, but the global error page requires those tags. And testing-library/react renders them in a div. So it has spurious errors.