### PR TITLE
Feature/dhscft 1054 block signed out upload screen

### DIFF
--- a/frontend/fingertips-frontend/app/upload/page.test.tsx
+++ b/frontend/fingertips-frontend/app/upload/page.test.tsx
@@ -1,20 +1,46 @@
+import { mockAuth, mockSession } from '@/mock/utils/mockAuth';
 import { BatchesApi } from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
 import { mockBatch } from '@/mock/data/mockBatch';
 import { mockDeep } from 'vitest-mock-extended';
 import UploadPage from './page';
+import {
+  NOT_SIGNED_IN_ERROR_MESSAGE,
+  NOT_SIGNED_IN_ERROR_TITLE,
+} from '@/lib/auth/errorMessages';
 
 const mockAuthenticatedBatchesApi = mockDeep<BatchesApi>();
+
 ApiClientFactory.getAuthenticatedBatchesApiClient = () =>
   Promise.resolve(mockAuthenticatedBatchesApi);
 
+beforeEach(vi.clearAllMocks);
+
 describe('Upload page component', () => {
   it('should make an API call to fetch batches', async () => {
+    mockAuth.mockImplementation(() => mockSession);
     mockAuthenticatedBatchesApi.getBatches.mockResolvedValue([mockBatch()]);
 
     const uploadPage = await UploadPage();
 
     expect(mockAuthenticatedBatchesApi.getBatches).toHaveBeenCalled();
     expect(uploadPage.props.batches).toEqual([mockBatch()]);
+  });
+
+  it('should not make a batches API call if user is not signed in', async () => {
+    mockAuth.mockImplementation(() => null);
+
+    const _ = await UploadPage();
+
+    expect(mockAuthenticatedBatchesApi.getBatches).not.toHaveBeenCalled();
+  });
+
+  it('should populate error page with expected props if user is not signed in', async () => {
+    mockAuth.mockImplementation(() => null);
+
+    const uploadPage = await UploadPage();
+
+    expect(uploadPage.props.title).toEqual(NOT_SIGNED_IN_ERROR_TITLE);
+    expect(uploadPage.props.description).toEqual(NOT_SIGNED_IN_ERROR_MESSAGE);
   });
 });

--- a/frontend/fingertips-frontend/app/upload/page.tsx
+++ b/frontend/fingertips-frontend/app/upload/page.tsx
@@ -1,8 +1,24 @@
+import { ErrorPage } from '@/components/pages/error';
 import { Batch } from '@/generated-sources/ft-api-client';
 import { ApiClientFactory } from '@/lib/apiClient/apiClientFactory';
+import { auth } from '@/lib/auth';
+import {
+  NOT_SIGNED_IN_ERROR_MESSAGE,
+  NOT_SIGNED_IN_ERROR_TITLE,
+} from '@/lib/auth/errorMessages';
 import { Upload } from '@/upload/components/pages/upload';
 
 export default async function UploadPage() {
+  const session = await auth();
+  if (!session) {
+    return (
+      <ErrorPage
+        title={NOT_SIGNED_IN_ERROR_TITLE}
+        description={NOT_SIGNED_IN_ERROR_MESSAGE}
+      />
+    );
+  }
+
   const batchApi = await ApiClientFactory.getAuthenticatedBatchesApiClient();
 
   let batches: Batch[] = [];

--- a/frontend/fingertips-frontend/components/pages/error/error.test.tsx
+++ b/frontend/fingertips-frontend/components/pages/error/error.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { ErrorPage } from '.';
 
@@ -7,5 +7,19 @@ describe('Error Page', () => {
     const container = render(<ErrorPage />);
 
     expect(container.asFragment()).toMatchSnapshot();
+  });
+
+  it('displays custom title and message', () => {
+    const expectedHeading = 'Custom Error Page Title';
+    const expectedMessage = 'Custom error message.';
+
+    render(<ErrorPage title={expectedHeading} description={expectedMessage} />);
+
+    expect(
+      screen.getByRole('heading', { name: expectedHeading })
+    ).toBeVisible();
+    expect(screen.getAllByRole('paragraph')[0]).toHaveTextContent(
+      expectedMessage
+    );
   });
 });

