### PR TITLE
DHSCFT-1199: Reduce Cache Expiry Time for Unpublished Data Requests

### DIFF
--- a/frontend/fingertips-frontend/components/charts/hooks/useApiGetHealthDataForAnIndicator.test.ts
+++ b/frontend/fingertips-frontend/components/charts/hooks/useApiGetHealthDataForAnIndicator.test.ts
@@ -13,6 +13,7 @@ import { IndicatorsApi } from '@/generated-sources/ft-api-client';
 import {
   API_CACHE_CONFIG,
   ApiClientFactory,
+  UNPUBLISHED_API_CACHE_CONFIG,
 } from '@/lib/apiClient/apiClientFactory';
 import { mockDeep } from 'vitest-mock-extended';
 import { mockHealthDataForArea } from '@/mock/data/mockHealthDataForArea';
@@ -102,7 +103,7 @@ describe('useApiGetHealthDataForAnIndicator', () => {
           benchmarkRefType: 'England',
           indicatorId: 123,
         },
-        API_CACHE_CONFIG
+        UNPUBLISHED_API_CACHE_CONFIG
       );
     });
 

--- a/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
+++ b/frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts
@@ -10,6 +10,7 @@ import { readEnvVar } from '../envUtils';
 import { getAuthHeader } from '@/lib/auth/accessToken';
 
 export const API_CACHE_CONFIG = { next: { revalidate: 600 } };
+export const UNPUBLISHED_API_CACHE_CONFIG = { next: { revalidate: 30 } };
 
 const buildConfig = (): Configuration => {
   const apiUrl = readEnvVar('FINGERTIPS_API_URL');

--- a/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedHealthDataForAnIndicator.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedHealthDataForAnIndicator.test.ts
@@ -9,6 +9,7 @@ import { mockDeep } from 'vitest-mock-extended';
 import {
   API_CACHE_CONFIG,
   ApiClientFactory,
+  UNPUBLISHED_API_CACHE_CONFIG,
 } from '@/lib/apiClient/apiClientFactory';
 import { mockIndicatorWithHealthDataForArea } from '@/mock/data/mockIndicatorWithHealthDataForArea';
 import { mockHealthDataForArea } from '@/mock/data/mockHealthDataForArea';
@@ -45,7 +46,7 @@ describe('getAuthorisedHealthDataForAnIndicator', () => {
 
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicatorIncludingUnpublishedData
-    ).toHaveBeenCalledWith(apiRequestParams, API_CACHE_CONFIG);
+    ).toHaveBeenCalledWith(apiRequestParams, UNPUBLISHED_API_CACHE_CONFIG);
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicator
     ).not.toHaveBeenCalled();
@@ -78,7 +79,7 @@ describe('getAuthorisedHealthDataForAnIndicator', () => {
 
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicatorIncludingUnpublishedData
-    ).toHaveBeenCalledWith(apiRequestParams, API_CACHE_CONFIG);
+    ).toHaveBeenCalledWith(apiRequestParams, UNPUBLISHED_API_CACHE_CONFIG);
     expect(mockIndicatorsApi.getHealthDataForAnIndicator).toHaveBeenCalledWith(
       apiRequestParams,
       API_CACHE_CONFIG
@@ -97,7 +98,7 @@ describe('getAuthorisedHealthDataForAnIndicator', () => {
 
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicatorIncludingUnpublishedData
-    ).toHaveBeenCalledWith(apiRequestParams, API_CACHE_CONFIG);
+    ).toHaveBeenCalledWith(apiRequestParams, UNPUBLISHED_API_CACHE_CONFIG);
     expect(mockIndicatorsApi.getHealthDataForAnIndicator).toHaveBeenCalledWith(
       apiRequestParams,
       API_CACHE_CONFIG
@@ -118,6 +119,6 @@ describe('getAuthorisedHealthDataForAnIndicator', () => {
 
     expect(
       mockIndicatorsApi.getHealthDataForAnIndicatorIncludingUnpublishedData
-    ).toHaveBeenCalledWith(apiRequestParams, API_CACHE_CONFIG);
+    ).toHaveBeenCalledWith(apiRequestParams, UNPUBLISHED_API_CACHE_CONFIG);
   });
 });

