### PR TITLE
DHSCFT-1202: Add an Operation Field to Batch Logs

### DIFF
--- a/api/DHSC.FingertipsNext.Modules.DataManagement.Service/DataManagementService.cs
+++ b/api/DHSC.FingertipsNext.Modules.DataManagement.Service/DataManagementService.cs
@@ -190,6 +190,7 @@ public class DataManagementService : IDataManagementService
     {
         var logObject = new BatchUploadLog
         {
+            Operation = "UploadFile",
             BatchId = batchId,
             Timestamp = valueLastModified,
             IndicatorId = indicatorId,
@@ -206,6 +207,7 @@ public class DataManagementService : IDataManagementService
     {
         var logObject = new BatchDeleteLog
         {
+            Operation = "BatchDelete",
             BatchId = deletedBatch.BatchId,
             Timestamp = timestamp,
             UserId = deletedBatch.DeletedUserId,

--- a/api/DHSC.FingertipsNext.Modules.DataManagement.Service/Models/LogClasses/BatchDeleteLog.cs
+++ b/api/DHSC.FingertipsNext.Modules.DataManagement.Service/Models/LogClasses/BatchDeleteLog.cs
@@ -4,6 +4,8 @@ namespace DHSC.FingertipsNext.Modules.DataManagement.Service.Models.LogClasses;
 
 public class BatchDeleteLog
 {
+    [JsonPropertyName("Operation")] public required string Operation { get; init; }
+
     [JsonPropertyName("OriginalFileName")] public required string OriginalFileName { get; init; }
 
     [JsonPropertyName("Timestamp")] public required DateTime? Timestamp { get; init; }

--- a/api/DHSC.FingertipsNext.Modules.DataManagement.Service/Models/LogClasses/BatchUploadLog.cs
+++ b/api/DHSC.FingertipsNext.Modules.DataManagement.Service/Models/LogClasses/BatchUploadLog.cs
@@ -4,6 +4,8 @@ namespace DHSC.FingertipsNext.Modules.DataManagement.Service.Models.LogClasses;
 
 public class BatchUploadLog
 {
+    [JsonPropertyName("Operation")] public required string Operation { get; init; }
+
     [JsonPropertyName("OriginalFileName")] public required string OriginalFileName { get; init; }
 
     [JsonPropertyName("Timestamp")] public required DateTime Timestamp { get; init; }


### PR DESCRIPTION
# Description

Jira ticket: [DHSCFT-1202](https://bjss-enterprise.atlassian.net/browse/DHSCFT-1202)

Include a summary of what this pull request is changing and any relevant background context.

## Changes

- Added an `Operation` field to `BatchUploadLog`
- Added an `Operation` field to `BatchDeleteLog`
- Set the `Operation` fields for the batch logs in `DataManagementService`

## Validation

Ran the API as part of the Docker stack locally and then used the upload page to upload a file and then delete the batch:
<img width="1275" height="406" alt="Screenshot 2025-07-31 at 17 01 06" src="https://github.com/user-attachments/assets/052f2e4d-eccb-4609-9429-dac9d2aee8f4" />
Full upload log:
```json
{"Operation":"UploadFile","OriginalFileName":"valid.csv","Timestamp":"2025-07-31T16:00:04.9925613Z","UserId":"DsZbYClNPP7PaOfnzQKQZzC-BSF7KovQSqRBxL2WmPw","PublishedAt":"2035-01-01T00:00:00Z","BatchId":"12345_2025-07-31T16:00:04.902","IndicatorId":12345}
```

<img width="1283" height="406" alt="Screenshot 2025-07-31 at 17 02 28" src="https://github.com/user-attachments/assets/0c7f08cd-60c1-48e2-b389-f4ee7c9ddbf6" />

Full delete log:
```json
{"Operation":"BatchDelete","OriginalFileName":"valid.csv","Timestamp":"2025-07-31T16:01:41.472616Z","UserId":"DsZbYClNPP7PaOfnzQKQZzC-BSF7KovQSqRBxL2WmPw","PublishedAt":"2035-01-01T00:00:00","BatchId":"12345_2025-07-31T16:00:04.902","IndicatorId":12345}
```
