### PR TITLE
DHSCFT-TECH: refactor out year for thematic map

### DIFF
--- a/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMap.tsx
+++ b/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMap.tsx
@@ -31,7 +31,6 @@ import {
   Frequency,
   PeriodType,
 } from '@/generated-sources/ft-api-client';
-import { getLatestYearForAreas } from '@/lib/chartHelpers/chartHelpers';
 
 interface ThematicMapProps {
   name?: string;
@@ -118,9 +117,6 @@ export function ThematicMap({
     { benchmarkComparisonMethod, polarity },
   ]);
 
-  const mostReccentYear = getLatestYearForAreas(healthIndicatorData);
-  if (!mostReccentYear) return;
-
   return (
     <>
       <H3 id={ChartTitleKeysEnum.ThematicMap}>
@@ -145,7 +141,6 @@ export function ThematicMap({
                 groupData={groupData}
                 polarity={polarity}
                 benchmarkToUse={benchmarkToUse}
-                year={mostReccentYear}
                 isSmallestReportingPeriod={isSmallestReportingPeriod}
               />
             </div>

--- a/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMapTooltip/ThematicMapTooltip.test.tsx
+++ b/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMapTooltip/ThematicMapTooltip.test.tsx
@@ -3,11 +3,9 @@ import { ThematicMapTooltip, ThematicMapTooltipProps } from './index';
 import {
   BenchmarkComparisonMethod,
   BenchmarkOutcome,
-  DatePeriod,
   Frequency,
   HealthDataPointTrendEnum,
   IndicatorPolarity,
-  PeriodType,
 } from '@/generated-sources/ft-api-client';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { allAgesAge, personsSex, noDeprivation } from '@/lib/mocks';
@@ -20,11 +18,13 @@ import {
   mockHealthDataForArea_England,
   mockHealthDataForArea_Group,
 } from '@/mock/data/mockHealthDataForArea';
+import { mockDatePeriod } from '@/mock/data/mockDatePeriod';
 
 const stubAreaData = mockHealthDataForArea({
   healthData: [
     {
-      year: 2023,
+      year: 0,
+      datePeriod: mockDatePeriod(2023),
       value: 1,
       ageBand: allAgesAge,
       sex: personsSex,
@@ -44,13 +44,8 @@ const stubGroupData = mockHealthDataForArea_Group();
 
 const stubEnglandData = mockHealthDataForArea_England();
 const mockFrequency = Frequency.Annually;
-const mockDatePeriod: DatePeriod = {
-  type: PeriodType.Financial,
-  from: new Date('2008-01-01'),
-  to: new Date('2008-12-31'),
-};
 const expectedDatePointLabel = formatDatePointLabel(
-  mockDatePeriod,
+  mockDatePeriod(2023),
   mockFrequency,
   true
 );
@@ -62,12 +57,11 @@ const testRender = (overides?: Partial<ThematicMapTooltipProps>) => {
     BenchmarkComparisonMethod.CIOverlappingReferenceValue95;
   const measurementUnit = overides?.measurementUnit ?? '%';
   const frequency = overides?.frequency ?? mockFrequency;
-  const latestDataPeriod = overides?.latestDataPeriod ?? mockDatePeriod;
+  const latestDataPeriod = overides?.latestDataPeriod ?? mockDatePeriod(2023);
   const englandData = overides?.englandData ?? undefined;
   const groupData = overides?.groupData ?? undefined;
   const polarity = overides?.polarity ?? IndicatorPolarity.Unknown;
   const benchmarkToUse = overides?.benchmarkToUse ?? areaCodeForEngland;
-  const year = overides?.year ?? 2023;
   render(
     <ThematicMapTooltip
       indicatorData={indicatorData}
@@ -79,7 +73,6 @@ const testRender = (overides?: Partial<ThematicMapTooltipProps>) => {
       groupData={groupData}
       polarity={polarity}
       benchmarkToUse={benchmarkToUse}
-      year={year}
       isSmallestReportingPeriod={true}
     />
   );
@@ -250,8 +243,7 @@ describe('ThematicMapTooltip', () => {
         polarity={IndicatorPolarity.Unknown}
         benchmarkToUse={areaCodeForEngland}
         frequency={mockFrequency}
-        latestDataPeriod={mockDatePeriod}
-        year={2023}
+        latestDataPeriod={mockDatePeriod(2023)}
         isSmallestReportingPeriod={true}
       />
     );

--- a/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMapTooltip/index.tsx
+++ b/frontend/fingertips-frontend/components/charts/ThematicMap/ThematicMapTooltip/index.tsx
@@ -17,7 +17,10 @@ import {
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SymbolsEnum } from '@/lib/chartHelpers/pointFormatterHelper';
 import { GovukColours } from '@/lib/styleHelpers/colours';
-import { formatDatePointLabel } from '@/lib/timePeriodHelpers/getTimePeriodLabels';
+import {
+  convertDateToNumber,
+  formatDatePointLabel,
+} from '@/lib/timePeriodHelpers/getTimePeriodLabels';
 
 export interface ThematicMapTooltipProps {
   indicatorData: HealthDataForArea;
@@ -29,7 +32,6 @@ export interface ThematicMapTooltipProps {
   groupData?: HealthDataForArea;
   polarity: IndicatorPolarity;
   benchmarkToUse?: string;
-  year: number;
   isSmallestReportingPeriod: boolean;
 }
 
@@ -43,7 +45,6 @@ export function ThematicMapTooltip({
   groupData,
   polarity,
   benchmarkToUse,
-  year,
   isSmallestReportingPeriod,
 }: Readonly<ThematicMapTooltipProps>) {
   const BenchmarkData =
@@ -52,14 +53,23 @@ export function ThematicMapTooltip({
     benchmarkToUse === areaCodeForEngland ? groupData : englandData;
 
   const mostRecentDataPointForArea = indicatorData.healthData.filter(
-    (area) => area.year === year
+    (area) =>
+      convertDateToNumber(area.datePeriod?.to) ===
+      convertDateToNumber(latestDataPeriod?.to)
   )[0];
+
   const mostRecentDataForNonBenchmark =
-    nonBenchmarkData?.healthData.filter((area) => area.year === year)[0] ??
-    undefined;
+    nonBenchmarkData?.healthData.filter(
+      (area) =>
+        convertDateToNumber(area.datePeriod?.to) ===
+        convertDateToNumber(latestDataPeriod?.to)
+    )[0] ?? undefined;
   const mostRecentDataForBenchmark =
-    BenchmarkData?.healthData.filter((area) => area.year === year)[0] ??
-    undefined;
+    BenchmarkData?.healthData.filter(
+      (area) =>
+        convertDateToNumber(area.datePeriod?.to) ===
+        convertDateToNumber(latestDataPeriod?.to)
+    )[0] ?? undefined;
 
   const comparisonTextForArea = getComparisonString(
     mostRecentDataPointForArea?.benchmarkComparison?.outcome ?? undefined,

--- a/frontend/fingertips-frontend/components/charts/ThematicMap/helpers/thematicMapHelpers.test.ts
+++ b/frontend/fingertips-frontend/components/charts/ThematicMap/helpers/thematicMapHelpers.test.ts
@@ -19,6 +19,7 @@ import {
   mockHealthDataForArea,
   mockHealthDataForArea_Group,
 } from '@/mock/data/mockHealthDataForArea';
+import { mockDatePeriod } from '@/mock/data/mockDatePeriod';
 
 describe('getMapGeographyData', () => {
   it('should return an object with the expected mapGroupBoundary', () => {
@@ -37,7 +38,8 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: 'England',
         healthData: [
           {
-            year: 2004,
+            year: 0,
+            datePeriod: mockDatePeriod(2004),
             value: 978.34,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -46,7 +48,8 @@ describe('prepareThematicMapSeriesData', () => {
             deprivation: noDeprivation,
           },
           {
-            year: 2008,
+            year: 0,
+            datePeriod: mockDatePeriod(2008),
             value: 800.232,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -61,7 +64,8 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: 'North East region (statistical)',
         healthData: [
           {
-            year: 2004,
+            year: 0,
+            datePeriod: mockDatePeriod(2004),
             value: 856.344,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -70,7 +74,8 @@ describe('prepareThematicMapSeriesData', () => {
             deprivation: noDeprivation,
           },
           {
-            year: 2008,
+            year: 0,
+            datePeriod: mockDatePeriod(2008),
             value: 767.343,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -85,7 +90,8 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: 'Yorkshire and the Humber region (statistical)',
         healthData: [
           {
-            year: 2004,
+            year: 0,
+            datePeriod: mockDatePeriod(2004),
             value: 674.434,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -94,7 +100,8 @@ describe('prepareThematicMapSeriesData', () => {
             deprivation: noDeprivation,
           },
           {
-            year: 2008,
+            year: 0,
+            datePeriod: mockDatePeriod(2008),
             value: 643.434,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -111,7 +118,7 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: mockHealthData[0].areaName,
         areaCode: mockHealthData[0].areaCode,
         value: mockHealthData[0].healthData[1].value,
-        year: mockHealthData[0].healthData[1].year,
+        year: mockHealthData[0].healthData[1].datePeriod?.to,
         benchmarkComparisonOutcome:
           mockHealthData[0].healthData[1].benchmarkComparison?.outcome,
         benchmarkColourCode: 55,
@@ -120,7 +127,7 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: mockHealthData[1].areaName,
         areaCode: mockHealthData[1].areaCode,
         value: mockHealthData[1].healthData[1].value,
-        year: mockHealthData[1].healthData[1].year,
+        year: mockHealthData[1].healthData[1].datePeriod?.to,
         benchmarkComparisonOutcome:
           mockHealthData[1].healthData[1].benchmarkComparison?.outcome,
         benchmarkColourCode: 5,
@@ -129,7 +136,7 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: mockHealthData[2].areaName,
         areaCode: mockHealthData[2].areaCode,
         value: mockHealthData[2].healthData[1].value,
-        year: mockHealthData[2].healthData[1].year,
+        year: mockHealthData[2].healthData[1].datePeriod?.to,
         benchmarkComparisonOutcome:
           mockHealthData[2].healthData[1].benchmarkComparison?.outcome,
         benchmarkColourCode: 35,
@@ -147,7 +154,8 @@ describe('prepareThematicMapSeriesData', () => {
         areaName: 'North East region (statistical)',
         healthData: [
           {
-            year: 2004,
+            year: 0,
+            datePeriod: mockDatePeriod(2004),
             value: 856.344,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -156,7 +164,8 @@ describe('prepareThematicMapSeriesData', () => {
             deprivation: noDeprivation,
           },
           {
-            year: 2018,
+            year: 0,
+            datePeriod: mockDatePeriod(2018),
             value: 767.343,
             ageBand: allAgesAge,
             sex: personsSex,
@@ -178,7 +187,7 @@ describe('prepareThematicMapSeriesData', () => {
         areaCode: 'E12000001',
         areaName: 'North East region (statistical)',
         value: 767.343,
-        year: 2018,
+        year: mockDatePeriod(2018).to,
         benchmarkComparisonOutcome: BenchmarkOutcome.Lower,
         benchmarkColourCode: 45,
       },

--- a/frontend/fingertips-frontend/components/charts/ThematicMap/helpers/thematicMapHelpers.ts
+++ b/frontend/fingertips-frontend/components/charts/ThematicMap/helpers/thematicMapHelpers.ts
@@ -13,8 +13,7 @@ import {
 } from '@/generated-sources/ft-api-client';
 import {
   getBenchmarkColour,
-  getIndicatorDataForAreasForMostRecentYearOnly,
-  getLatestYearForAreas,
+  getIndicatorDataForAreasForMostRecentPeriodOnly,
 } from '@/lib/chartHelpers/chartHelpers';
 import { allAreaTypes } from '@/lib/areaFilterHelpers/areaType';
 import {
@@ -278,7 +277,7 @@ function getBenchmarkColourScale(
 }
 
 export function prepareThematicMapSeriesData(data: HealthDataForArea[]) {
-  const recentData = getIndicatorDataForAreasForMostRecentYearOnly(data);
+  const recentData = getIndicatorDataForAreasForMostRecentPeriodOnly(data);
   if (!recentData) {
     return;
   }
@@ -289,7 +288,7 @@ export function prepareThematicMapSeriesData(data: HealthDataForArea[]) {
       areaName: areaData.areaName,
       areaCode: areaData.areaCode,
       value: mostRecentDataPoint?.value ?? undefined,
-      year: mostRecentDataPoint?.year ?? undefined,
+      year: mostRecentDataPoint?.datePeriod?.to ?? undefined,
       benchmarkComparisonOutcome:
         mostRecentDataPoint?.benchmarkComparison?.outcome ??
         BenchmarkOutcome.NotCompared,
@@ -404,7 +403,8 @@ export function thematicMapTitle(
   const areaType = allAreaTypes.find(
     (areaType) => areaType.key === selectedAreaType
   );
-  if (!areaType) return '';
+  if (!areaType || healthIndicatorData.at(0)?.healthData.length === 0)
+    return '';
 
   const areaTitle = groupData?.areaName ?? 'England';
   const periodLabelText = getPeriodLabel(periodType, frequency) ?? '';
@@ -414,9 +414,6 @@ export function thematicMapTitle(
     frequency,
     isSmallestReportingPeriod
   );
-
-  const latestYear = getLatestYearForAreas(healthIndicatorData);
-  if (!latestYear) return '';
 
   return `${indicatorName} for ${areaType.name} in ${areaTitle}, ${periodLabelText} ${datePointLabel}`;
 }

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -7,16 +7,12 @@ import {
   sortHealthDataByYearDescending,
   sortHealthDataForAreasByDate,
   sortHealthDataPointsByDescendingYear,
-  getIndicatorDataForAreasForMostRecentYearOnly,
   seriesDataWithoutGroup,
   determineHealthDataForArea,
   AreaTypeLabelEnum,
   getTooltipContent,
   createTooltipHTML,
   getLatestYear,
-  getFirstYear,
-  getLatestYearForAreas,
-  getFirstYearForAreas,
   getFormattedLabel,
   determineAreasForBenchmarking,
   determineBenchmarkToUse,
@@ -24,6 +20,7 @@ import {
   getFirstPeriod,
   getLatestPeriodForAreas,
   getFirstPeriodForAreas,
+  getIndicatorDataForAreasForMostRecentPeriodOnly,
 } from '@/lib/chartHelpers/chartHelpers';
 import { mockHealthData } from '@/mock/data/healthdata';
 import { areaCodeForEngland } from './constants';
@@ -49,6 +46,7 @@ import {
 } from './testHelpers';
 import { ALL_AREAS_SELECTED } from '../areaFilterHelpers/constants';
 import { convertDateToNumber } from '../timePeriodHelpers/getTimePeriodLabels';
+import { mockDatePeriod } from '@/mock/data/mockDatePeriod';
 
 const mockData: HealthDataForArea[] = [
   {
@@ -709,14 +707,15 @@ describe('getHealthDataWithoutInequalities', () => {
   });
 });
 
-describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
+describe('getIndicatorDataForAreasForMostRecentPeriodOnly', () => {
   const mockHealthData: HealthDataForArea[] = [
     {
       areaCode: 'A1425',
       areaName: 'Greater Manchester ICB - 00T',
       healthData: [
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 222,
           value: 890.305692,
           lowerCi: 821.987617,
@@ -727,7 +726,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 267,
           value: 703.420759,
           lowerCi: 635.102684,
@@ -738,7 +738,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 267,
           value: 703.420759,
           lowerCi: 441.69151,
@@ -749,7 +750,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 300,
           value: 602.820845,
           lowerCi: 534.50277,
@@ -760,7 +762,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 389,
           value: 278.29134,
           lowerCi: 209.973265,
@@ -771,7 +774,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2020,
+          year: 0,
+          datePeriod: mockDatePeriod(2020),
           count: 200,
           value: 971.435418,
           lowerCi: 903.117343,
@@ -788,7 +792,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
       areaName: 'England',
       healthData: [
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 200,
           value: 904.874,
           lowerCi: 0,
@@ -799,7 +804,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 179,
           value: 709.7645,
           lowerCi: 0,
@@ -810,7 +816,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 500,
           value: 965.9843,
           lowerCi: 0,
@@ -821,7 +828,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 400,
           value: 908.8475,
           lowerCi: 0,
@@ -838,7 +846,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
       areaName: 'South FooBar',
       healthData: [
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 157,
           value: 723.090354,
           lowerCi: 612.272279,
@@ -849,7 +858,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2020,
+          year: 0,
+          datePeriod: mockDatePeriod(2020),
           count: 256,
           value: 905.145997,
           lowerCi: 833.327922,
@@ -860,7 +870,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 222,
           value: 135.149304,
           lowerCi: 85.331229,
@@ -871,7 +882,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 131,
           value: 890.328253,
           lowerCi: 829.010178,
@@ -882,7 +894,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 452,
           value: 478.996862,
           lowerCi: 404.178787,
@@ -899,7 +912,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
       areaName: 'Area 1427',
       healthData: [
         {
-          year: 2020,
+          year: 0,
+          datePeriod: mockDatePeriod(2020),
           count: 411,
           value: 579.848756,
           lowerCi: 515.030681,
@@ -910,7 +924,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 367,
           value: 383.964067,
           lowerCi: 334.145992,
@@ -921,7 +936,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 289,
           value: 851.163104,
           lowerCi: 777.34503,
@@ -932,7 +948,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 356,
           value: 775.129883,
           lowerCi: 725.311808,
@@ -943,7 +960,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 489,
           value: 290.465304,
           lowerCi: 190.647229,
@@ -960,7 +978,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
       areaName: 'Area 1428',
       healthData: [
         {
-          year: 2020,
+          year: 0,
+          datePeriod: mockDatePeriod(2020),
           count: 311,
           value: 400.848756,
           lowerCi: 312.030681,
@@ -971,7 +990,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 469,
           value: 320.964067,
           lowerCi: 271.145992,
@@ -982,7 +1002,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 120,
           value: 600.163104,
           lowerCi: 550.34503,
@@ -993,7 +1014,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 250,
           value: 650.129883,
           lowerCi: 561.311808,
@@ -1004,7 +1026,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 344,
           value: 500.650389,
           lowerCi: 440.832314,
@@ -1021,7 +1044,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
       areaName: 'Area 1429',
       healthData: [
         {
-          year: 2006,
+          year: 0,
+          datePeriod: mockDatePeriod(2006),
           count: 322,
           value: 472.650389,
           lowerCi: 404.332314,
@@ -1032,7 +1056,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2012,
+          year: 0,
+          datePeriod: mockDatePeriod(2012),
           count: 234,
           value: 472.7613425,
           lowerCi: 404.443268,
@@ -1043,7 +1068,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2008,
+          year: 0,
+          datePeriod: mockDatePeriod(2008),
           count: 299,
           value: 582.306765,
           lowerCi: 513.98869,
@@ -1054,7 +1080,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2020,
+          year: 0,
+          datePeriod: mockDatePeriod(2020),
           count: 435,
           value: 563.4002,
           lowerCi: 495.082125,
@@ -1065,7 +1092,8 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
           deprivation: noDeprivation,
         },
         {
-          year: 2004,
+          year: 0,
+          datePeriod: mockDatePeriod(2004),
           count: 277,
           value: 627.899536,
           lowerCi: 559.581462,
@@ -1127,12 +1155,12 @@ describe('getIndicatorDataForAreasForMostRecentYearOnly', () => {
   ];
   it('should return healthdata for all areas, only for the most reccent year', () => {
     const actual =
-      getIndicatorDataForAreasForMostRecentYearOnly(mockHealthData);
+      getIndicatorDataForAreasForMostRecentPeriodOnly(mockHealthData);
     expect(actual).toEqual(expected);
   });
 
   it('should return undefined if there are no areas with data', () => {
-    const actual = getIndicatorDataForAreasForMostRecentYearOnly([
+    const actual = getIndicatorDataForAreasForMostRecentPeriodOnly([
       {
         areaCode: 'missingCode',
         areaName: 'missing Area',
@@ -1419,12 +1447,6 @@ describe('getLatestYear', () => {
   });
 });
 
-describe('getFirstYear', () => {
-  it('should return the first year for an area', () => {
-    expect(getFirstYear(mockData[0].healthData)).toBe(2004);
-  });
-});
-
 describe('getLatestPeriod', () => {
   it('should return the latest period as an number for an area', () => {
     expect(getLatestPeriod(mockData[0].healthData)).toBe(
@@ -1438,28 +1460,6 @@ describe('getFirstPeriod', () => {
     expect(getFirstPeriod(mockData[0].healthData)).toBe(
       convertDateToNumber('2004-12-31')
     );
-  });
-});
-
-describe('getLatestYearForAreas', () => {
-  it('should return the latest year for a group of areas', () => {
-    expect(getLatestYearForAreas(mockData)).toBe(2006);
-  });
-
-  it('should return undefined when the data provided is an empty list', () => {
-    expect(getLatestYearForAreas([])).toBeUndefined();
-  });
-});
-
-describe('getFirstYearForAreas', () => {
-  it('should return the latest year for a group of areas', () => {
-    expect(getFirstYearForAreas(mockData)).toBe(2004);
-  });
-
-  // This can occur when no area is selected. When undefined is returned, the chart min/max
-  // simply use those of the default benchmark i.e. England
-  it('should return undefined when the data provided is an empty list', () => {
-    expect(getFirstYearForAreas([])).toBeUndefined();
   });
 });
 

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -213,18 +213,6 @@ export function getLatestPeriod(
   return latestDateAsNumber;
 }
 
-export function getFirstYear(
-  points: HealthDataPoint[] | undefined
-): number | undefined {
-  if (!points || points.length < 1) return undefined;
-
-  const year = points.reduce(
-    (previous, point) => Math.min(previous, point.year),
-    points[0].year
-  );
-  return year;
-}
-
 export function getFirstPeriod(
   points: HealthDataPoint[] | undefined
 ): number | undefined {
@@ -238,20 +226,6 @@ export function getFirstPeriod(
   return firstDateAsNumber;
 }
 
-export function getLatestYearForAreas(
-  healthDataForAreas: HealthDataForArea[]
-): number | undefined {
-  if (!healthDataForAreas.length) {
-    return undefined;
-  }
-
-  const years = healthDataForAreas.map(
-    (area) => getLatestYear(area.healthData) ?? 0
-  );
-  const mostRecentYear = Math.max(...years);
-  return mostRecentYear === 0 ? undefined : mostRecentYear;
-}
-
 export function getLatestPeriodForAreas(
   healthDataForAreas: HealthDataForArea[]
 ): number | undefined {
@@ -263,20 +237,6 @@ export function getLatestPeriodForAreas(
     (area) => getLatestPeriod(area.healthData) ?? 0
   );
   const mostRecentYear = Math.max(...latestPeriodForAreas);
-  return mostRecentYear === 0 ? undefined : mostRecentYear;
-}
-
-export function getFirstYearForAreas(
-  healthDataForAreas: HealthDataForArea[]
-): number | undefined {
-  if (!healthDataForAreas.length) {
-    return undefined;
-  }
-
-  const years = healthDataForAreas.map(
-    (area) => getFirstYear(area.healthData) ?? 0
-  );
-  const mostRecentYear = Math.min(...years);
   return mostRecentYear === 0 ? undefined : mostRecentYear;
 }
 
@@ -295,41 +255,42 @@ export function getFirstPeriodForAreas(
   return mostRecentYear === 0 ? undefined : mostRecentYear;
 }
 
-function getAreasIndicatorDataForYear(
+function getAreasIndicatorDataForPeriod(
   healthDataForAreas: HealthDataForArea[],
-  year: number
+  dateAsNumber: number
 ): HealthDataForArea[] {
   return healthDataForAreas.map((healthDataForArea) =>
-    getAreaIndicatorDataForYear(healthDataForArea, year)
+    getAreaIndicatorDataForPeriod(healthDataForArea, dateAsNumber)
   );
 }
 
-export function getAreaIndicatorDataForYear(
+export function getAreaIndicatorDataForPeriod(
   healthDataForArea: HealthDataForArea,
-  year: number
+  dateAsNumber: number
 ): HealthDataForArea {
-  const dataPointForMostRecentYear = healthDataForArea.healthData.find(
-    (healthDataPoint) => healthDataPoint.year === year
+  const dataPointForMostRecentPeriod = healthDataForArea.healthData.find(
+    (healthDataPoint) =>
+      convertDateToNumber(healthDataPoint.datePeriod?.to) === dateAsNumber
   );
 
   return {
     ...healthDataForArea,
-    healthData: dataPointForMostRecentYear
-      ? [{ ...dataPointForMostRecentYear }]
+    healthData: dataPointForMostRecentPeriod
+      ? [{ ...dataPointForMostRecentPeriod }]
       : [],
   };
 }
 
-export function getIndicatorDataForAreasForMostRecentYearOnly(
+export function getIndicatorDataForAreasForMostRecentPeriodOnly(
   healthDataForAreas: HealthDataForArea[]
 ): HealthDataForArea[] | undefined {
-  const mostRecentYearForAreas = getLatestYearForAreas(healthDataForAreas);
-  if (!mostRecentYearForAreas) {
+  const mostRecentPeriodForAreas = getLatestPeriodForAreas(healthDataForAreas);
+  if (!mostRecentPeriodForAreas) {
     return undefined;
   }
-  return getAreasIndicatorDataForYear(
+  return getAreasIndicatorDataForPeriod(
     healthDataForAreas,
-    mostRecentYearForAreas
+    mostRecentPeriodForAreas
   );
 }
 


### PR DESCRIPTION
# Description

Removes the use of the to be deprecated `year` in favour of `datePeriod`

<img width="1218" height="770" alt="Screenshot 2025-08-01 at 16 07 18" src="https://github.com/user-attachments/assets/782a2284-6e5c-41eb-b6a7-9dabd8cc3ec8" />

## Validation

Manual testing to check it works as before
