### PR TITLE
DHSCFT-1188: Bug fix for benchmarking inequalities when there is no aggregate value to be found

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.HealthData.Service/BenchmarkComparisonEngine.cs
+++ b/api/DHSC.FingertipsNext.Modules.HealthData.Service/BenchmarkComparisonEngine.cs
@@ -61,18 +61,27 @@ internal static class BenchmarkComparisonEngine
                     polarity);
 
             // Perform Inequality benchmarking against aggregate segment
-            var aggregateSegment = areaHealthData.IndicatorSegments.First(segment => segment.IsAggregate);
+            var aggregateSegment = areaHealthData.IndicatorSegments.FirstOrDefault(segment => segment.IsAggregate);
             var newIndicatorSegments = new List<IndicatorSegment>();
-            foreach (var targetSegment in areaHealthData.IndicatorSegments)
+
+            // There may not be an aggregateSegment available - check for this and just return the original segments without benchmarking
+            if (aggregateSegment != null)
             {
-                var newSegment = ProcessBenchmarkComparisonsForAreaSegment(
-                    targetSegment,
-                    aggregateSegment,
-                    areaHealthData.AreaCode,
-                    areaHealthData.AreaName,
-                    polarity
-                );
-                newIndicatorSegments.Add(newSegment);
+                foreach (var targetSegment in areaHealthData.IndicatorSegments)
+                {
+                    var newSegment = ProcessBenchmarkComparisonsForAreaSegment(
+                        targetSegment,
+                        aggregateSegment,
+                        areaHealthData.AreaCode,
+                        areaHealthData.AreaName,
+                        polarity
+                    );
+                    newIndicatorSegments.Add(newSegment);
+                }
+            }
+            else
+            {
+                newIndicatorSegments.AddRange(areaHealthData.IndicatorSegments);
             }
 
             var newAreaHealthData = new HealthDataForArea

--- a/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-inequalities.http
+++ b/api/DHSC.FingertipsNext.Modules.HealthData/HttpClientScripts/test-indicators-inequalities.http
@@ -138,3 +138,20 @@ GET http://localhost:5144/indicators/92708/data?area_codes=E92000001&inequalitie
         });
     });
 %}
+
+
+
+### GET inequality for when there is no 'aggregate' data available - check benchmarkComparison is null
+GET http://localhost:5144/indicators/90362/data?area_codes=E92000001&area_type=england&[…]rk_ref_type=England&inequalities=sex&inequalities=deprivation 
+> {%
+    client.test("Expected health data returned with sex inequalities breakdown", function (callbackfn, thisArg) {
+        client.assert(response.status === 200, "Response status is not 200");
+
+        response.body.areaHealthData[0].indicatorSegments[0].healthData.forEach((dataPoint) => {
+             client.assert(
+               dataPoint.benchmarkComparison === null,
+                `HealthData expected to have null benchmarkComparison, but found ${dataPoint.benchmarkComparison}`
+            );
+        });
+    });
+%}


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1188](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1188)

Adds handling for inequalities benchmarking for the case where there isn't aggregate data available.
## Changes

- Logic for handling the scenario
- Test to validate

## Validation

New test added
Existing tests pass