### PR TITLE
Sort healthdata by enddate as well as by start date 

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Repository/HealthDataRepository.cs
@@ -101,6 +101,7 @@ public class HealthDataRepository(HealthDataDbContext healthDataDbContext) : IHe
             .Include(healthMeasure => healthMeasure.DeprivationDimension)
             .Include(healthMeasure => healthMeasure.TrendDimension)
             .OrderBy(healthMeasure => healthMeasure.FromDateDimension.Date)
+            .ThenBy(healthMeasure => healthMeasure.ToDateDimension.Date)
             .AsNoTracking()
             .ToListAsync();
 


### PR DESCRIPTION
Handle ordering cumulative data without affecting other data.

# Description

Jira ticket: [DHSCFT-1163](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1163)

Health data is ordered by stat date. That is fine for most indicators, however cumulative data all has the same start date for all health data. This PR adds an additional ordering in the database query to also order by end date to ensure that all health data is correctly ordered. This should not affect the ordering of other indicator data, just 91112.

## Changes

- Add an additional order by in the HealthDataRepository

## Validation

Run HTTP tests and check they work.
Ensure the data for indicator 91112 is ordered correctly by date (it wasn't before)