--- a/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedHealthDataForAnIndicator.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedHealthDataForAnIndicator.ts
@@ -6,6 +6,7 @@ import {
 import {
   API_CACHE_CONFIG,
   ApiClientFactory,
+  UNPUBLISHED_API_CACHE_CONFIG,
 } from '@/lib/apiClient/apiClientFactory';
 import { auth } from '@/lib/auth';
 
@@ -28,7 +29,7 @@ export async function getAuthorisedHealthDataForAnIndicator(
       await ApiClientFactory.getAuthenticatedIndicatorsApiClient();
     return await indicatorApi.getHealthDataForAnIndicatorIncludingUnpublishedData(
       apiRequestParams,
-      API_CACHE_CONFIG
+      UNPUBLISHED_API_CACHE_CONFIG
     );
   } catch (error: unknown) {
     if (

--- a/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedQuartilesDataForAnIndicator.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedQuartilesDataForAnIndicator.test.ts
@@ -10,6 +10,7 @@ import { mockDeep } from 'vitest-mock-extended';
 import {
   API_CACHE_CONFIG,
   ApiClientFactory,
+  UNPUBLISHED_API_CACHE_CONFIG,
 } from '../apiClient/apiClientFactory';
 import { mockQuartileData } from '@/mock/data/mockQuartileData';
 
@@ -65,7 +66,7 @@ describe('getAuthorisedQuartilesDataForAnIndicator', () => {
     await waitFor(() => {
       expect(mockIndicatorsApi.indicatorsQuartilesAllGet).toHaveBeenCalledWith(
         apiRequestParams,
-        API_CACHE_CONFIG
+        UNPUBLISHED_API_CACHE_CONFIG
       );
     });
     expect(mockIndicatorsApi.indicatorsQuartilesGet).not.toHaveBeenCalled();
@@ -83,7 +84,7 @@ describe('getAuthorisedQuartilesDataForAnIndicator', () => {
 
     expect(mockIndicatorsApi.indicatorsQuartilesAllGet).toHaveBeenCalledWith(
       apiRequestParams,
-      API_CACHE_CONFIG
+      UNPUBLISHED_API_CACHE_CONFIG
     );
     expect(mockIndicatorsApi.indicatorsQuartilesGet).toHaveBeenCalledWith(
       apiRequestParams,
@@ -103,7 +104,7 @@ describe('getAuthorisedQuartilesDataForAnIndicator', () => {
 
     expect(mockIndicatorsApi.indicatorsQuartilesAllGet).toHaveBeenCalledWith(
       apiRequestParams,
-      API_CACHE_CONFIG
+      UNPUBLISHED_API_CACHE_CONFIG
     );
     expect(mockIndicatorsApi.indicatorsQuartilesGet).toHaveBeenCalledWith(
       apiRequestParams,
@@ -125,7 +126,7 @@ describe('getAuthorisedQuartilesDataForAnIndicator', () => {
 
     expect(mockIndicatorsApi.indicatorsQuartilesAllGet).toHaveBeenCalledWith(
       apiRequestParams,
-      API_CACHE_CONFIG
+      UNPUBLISHED_API_CACHE_CONFIG
     );
   });
 });

--- a/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedQuartilesDataForAnIndicator.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/getAuthorisedQuartilesDataForAnIndicator.ts
@@ -6,6 +6,7 @@ import {
 import {
   API_CACHE_CONFIG,
   ApiClientFactory,
+  UNPUBLISHED_API_CACHE_CONFIG,
 } from '@/lib/apiClient/apiClientFactory';
 import { auth } from '@/lib/auth';
 
@@ -27,7 +28,7 @@ export async function getAuthorisedQuartilesDataForAnIndicator(
       await ApiClientFactory.getAuthenticatedIndicatorsApiClient();
     return await indicatorApi.indicatorsQuartilesAllGet(
       apiRequestParams,
-      API_CACHE_CONFIG
+      UNPUBLISHED_API_CACHE_CONFIG
     );
   } catch (error: unknown) {
     if (


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1199](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1199)

This PR updates the calls to request unpublished data so that they use a much shorter (30s vs 10 minutes) cache expiry time. This is to allow deletion of a batch of unpublished data to be reflected on the chart page much quicker.

## Changes

- Add a new `UNPUBLISHED_API_CACHE_CONFIG` value to `frontend/fingertips-frontend/lib/apiClient/apiClientFactory.ts`, with a 30 second cache expiry time
- Updated the call to `getHealthDataForAnIndicatorIncludingUnpublishedData` to use `UNPUBLISHED_API_CACHE_CONFIG`
- Updated the call to `indicatorsQuartilesAllGet` to use `UNPUBLISHED_API_CACHE_CONFIG`

## Validation

TODO
