### PR TITLE
DHSCFT-TECH: Remove the remaining use of `year` in charts

### DIFF
--- a/frontend/fingertips-frontend/components/charts/CompareAreasTable/BarChartEmbeddedRow/BarChartEmbeddedRow.tsx
+++ b/frontend/fingertips-frontend/components/charts/CompareAreasTable/BarChartEmbeddedRow/BarChartEmbeddedRow.tsx
@@ -65,7 +65,6 @@ export const BarChartEmbeddedRow: FC<BarChartEmbeddedRowProps> = ({
             polarity={polarity}
             label={AreaTypeLabelEnum.Area}
             area={item.area}
-            year={item.year}
             measurementUnit={measurementUnit}
             benchmarkArea={item.benchmarkComparison?.benchmarkAreaName}
             period={period}

--- a/frontend/fingertips-frontend/components/charts/CompareAreasTable/BarChartEmbeddedTable/BarChartEmbeddedTable.tsx
+++ b/frontend/fingertips-frontend/components/charts/CompareAreasTable/BarChartEmbeddedTable/BarChartEmbeddedTable.tsx
@@ -289,7 +289,6 @@ export function BarChartEmbeddedTable({
                     polarity={polarity}
                     label={englandLabel}
                     area={englandData?.areaName}
-                    year={englandDataPoint.year}
                     measurementUnit={measurementUnit}
                     barColor={GovukColours.DarkGrey}
                     showComparisonLabels={showComparisonLabels}
@@ -349,7 +348,6 @@ export function BarChartEmbeddedTable({
                     polarity={polarity}
                     label={groupLabel}
                     area={groupIndicatorData?.areaName}
-                    year={groupDataPoint.year}
                     measurementUnit={measurementUnit}
                     barColor={GovukColours.DarkGrey}
                     period={datePointLabel}

--- a/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTable.test.tsx
@@ -32,7 +32,10 @@ describe('Spine chart table suite', () => {
         areaName: areaName,
         healthData: [
           {
-            year: mismatchedYears ? 2022 : 2023,
+            year: 0,
+            datePeriod: mismatchedYears
+              ? mockDatePeriod(2022)
+              : mockDatePeriod(2023),
             count: 222,
             value: 690.305692,
             lowerCi: 341.69151,

--- a/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTableRow.test.tsx
+++ b/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTableRow.test.tsx
@@ -7,12 +7,14 @@ import { GovukColours } from '@/lib/styleHelpers/colours';
 import {
   HealthDataForArea,
   HealthDataPointTrendEnum,
+  PeriodType,
 } from '@/generated-sources/ft-api-client';
 import { SpineChartIndicatorData } from '../helpers/buildSpineChartIndicatorData';
 import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
 import { mockSpineIndicatorData } from '@/components/charts/SpineChart/SpineChartTable/spineChartMockTestData';
 import { areaCodeForEngland } from '@/lib/chartHelpers/constants';
 import { SearchParams, SearchStateParams } from '@/lib/searchStateManager';
+import { mockDatePeriod } from '@/mock/data/mockDatePeriod';
 
 const mockSearchState: SearchStateParams = {
   [SearchParams.SearchedIndicator]: 'some search',
@@ -104,7 +106,12 @@ describe('Spine chart table row', () => {
           areaName: 'Greater Manchester ICB - 01T',
           healthData: [
             {
-              year: 2025,
+              year: 0,
+              datePeriod: mockDatePeriod({
+                type: PeriodType.Financial,
+                from: new Date('2023-04-06'),
+                to: new Date('2024-04-05'),
+              }),
               count: 333,
               value: 800.305692,
               lowerCi: 341.69151,

--- a/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTableRow.tsx
+++ b/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/SpineChartTableRow.tsx
@@ -29,7 +29,10 @@ import {
 import { StyledAlignRightTableCellPaddingRight } from '@/lib/tableHelpers';
 import { SearchParams } from '@/lib/searchStateManager';
 import { useSearchStateParams } from '@/components/hooks/useSearchStateParams';
-import { formatDatePointLabel } from '@/lib/timePeriodHelpers/getTimePeriodLabels';
+import {
+  convertDateToNumber,
+  formatDatePointLabel,
+} from '@/lib/timePeriodHelpers/getTimePeriodLabels';
 
 export interface SpineChartTableRowProps {
   indicatorData: SpineChartIndicatorData;
@@ -62,8 +65,12 @@ export const SpineChartTableRow: FC<SpineChartTableRowProps> = ({
 
   if (twoAreasRequested) {
     twoAreasLatestPeriodMatching =
-      areasHealthData[0]?.healthData.at(-1)?.year ===
-      areasHealthData[1]?.healthData.at(-1)?.year;
+      convertDateToNumber(
+        areasHealthData[0]?.healthData.at(-1)?.datePeriod?.to
+      ) ===
+      convertDateToNumber(
+        areasHealthData[1]?.healthData.at(-1)?.datePeriod?.to
+      );
   }
 
   const areaNames = areasHealthData.map(

--- a/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/spineChartMockTestData.ts
+++ b/frontend/fingertips-frontend/components/charts/SpineChart/SpineChartTable/spineChartMockTestData.ts
@@ -23,7 +23,12 @@ export const mockSpineHealthDataForArea: HealthDataForArea = {
   areaName: 'Greater Manchester ICB - 00T',
   healthData: [
     {
-      year: 2025,
+      year: 0,
+      datePeriod: mockDatePeriod({
+        type: PeriodType.Financial,
+        from: new Date('2023-04-06'),
+        to: new Date('2024-04-05'),
+      }),
       count: 222,
       value: 690.305692,
       lowerCi: 341.69151,
@@ -47,7 +52,12 @@ export const mockSpineGroupData = {
   areaName: 'Manchester',
   healthData: [
     {
-      year: 2025,
+      year: 0,
+      datePeriod: mockDatePeriod({
+        type: PeriodType.Financial,
+        from: new Date('2023-04-06'),
+        to: new Date('2024-04-05'),
+      }),
       count: 3333,
       value: 890.305692,
       lowerCi: 341.69151,

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/LineChartTable.test.tsx
@@ -3,8 +3,6 @@ import { render, screen, within } from '@testing-library/react';
 import {
   LineChartTable,
   LineChartTableHeadingEnum,
-  LineChartTableRowData,
-  mapToLineChartTableData,
 } from '@/components/organisms/LineChartTable/index';
 import {
   MOCK_ENGLAND_DATA,
@@ -23,6 +21,10 @@ import {
 import { allAgesAge, noDeprivation, personsSex } from '@/lib/mocks';
 import { IndicatorDocument } from '@/lib/search/searchTypes';
 import { mockHealthDataForArea } from '@/mock/data/mockHealthDataForArea';
+import {
+  convertDateToNumber,
+  formatDatePointLabel,
+} from '@/lib/timePeriodHelpers/getTimePeriodLabels';
 
 describe('Line chart table suite', () => {
   beforeAll(() => {
@@ -40,7 +42,7 @@ describe('Line chart table suite', () => {
       areaName: 'Greater Manchester ICB - 00T',
       healthData: [
         {
-          year: 2008,
+          year: 0,
           datePeriod: {
             type: PeriodType.Calendar,
             from: new Date('2008-01-01'),
@@ -59,7 +61,7 @@ describe('Line chart table suite', () => {
           },
         },
         {
-          year: 2004,
+          year: 0,
           datePeriod: {
             type: PeriodType.Calendar,
             from: new Date('2004-01-01'),
@@ -84,7 +86,7 @@ describe('Line chart table suite', () => {
       healthData: [
         ...MOCK_HEALTH_DATA[1].healthData.slice(0, -1),
         {
-          year: 2004,
+          year: 0,
           datePeriod: {
             type: PeriodType.Calendar,
             from: new Date('2004-01-01'),
@@ -538,56 +540,23 @@ describe('Line chart table suite', () => {
     });
   });
 
-  describe('mapToLineChartTableData', () => {
-    it('should map to linechart table row data', () => {
-      const expectedRowData: LineChartTableRowData[] = [
-        {
-          period: 2008,
-          value: 890.305692,
-          count: 222,
-          upper: 578.32766,
-          lower: 441.69151,
-        },
-        {
-          count: 267,
-          lower: 441.69151,
-          period: 2004,
-          upper: 578.32766,
-          value: 703.420759,
-        },
-        {
-          period: 2004,
-          count: 267,
-          value: 703.420759,
-          lower: 441.69151,
-          upper: 578.32766,
-        },
-        {
-          period: 2004,
-          count: 267,
-          value: 703.420759,
-          lower: 441.69151,
-          upper: 578.32766,
-        },
-      ];
-
-      expect(mapToLineChartTableData(MOCK_HEALTH_DATA[0])).toEqual(
-        expectedRowData
-      );
-    });
-  });
-
   const expectPeriodsToBeDisplayedInAscendingOrder = (cellsPerRow: number) => {
     const sortedHealthData = {
       ...mockHealthData[0],
       healthData: mockHealthData[0].healthData.toSorted(
-        (a, b) => a.year - b.year
+        (a, b) =>
+          convertDateToNumber(a.datePeriod?.to) -
+          convertDateToNumber(b.datePeriod?.to)
       ),
     };
 
     for (let i = 0; i < mockHealthData[0].healthData.length; i++) {
       expect(screen.getAllByRole('cell')[i * cellsPerRow]).toHaveTextContent(
-        String(sortedHealthData.healthData[i].year)
+        formatDatePointLabel(
+          sortedHealthData.healthData[i].datePeriod,
+          Frequency.Annually,
+          true
+        )
       );
     }
   };

--- a/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/LineChartTable/index.tsx
@@ -72,7 +72,7 @@ export interface LineChartTableProps {
 }
 
 export interface LineChartTableRowData {
-  period: number;
+  period: string;
   count?: number;
   value?: number;
   lower?: number;
@@ -181,18 +181,6 @@ const BenchmarkCell: FC<BenchmarkCellProps> = ({
     </CellWrapper>
   );
 };
-
-export const mapToLineChartTableData = (
-  areaData: HealthDataForArea
-): LineChartTableRowData[] =>
-  areaData.healthData.map((healthPoint) => ({
-    period: healthPoint.year,
-    count: healthPoint.count,
-    value: healthPoint.value,
-    lower: healthPoint.lowerCi,
-    upper: healthPoint.upperCi,
-    benchmarkComparison: healthPoint.benchmarkComparison,
-  }));
 
 const StyledTitleCell = styled(StyledAlignLeftHeader)({
   border: 'none',

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/SparklineChart.test.tsx
@@ -13,7 +13,6 @@ describe('SparklineChart', () => {
         showConfidenceIntervalsData={true}
         label={'mock'}
         area={'mockArea'}
-        year={2000}
         measurementUnit={''}
       />
     );

--- a/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
+++ b/frontend/fingertips-frontend/components/organisms/SparklineChart/index.tsx
@@ -29,7 +29,6 @@ interface SparklineChartProps {
   polarity?: IndicatorPolarity;
   label: string;
   area: string | undefined;
-  year: number | undefined;
   measurementUnit: string | undefined;
   barColor?: string;
   benchmarkArea?: string;

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.test.ts
@@ -363,7 +363,7 @@ describe('getIndicatorData', () => {
       areaCodes: [areaCodeForEngland],
       areaType: 'england',
       indicatorId: 1,
-      years: [2006],
+      latestOnly: true,
     });
     expect(
       mockedGetgetAuthorisedHealthDataForAnIndicator
@@ -371,7 +371,7 @@ describe('getIndicatorData', () => {
       areaCodes: ['ggg'],
       areaType: 'test_group_type',
       indicatorId: 1,
-      years: [2006],
+      latestOnly: true,
     });
   });
 

--- a/frontend/fingertips-frontend/lib/ViewsHelpers.ts
+++ b/frontend/fingertips-frontend/lib/ViewsHelpers.ts
@@ -82,49 +82,25 @@ export interface GetIndicatorDataParam {
 }
 
 /**
- * Retrieves the latest year from the area health data in the API response.
- * Note: this MUST only be used in the context of requests that use the latest_only parameter.
- * @param areaHealthDataList
- * @returns - the latest data for the year or undefined
- */
-function getLatestYearFromResponseData(
-  areaHealthDataList: HealthDataForArea[]
-): number | undefined {
-  return areaHealthDataList.find(
-    (areaHealthData) => areaHealthData.healthData.length
-  )?.healthData[0].year;
-}
-
-/**
  * Retrieves data for England and group - where applicable - that corresponds to the latest year
  * of the area data that has already been obtained.
  *
  * @param param0 - GetIndicatorDataParam
- * @param subAreaHealthData - the area health data for the requested area codes
  * @returns - a flattened array containing both the original area health data and health data for England
  * and the requested group, where applicable
  */
-async function getLatestYearDataForGroupAndEngland(
-  {
-    areasSelected,
-    indicatorSelected,
-    selectedGroupCode,
-    selectedGroupType,
-  }: GetIndicatorDataParam,
-  subAreaHealthData: HealthDataForArea[]
-): Promise<HealthDataForArea[]> {
-  const latestYear = getLatestYearFromResponseData(subAreaHealthData);
+async function getLatestYearDataForGroupAndEngland({
+  areasSelected,
+  indicatorSelected,
+  selectedGroupCode,
+  selectedGroupType,
+}: GetIndicatorDataParam): Promise<HealthDataForArea[]> {
   const indicatorRequestArray = [];
 
-  const defaultApiRequestParams = latestYear
-    ? {
-        indicatorId: Number(indicatorSelected[0]),
-        years: [latestYear],
-      }
-    : {
-        indicatorId: Number(indicatorSelected[0]),
-        latestOnly: true,
-      };
+  const defaultApiRequestParams = {
+    indicatorId: Number(indicatorSelected[0]),
+    latestOnly: true,
+  };
 
   if (!areasSelected.includes(areaCodeForEngland)) {
     indicatorRequestArray.push(
@@ -231,15 +207,12 @@ export async function getIndicatorData(
 
   if (latestOnly) {
     const latestDataForGroupAndEngland =
-      await getLatestYearDataForGroupAndEngland(
-        {
-          areasSelected,
-          indicatorSelected,
-          selectedGroupCode,
-          selectedGroupType,
-        },
-        indicatorDataAllAreas.areaHealthData
-      );
+      await getLatestYearDataForGroupAndEngland({
+        areasSelected,
+        indicatorSelected,
+        selectedGroupCode,
+        selectedGroupType,
+      });
     indicatorDataAllAreas.areaHealthData.push(...latestDataForGroupAndEngland);
   }
 

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.test.ts
@@ -12,7 +12,6 @@ import {
   AreaTypeLabelEnum,
   getTooltipContent,
   createTooltipHTML,
-  getLatestYear,
   getFormattedLabel,
   determineAreasForBenchmarking,
   determineBenchmarkToUse,
@@ -1438,12 +1437,6 @@ describe('getTooltipHtml', () => {
         '%'
       )
     ).toEqual(expected);
-  });
-});
-
-describe('getLatestYear', () => {
-  it('should return the latest year for an area', () => {
-    expect(getLatestYear(mockData[0].healthData)).toBe(2006);
   });
 });
 

--- a/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
+++ b/frontend/fingertips-frontend/lib/chartHelpers/chartHelpers.ts
@@ -189,17 +189,6 @@ export function generateConfidenceIntervalSeries(
   };
 }
 
-export function getLatestYear(
-  points: HealthDataPoint[] | undefined
-): number | undefined {
-  if (!points || points.length < 1) return undefined;
-
-  const dateAsNumber = points.reduce((previous, point) => {
-    return Math.max(previous, point.year);
-  }, points[0].year);
-  return dateAsNumber;
-}
-
 export function getLatestPeriod(
   points: HealthDataPoint[] | undefined
 ): number | undefined {


### PR DESCRIPTION
# Description

<img width="856" height="429" alt="Screenshot 2025-08-06 at 11 44 21" src="https://github.com/user-attachments/assets/163cac40-9bde-49ed-8eb9-1305ca2e3a2a" />

Besides the inequalities and the mock helper removes the use of year in charts

## Validation

Tested manually for regression