--- a/frontend/fingertips-frontend/components/pages/error/index.tsx
+++ b/frontend/fingertips-frontend/components/pages/error/index.tsx
@@ -3,17 +3,26 @@
 import { H1, Paragraph } from 'govuk-react';
 import { useEffect } from 'react';
 
-export function ErrorPage() {
+export interface ErrorPageProps {
+  title?: string;
+  description?: string;
+}
+
+const genericErrorPageTitle = 'Sorry, there is a problem with the service';
+const genericErrorPageMessage = 'Try again later.';
+
+export function ErrorPage({
+  title = genericErrorPageTitle,
+  description = genericErrorPageMessage,
+}: Readonly<ErrorPageProps>) {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <>
-      <H1 data-testid="error-page-title">
-        Sorry, there is a problem with the service
-      </H1>
-      <Paragraph>Try again later.</Paragraph>
+      <H1 data-testid="error-page-title">{title}</H1>
+      <Paragraph>{description}</Paragraph>
       <Paragraph>
         You can [go back to the homepage](/) and start your search again.
       </Paragraph>

--- a/frontend/fingertips-frontend/lib/auth/errorMessages.ts
+++ b/frontend/fingertips-frontend/lib/auth/errorMessages.ts
@@ -1,0 +1,3 @@
+export const NOT_SIGNED_IN_ERROR_TITLE = 'You are not signed in';
+export const NOT_SIGNED_IN_ERROR_MESSAGE =
+  'You need to sign in to access this page.';

--- a/frontend/fingertips-frontend/playwright/tests/fully_integrated_e2e_tests/data_upload.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/fully_integrated_e2e_tests/data_upload.spec.ts
@@ -22,7 +22,9 @@ test.describe(
     tag: [TestTag.CI, TestTag.CD],
   },
   () => {
-    test('upload a file', async ({ uploadPage }) => {
+    // The upload page requires authentication to view
+    // so this test is invalid until DHSCFT-1140 is completed
+    test.skip('upload a file', async ({ uploadPage }) => {
       await test.step('Navigate to upload page and upload a file', async () => {
         await uploadPage.navigateToUploadPage();
         await uploadPage.checkOnUploadPage();

--- a/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
+++ b/frontend/fingertips-frontend/playwright/tests/isolated_ui_tests/navigation_and_validation.spec.ts
@@ -534,6 +534,49 @@ test.describe('Navigation Tests', () => {
   });
 });
 
+test.describe('Upload Page Tests', () => {
+  test('Navigating to upload page while not signed in should show an error page', async ({
+    homePage,
+    uploadPage,
+  }) => {
+    await test.step('Navigate to home page and verify not signed in', async () => {
+      await homePage.navigateToHomePage();
+      await homePage.checkOnHomePage();
+      await homePage.checkSignInDisplayed();
+    });
+
+    await test.step('Navigate to upload page and verify error message', async () => {
+      await uploadPage.navigateToUploadPage();
+
+      await test
+        .expect(uploadPage.errorPageTitle())
+        .toContainText('You are not signed in');
+    });
+  });
+
+  test('Navigating to upload page while signed in should not show an error page', async ({
+    homePage,
+    uploadPage,
+  }) => {
+    await test.step('Navigate to home page', async () => {
+      await homePage.navigateToHomePage();
+      await homePage.checkOnHomePage();
+    });
+
+    await test.step('Sign in', async () => {
+      await homePage.clickSignIn();
+      await homePage.signInToMock(password);
+      await homePage.checkSignOutDisplayed();
+    });
+
+    await test.step('Navigate to upload page and verify no error message', async () => {
+      await uploadPage.navigateToUploadPage();
+
+      await test.expect(uploadPage.errorPageTitle()).toHaveCount(0);
+    });
+  });
+});
+
 // Capture and log out URL on test failure
 test.afterEach(async ({ page }, testInfo) => {
   if (testInfo.status !== testInfo.expectedStatus) {


### PR DESCRIPTION
Added a custom error for trying to access the upload page without a session.

Not sure if we'd rather use the experimental unauthorized feature or not
https://nextjs.org/docs/app/api-reference/file-conventions/unauthorized

added unit / UI tests, skipped a e2e test that now requires auth in the e2e tests to run
